### PR TITLE
added command line input for private and overwrite config

### DIFF
--- a/src/weathergen/__init__.py
+++ b/src/weathergen/__init__.py
@@ -16,7 +16,7 @@ import traceback
 import pandas as pd
 
 from weathergen.train.trainer import Trainer
-from weathergen.utils.config import Config, load_private_conf, load_overwrite_conf
+from weathergen.utils.config import Config, load_overwrite_conf, load_private_conf
 from weathergen.utils.logger import init_loggers
 
 
@@ -150,14 +150,14 @@ def train() -> None:
         default=None,
         help="Run/model id of pretrained WeatherGenerator model to continue training. Defaults to None.",
     )
-    
+
     parser.add_argument(
         "--private_config",
         type=str,
         default=None,
         help="Path to private configuration file for paths.",
     )
-    
+
     parser.add_argument(
         "--overwrite_config",
         type=str,
@@ -169,8 +169,8 @@ def train() -> None:
 
     # TODO: move somewhere else
     init_loggers()
-    
-    #get the non-default configs: private and overwrite
+
+    # get the non-default configs: private and overwrite
     private_cf = load_private_conf(args.private_config)
     overwrite_cf = load_overwrite_conf(args.overwrite_config)
 
@@ -286,7 +286,6 @@ def train() -> None:
     cf.norm_type = "LayerNorm"  #'LayerNorm' #'RMSNorm'
     cf.nn_module = "te"
 
-
     cf.start_date = 201301010000
     cf.end_date = 202012310000
     cf.start_date_val = 202101010000
@@ -306,8 +305,8 @@ def train() -> None:
 
     cf.run_id = args.run_id
     cf.desc = ""
-    
-     # overwrite parameters from private config
+
+    # overwrite parameters from private config
     for k, v in private_cf.items():
         setattr(cf, k, v)
     cf.data_path = private_cf["data_path_anemoi"]  # for backward compatibility

--- a/src/weathergen/__init__.py
+++ b/src/weathergen/__init__.py
@@ -159,7 +159,7 @@ def train() -> None:
     )
 
     parser.add_argument(
-        "--overwrite_config",
+        "--config",
         type=str,
         default=None,
         help="Path to private configuration file for overwriting the defaults in the function body. Defaults to None.",
@@ -172,7 +172,7 @@ def train() -> None:
 
     # get the non-default configs: private and overwrite
     private_cf = load_private_conf(args.private_config)
-    overwrite_cf = load_overwrite_conf(args.overwrite_config)
+    overwrite_cf = load_overwrite_conf(args.config)
 
     cf = Config()
 

--- a/src/weathergen/utils/config.py
+++ b/src/weathergen/utils/config.py
@@ -69,11 +69,29 @@ class Config:
         return cf
 
 
-# Function that checks if WEATHERGEN_PRIVATE_HOME is set and returns it:
-def private_conf() -> Any:
-    if "WEATHERGEN_PRIVATE_CONF" in os.environ:
-        private_home = Path(os.environ["WEATHERGEN_PRIVATE_CONF"])
+def load_overwrite_conf(pth: str) -> dict:
+    " Return the overwrite configuration."
+    "If path is None, return an empty dictionary."
+    if not pth:
+        return {}
+    else:
+        overwrite_path = Path(pth)
+        overwrite_conf = yaml.safe_load(overwrite_path.read_text())
+        return overwrite_conf
+    
+def load_private_conf(pth: str = None) -> dict:
+    " Return the private configuration."
+    "If none, take it from the environment variable WEATHERGEN_PRIVATE_CONF. "
+    
+    if not pth:
+        if "WEATHERGEN_PRIVATE_CONF" in os.environ:
+            private_home = Path(os.environ["WEATHERGEN_PRIVATE_CONF"])
+            private_conf = yaml.safe_load(private_home.read_text())
+            return private_conf
+        else:
+            raise ValueError("No private config path is provided in the command line and WEATHERGEN_PRIVATE_CONF is not set.")
+    else:
+        private_home = Path(pth)
         private_conf = yaml.safe_load(private_home.read_text())
         return private_conf
-    else:
-        raise ValueError("WEATHERGEN_PRIVATE_CONF is not set.")
+    

--- a/src/weathergen/utils/config.py
+++ b/src/weathergen/utils/config.py
@@ -79,9 +79,9 @@ def load_overwrite_conf(pth: str) -> dict:
         return overwrite_conf
 
 
-def load_private_conf(pth: str = None) -> dict:
+def load_private_conf(pth: str) -> dict:
     "Return the private configuration."
-    "If none, take it from the environment variable WEATHERGEN_PRIVATE_CONF. "
+    "If none, take it from the environment variable WEATHERGEN_PRIVATE_CONF."
 
     if not pth:
         if "WEATHERGEN_PRIVATE_CONF" in os.environ:

--- a/src/weathergen/utils/config.py
+++ b/src/weathergen/utils/config.py
@@ -10,7 +10,6 @@
 import json
 import os
 from pathlib import Path
-from typing import Any
 
 import yaml
 
@@ -70,7 +69,7 @@ class Config:
 
 
 def load_overwrite_conf(pth: str) -> dict:
-    " Return the overwrite configuration."
+    "Return the overwrite configuration."
     "If path is None, return an empty dictionary."
     if not pth:
         return {}
@@ -78,20 +77,22 @@ def load_overwrite_conf(pth: str) -> dict:
         overwrite_path = Path(pth)
         overwrite_conf = yaml.safe_load(overwrite_path.read_text())
         return overwrite_conf
-    
+
+
 def load_private_conf(pth: str = None) -> dict:
-    " Return the private configuration."
+    "Return the private configuration."
     "If none, take it from the environment variable WEATHERGEN_PRIVATE_CONF. "
-    
+
     if not pth:
         if "WEATHERGEN_PRIVATE_CONF" in os.environ:
             private_home = Path(os.environ["WEATHERGEN_PRIVATE_CONF"])
             private_conf = yaml.safe_load(private_home.read_text())
             return private_conf
         else:
-            raise ValueError("No private config path is provided in the command line and WEATHERGEN_PRIVATE_CONF is not set.")
+            raise ValueError(
+                "No private config path is provided in the command line and WEATHERGEN_PRIVATE_CONF is not set."
+            )
     else:
         private_home = Path(pth)
         private_conf = yaml.safe_load(private_home.read_text())
         return private_conf
-    


### PR DESCRIPTION
With this implementation we have two command line inputs for only the train():
overwite_config and private_config

overwrite_config takes a yaml file path and overwrites the parameters given in the function body or adds to them.

private_config takes a yaml file path and sets some path configurations. If no path provided in the command line, the code looks for this in the environement variable WEATHERGEN_PRIVATE_CONF. if this is also empty, the code throws an error.