### PR TITLE
[91] use pathlib for path manipulation consistently

### DIFF
--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -9,6 +9,7 @@
 
 import math
 import warnings
+from pathlib import Path
 
 import astropy_healpix as hp
 import astropy_healpix.healpy
@@ -536,11 +537,11 @@ class Model(torch.nn.Module):
 
     #########################################
     def load(self, run_id, epoch=None):
-        path_run = "./models/" + run_id + "/"
-        fname = path_run + f"{run_id}"
-        fname += f"_epoch{epoch:05d}.chkpt" if epoch is not None else "_latest.chkpt"
+        path_run = Path("./models/") / run_id
+        epoch_id = f"epoch{epoch:05d}" if epoch is not None else "latest"
+        filename = f"{run_id}_{epoch_id}.chkpt"
 
-        params = torch.load(fname, map_location=torch.device("cpu"), weights_only=True)
+        params = torch.load(path_run / filename , map_location=torch.device("cpu"), weights_only=True)
         params_renamed = {}
         for k in params.keys():
             params_renamed[k.replace("module.", "")] = params[k]

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -8,8 +8,8 @@
 # nor does it submit to any jurisdiction.
 
 import logging
-import os
 import time
+from pathlib import Path
 
 import numpy as np
 import torch
@@ -78,11 +78,11 @@ class Trainer(Trainer_Base):
         cf = self.init_streams(cf, run_id_contd)
 
         # create output directory
-        path_run = "./results/" + cf.run_id + "/"
-        path_model = "./models/" + cf.run_id + "/"
+        path_run = Path("./results") / cf.run_id
+        path_model = Path("./models") / cf.run_id
         if self.cf.rank == 0:
-            os.makedirs(path_run, exist_ok=True)
-            os.makedirs(path_model, exist_ok=True)
+            path_run.mkdir(exist_ok=True)
+            path_model.mkdir(exist_ok=True)
             # save config
             cf.save()
             if run_mode == "training":
@@ -778,10 +778,11 @@ class Trainer(Trainer_Base):
 
     ###########################################
     def save_model(self, epoch=-1, name=None):
-        file_out = "./models/" + self.cf.run_id + f"/{self.cf.run_id}_"
-        file_out += "latest" if epoch == -1 else f"epoch{epoch:05d}"
-        file_out += ("_" + name) if name is not None else ""
-        file_out += "{}.chkpt"
+        path_model = Path("./models/") / self.cf.run_id
+        epoch_str = "latest" if epoch == -1 else f"epoch{epoch:05d}"
+        name_str = f"_{name}" if name is not None else ""
+        file_out = path_model / f"{self.cf.run_id}_{epoch_str}_{name_str}.chkpt"
+        temp_file_out = path_model / f"{self.cf.run_id}_{epoch_str}_{name_str}_temp.chkpt"
 
         if self.cf.with_ddp and self.cf.with_fsdp:
             _cfg = FullStateDictConfig(offload_to_cpu=True, rank0_only=True)
@@ -796,9 +797,9 @@ class Trainer(Trainer_Base):
 
         if self.cf.rank == 0:
             # save temp file (slow)
-            torch.save(state, file_out.format("_temp"))
+            torch.save(state, temp_file_out)
             # move file (which is changing the link in the file system and very fast)
-            os.replace(file_out.format("_temp"), file_out.format(""))
+            temp_file_out.replace(file_out)
             # save config
             self.cf.save(epoch)
 

--- a/src/weathergen/train/trainer_base.py
+++ b/src/weathergen/train/trainer_base.py
@@ -113,14 +113,14 @@ class Trainer_Base:
         if not hasattr(cf, "streams") or not isinstance(cf.streams, list):
             cf.streams = []
 
+        streams_dir = Path(cf.streams_directory)
         # warn if specified dir does not exist
-        if not os.path.isdir(cf.streams_directory):
-            sd = cf.streams_directory
-            _logger.warning(f"Streams directory {sd} does not exist.")
+        if not streams_dir.is_dir():
+            _logger.warning(f"Streams directory {streams_dir} does not exist.")
 
         # read all reportypes from directory, append to existing ones
         temp = {}
-        streams_dir = Path(cf.streams_directory).absolute()
+        streams_dir = streams_dir.absolute()
         _logger.info(f"Reading streams from {streams_dir}")
 
         for fh in sorted(streams_dir.rglob("*.yml")):

--- a/src/weathergen/utils/config.py
+++ b/src/weathergen/utils/config.py
@@ -30,19 +30,15 @@ class Config:
                         print("{}{} : {}".format("" if k == "reportypes" else "  ", k, v))
 
     def save(self, epoch=None):
+        path_models = Path("./models")
         # save in directory with model files
-        dirname = f"./models/{self.run_id}"
-        # if not os.path.exists(dirname):
-        os.makedirs(dirname, exist_ok=True)
-        dirname = f"./models/{self.run_id}"
-        # if not os.path.exists(dirname):
-        os.makedirs(dirname, exist_ok=True)
+        dirname = path_models / {self.run_id}
+        dirname.mkdir(exist_ok=True, paraents=True)
 
-        fname = f"./models/{self.run_id}/model_{self.run_id}"
         epoch_str = ""
         if epoch is not None:
             epoch_str = "_latest" if epoch == -1 else f"_epoch{epoch:05d}"
-        fname += f"{epoch_str}.json"
+        fname = dirname / f"model_{self.run_id}{epoch_str}.json"
 
         json_str = json.dumps(self.__dict__)
         with open(fname, "w") as f:
@@ -51,13 +47,13 @@ class Config:
     @staticmethod
     def load(run_id, epoch=None):
         if "/" in run_id:  # assumed to be full path instead of just id
-            fname = run_id
+            fname = Path(run_id)
         else:
-            fname = f"./models/{run_id}/model_{run_id}"
+            path_models = Path("./models")
             epoch_str = ""
             if epoch is not None:
                 epoch_str = "_latest" if epoch == -1 else f"_epoch{epoch:05d}"
-            fname += f"{epoch_str}.json"
+            fname = path_models / run_id / f"model_{run_id}{epoch_str}.json"
 
         with open(fname) as f:
             json_str = f.readlines()

--- a/src/weathergen/utils/plot_training.py
+++ b/src/weathergen/utils/plot_training.py
@@ -11,6 +11,7 @@ import argparse
 import code
 import glob
 import os
+import pathlib
 import subprocess
 
 import matplotlib.pyplot as plt
@@ -20,14 +21,13 @@ import pandas as pd
 from weathergen.utils.config import Config
 from weathergen.utils.train_logger import TrainLogger
 
-out_folder = "./plots/"
+out_folder = pathlib.Path("./plots/")
 
 
 ####################################################################################################
 def clean_out_folder():
-    files = glob.glob(out_folder + "*.png")
-    for f in files:
-        os.remove(f)
+    for image in out_folder.glob("*.png"):
+        image.unlink()
 
 
 ####################################################################################################
@@ -229,7 +229,7 @@ def plot_loss_per_stream(
         plt.tight_layout()
         rstr = "".join([f"{r}_" for r in runs_ids])
         plt.savefig(
-            out_folder + "{}{}{}.png".format(rstr, "".join([f"{m}_" for m in modes]), stream_name)
+            out_folder / "{}{}{}.png".format(rstr, "".join([f"{m}_" for m in modes]), stream_name)
         )
         plt.close()
 
@@ -307,7 +307,7 @@ def plot_loss_per_run(
     sstr = "".join(
         [f"{r}_".replace(",", "").replace("/", "_").replace(" ", "_") for r in legend_str]
     )
-    plt.savefig(out_folder + "{}_{}{}.png".format(run_id, "".join([f"{m}_" for m in modes]), sstr))
+    plt.savefig(out_folder / "{}_{}{}.png".format(run_id, "".join([f"{m}_" for m in modes]), sstr))
     plt.close()
 
 

--- a/src/weathergen/utils/train_logger.py
+++ b/src/weathergen/utils/train_logger.py
@@ -10,8 +10,8 @@
 import datetime
 import json
 import math
-import os.path
 import time
+from pathlib import Path
 
 import numpy as np
 
@@ -20,7 +20,7 @@ from weathergen.utils.config import Config
 
 class TrainLogger:
     #######################################
-    def __init__(self, cf, path_run) -> None:
+    def __init__(self, cf, path_run: Path) -> None:
         self.cf = cf
         self.path_run = path_run
 
@@ -42,7 +42,7 @@ class TrainLogger:
 
         # TODO: performance: we repeatedly open the file for each call. Better for multiprocessing
         # but we can probably do better and rely for example on the logging module.
-        with open(os.path.join(self.path_run, "metrics.json"), "ab") as f:
+        with open(self.path_run / "metrics.json", "ab") as f:
             s = json.dumps(clean_metrics) + "\n"
             f.write(s.encode("utf-8"))
 
@@ -71,7 +71,7 @@ class TrainLogger:
                 log_vals += [stddev_avg[i_obs]]
                 metrics[f"stream_{i_obs}.stddev_avg"] = stddev_avg[i_obs]
 
-        with open(self.path_run + self.cf.run_id + "_train_log.txt", "ab") as f:
+        with open(self.path_run / f"{self.cf.run_id}_train_log.txt", "ab") as f:
             np.savetxt(f, log_vals)
 
         log_vals = []
@@ -82,7 +82,7 @@ class TrainLogger:
         if perf_mem > 0.0:
             metrics["perf.memory"] = perf_mem
         self.log_metrics(metrics)
-        with open(self.path_run + self.cf.run_id + "_perf_log.txt", "ab") as f:
+        with open(self.path_run / f"{self.cf.run_id}_perf_log.txt", "ab") as f:
             np.savetxt(f, log_vals)
 
     #######################################
@@ -101,7 +101,7 @@ class TrainLogger:
             for i_obs, _rt in enumerate(self.cf.streams):
                 log_vals += [stddev_avg[i_obs]]
 
-        with open(self.path_run + self.cf.run_id + "_val_log.txt", "ab") as f:
+        with open(self.path_run / f"{self.cf.run_id}_val_log.txt", "ab") as f:
             np.savetxt(f, log_vals)
 
     #######################################
@@ -114,10 +114,10 @@ class TrainLogger:
         cf = Config.load(run_id, epoch)
         run_id = cf.run_id
 
-        fname_log_train = f"./results/{run_id}/{run_id}_train_log.txt"
-        fname_log_val = f"./results/{run_id}/{run_id}_val_log.txt"
-        fname_perf_val = f"./results/{run_id}/{run_id}_perf_log.txt"
-        # fname_config = f"./models/model_{run_id}.json"
+        result_dir = Path(f"./results/{run_id}")
+        fname_log_train = result_dir / f"{run_id}_train_log.txt"
+        fname_log_val = result_dir / f"{run_id}_val_log.txt"
+        fname_perf_val = result_dir / f"{run_id}_perf_log.txt"
 
         # training
 

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -7,6 +7,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+from pathlib import Path
 
 import numpy as np
 import torch
@@ -18,10 +19,10 @@ def sanitize_stream_str(istr):
 
 
 #################################
-def read_validation(cf, epoch, base_path, instruments, forecast_steps, rank=0):
+def read_validation(cf, epoch, base_path: Path, instruments, forecast_steps, rank=0):
     streams, columns, data = [], [], []
 
-    fname = base_path + f"validation_epoch{epoch:05d}_rank{rank:04d}.zarr"
+    fname = base_path / f"validation_epoch{epoch:05d}_rank{rank:04d}.zarr"
     store = zarr.DirectoryStore(fname)
     ds = zarr.group(store=store)
 
@@ -57,7 +58,7 @@ def read_validation(cf, epoch, base_path, instruments, forecast_steps, rank=0):
 #################################
 def write_validation(
     cf,
-    base_path,
+    base_path: Path,
     rank,
     epoch,
     cols,
@@ -71,11 +72,11 @@ def write_validation(
     if len(cf.analysis_streams_output) == 0:
         return
 
-    fname = base_path + f"validation_epoch{epoch:05d}_rank{rank:04d}"
+    fname = f"validation_epoch{epoch:05d}_rank{rank:04d}"
     fname += "" if jac is None else "_jac"
     fname += ".zarr"
 
-    store = zarr.DirectoryStore(fname)
+    store = zarr.DirectoryStore(base_path / fname)
     ds = zarr.group(store=store)
 
     for k, si in enumerate(cf.streams):


### PR DESCRIPTION
Handle all path manipulation throughout the entire code base consistently:
- All pathes/files are instances of `pathlib.Path`
- use pathlib features instead of `os.path`
- use `/` operator to concatenate paths
- use format strings to build up filenames (final path component) => no string concatenation with `+`

This fixes #91 and reimplements many of the changes present in #83 related to usage of `pathlib`. In constrast to #83 this PR is only concerned with the consistent usage of pathlib and not implementing new features. As such it may serve as new base for #83.