### PR TITLE
fixed: searchin for key instead of attribute in private config

### DIFF
--- a/src/weathergen/__init__.py
+++ b/src/weathergen/__init__.py
@@ -93,7 +93,7 @@ def evaluate():
     init_loggers()
 
     # load config: if run_id is full path, it loads from there
-    model_path = private_cf["model_path"] if hasattr(private_cf, "model_path") else "./models"
+    model_path = private_cf["model_path"] if "model_path" in private_cf.keys() else "./models"
     cf = Config.load(args.run_id, args.epoch, model_path)
 
     # add parameters from private (paths) config


### PR DESCRIPTION
The hotfix in the evaluate() function was checking if the "model_path" was given in the private config. The private config is read from json as a dict object, so checking `hasattr(private_cf, "model_path")` was always returning false, as the dict object does not have the attribute.

Instead one should look at the keys of the dictionary using `"model_path" in private_cf.keys()`.

This PR is fixing this.