### PR TITLE
Urgent Rectification of Code Anarchy

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -1,0 +1,68 @@
+**The Sacred Coding Standards of the Holy Grail Repository**  
+*Verily, as dictated by the Lady of the Lake, her arm clad in the purest shimmering samite, and etched into the Codex of Antioch by the Divine Hand of Saint Attila himself.*  
+
+---
+
+**1. The Holy Naming of Variables, Functions, and Classes**  
+*And the Lord spake, saying:*  
+"Thou shalt name thy variables as the beasts of the field, that their purpose may be clear unto even the densest of shrubberies. Forsooth, a variable `num_knights` is righteous, but `x` or `temp` shall be cast into the Gorge of Eternal Peril. Functions shalt be verbs of holy action, such as `smite_the_wicked()` or `summon_coconut_swallows()`, and classes shalt bear titles grander than the Court of Camelot, e.g., `HolyHandGrenade` or `EnchanterTimTheWise`. Verily, if thy class be abstract, thou shalt suffix it with `Base` or `Abstract`, as in `KillerRabbitBase`, lest it leapeth out and rend thy code asunder."  
+
+**2. The Sacrament of Comments**  
+*And Saint Attila did decree:*  
+"Each comment shalt begin with a blessing unto the Lord, that He may guide the reader through the Valley of Confusion. For example:  
+`# O Lord, bless this loop that it may iterate justly through the hordes of Gaul.`  
+Comments explaining dark magic (recursion, regex) shall include a plea for mercy, lest the code anger the spirits of the underworld.
+
+**3. The Counting of Lines (Three Shalt Be Thy Number)**  
+*Verily, the Lord did grin and spake:*  
+"Functions shalt span no more than three screenfuls of code, nor fewer than three lines if they perform holy work. Four screenfuls are right out, and five shalt cause the compiler to revolt. If thy function groweth like the Killer Rabbit of Caerbannog, thou shalt refactor it into smaller shards, each blessed by the Sacred Shears of Abstraction. And woe unto he who writeth nested loops deeper than three levels—such hubris invites the wrath of the Bridgekeeper!"  
+
+**4. The Handling of Errors (Lest Thou Triggerest the Grenade Prematurely)**  
+*And the Wise One did proclaim:*  
+"Thou shalt check the Holy Pin (null pointers, invalid inputs) before thou pullest it. For as the Grenade of Antioch demands:  
+```python  
+if holy_pin is None:  
+    raise DivineInterventionError("Thou hast forgotten the Counting of the Three!")  
+```  
+Errors shalt be caught with the grace of Sir Galahad, not the cowardice of Sir Robin. And when logging failures, thou shalt include a lamentation, e.g., `logger.wail("Tis but a scratch!")`
+
+**5. The Testing Feast (A Multitude of Beasts and Edge Cases)**  
+*And the people did feast upon:*  
+"Unit tests for lambs, sloths, carp, and all creatures strange and wondrous. Verify thy grenade against knights who say 'Ni', shrubberies demanding a herring, and ducks of unnatural density. He who writes no tests shall be taunted by the French in *ALL CAPS*. Each test case shalt be named as a trial from the Book of Armaments, e.g., `test_duck_sinketh_witch()` or `test_grail_location_parsing()`."  
+
+**6. The Proclamation of Commits (Messages Worthy of the Annals)**  
+*Commit messages shalt be as prophetic visions:*  
+`"Fixeth the treacherous overflow in the Castle of Aaaarrrrggh"`  
+`"Addeth the Sacred Flesh-Wound Detection Algorithm"`  
+Avoid vague incantations like `"stuff"` or `"lol"`, lest ye be smote with the Holy Catapult of Code Review. Commit messages longer than three lines must conclude with `--Amen`.
+
+**7. The Forbidden Arts (Thou Shalt Not...)**  
+*The Lord did thunder:*  
+- **Invoke global variables** without an offering of incense (a 3-page comment explaining why).  
+- **Hardcode magic numbers**, unless they be 3, 5 (the Holy Hand Grenade’s count), or 42 (the Answer).  
+- **Neglect thy documentation**, for the Knights of Ni demand... A SHRUBBERY!  
+
+**8. The Ordinance of Code Formatting (Coconuts and Swallows)**  
+*And the Council of Antiope did declare:*  
+"Indentations shalt be four spaces, as measured by the wingspan of an African swallow. Brackets shalt be placed as the Holy Python dictates, and whitespace shalt be respected as the sacred groves of Avalon. If thy linter complaineth, thou shalt repent by reciting the Oath of the Dynamic Typist three times: *'We are all individuals! We are all different!'*"  
+
+**9. The Handling of Dependencies (Beware the Rabbit of Caerbannog)**  
+*The Black Knight did warn:*  
+"Import not libraries of dubious provenance, lest ye awaken the Beast of Unmaintainable Code. Dependencies shalt be fewer than three score and ten, and each must be vetted by the Knights Who Say 'pip'. If a library be abandoned, thou shalt replace it with a shrubbery—or at least a fork."  
+
+**10. The Ritual of Code Review (Bring Forth the Comfy Chair!)**  
+***NOBODY EXPECTS THE SPANISH INQUISITION!***  
+*Cardinal Ximinez did interject, flanked by Cardinals Biggles and Fang:*  
+"Our chief weapon is surprise! Surprise and meticulous code reviews. The two chief weapons are surprise, ruthless efficiency, and an almost fanatical devotion to PEP8. Amongst our weaponry are such diverse elements as: the Comfy Chair, the Soft Pillows of Nitpicking, and nice red uniforms—oh damn..."  
+
+- **Thou shalt submit to the Inquisition’s scrutiny**: All pull requests shall be reviewed by at least three Inquisitors, who will demand justification for every line.  
+- **Unit tests must appease the Inquisition**: Any PR without tests shall be met with… *THE COMFY CHAIR*.  
+- **Redundant code shall be confessed**: Repent of thy copy-paste sins, or face… *THE SOFT CUSHIONS*.  
+- **Refactor or perish**: If thy code is spaghetti, thou shalt be charged with heresy and forced to refactor while listening to the "Phony French Accent" on loop.  
+
+---  
+
+**Final Judgment:**  
+*He who breach these standards shall be cast into the Caves of Scary Shadows, forced to debug COBOL by the light of a flickering coconut. Go forth, and code with the strength of ten men (and a herring).*  
+
+***AND THE SPANISH INQUISITION WILL BE WATCHING.*** 🐍⚔️🪑


### PR DESCRIPTION
**Ministry of Silly Pull Requests**  
*Official Communiqué: MSPR/2025/42-B*  
**Date:** *IV/I/MDCCCLXXV*  
---

**Dear Developers, Knights, and Assorted Python-Wranglers,**  

It has come to the Ministry’s attention that your current codebase **flagrantly violates Regulation 42(b)** of the *Silly Code Strut Compliance Act (1971)*, which mandates:  
*"All code shalt be whimsical, properly strutted, and free from the taint of sanity."*  
The absence of Sacred Coding Standards has resulted in:  
1. Variables named `ni` (a clear affront to the Knights Who Say ‘Ni’).  
2. Untested edge cases (see: *Great Rabbit-Induced Chaos of ‘72*).  
3. Tea spillage during merges (a national tragedy).  

**This PR** hereby rectifies this *egregious oversight* by enforcing:  
- **`CODING_STANDARDS.md`**: 10 commandments, including mandatory herring references and shrubbery bribes.  

**Compliance Checklist (Or Face the Spanish Inquisition):**  
- [x] Commit messages cite Monty Python episodes (e.g., `"Fix: Ex-parrot detection"`).  
- [x] Form 27B/6 (*Proof of Rubber Chicken Sacrifice*) attached.  
- [ ] Code reviewed while hopping backward.  

---  

**Approval Required By:**  
- [x] Minister of Silly Pull Requests  
- [x] Under-Secretary of Newt Sanitization  
- [x] A Witch-Approved Duck  

---  

*Seal of the Ministry:* 🔴 *[Stamp Here With Jam]*  