### PR TITLE
fix small issue in train_contiue

### DIFF
--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -536,9 +536,9 @@ class Model(torch.nn.Module):
         print("-----------------")
 
     #########################################
-    def load(self, run_id, epoch=None):
+    def load(self, run_id, epoch=-1):
         path_run = Path(self.cf.model_path) / run_id
-        epoch_id = f"epoch{epoch:05d}" if epoch is not None else "latest"
+        epoch_id = f"epoch{epoch:05d}" if epoch is not -1 else "latest"
         filename = f"{run_id}_{epoch_id}.chkpt"
 
         params = torch.load(


### PR DESCRIPTION
- fix a small problem in train_continue when loading the last checkpoint. 
- make the fine-tuning for forecasting as optional in `train_continue` and just keep training with the previous settings when the flag `--finetune_forecast` is not specified. 
