### PR TITLE
langguth/develop/issue_0166

### DIFF
--- a/src/weathergen/__init__.py
+++ b/src/weathergen/__init__.py
@@ -239,6 +239,12 @@ def train() -> None:
         default=None,
         help="Path to private configuration file for paths",
     )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        help="Path to private configuration file for overwriting the defaults in the function body. Defaults to None.",
+    )
 
     args = parser.parse_args()
 


### PR DESCRIPTION
## Description

Make running `train` from command-line working again.


## Type of Change

Re-add `--config` as parsing argument to train in `__init__.py`

## Issue Number

Issue is described in #166 

## Code Compatibility

Defaults can be overwritten by passing a custom YAML configuration file again.

### Code Performance and Testing

`uv run train --config <...>` works again.

### Dependencies

None.

### Documentation

-

## Additional Notes
-