### PR TITLE
Fix for issue 168 regarding the coordinates in anemoi datasets

### DIFF
--- a/src/weathergen/datasets/anemoi_dataset.py
+++ b/src/weathergen/datasets/anemoi_dataset.py
@@ -78,6 +78,9 @@ class AnemoiDataset:
         self.latitudes = ds.latitudes.astype(np.float32)
         self.longitudes = ds.longitudes.astype(np.float32)
 
+        # Ensures that coordinates remain into the interval [-90,90] for latitudes
+        # and [-180, 180] for longitudes. Ensures that periodicity has been taken
+        # into consideration for the specific intervals.
         il, ir = (-90.0, 90.0)
 
         self.latitudes = np.where(

--- a/src/weathergen/datasets/anemoi_dataset.py
+++ b/src/weathergen/datasets/anemoi_dataset.py
@@ -78,6 +78,22 @@ class AnemoiDataset:
         self.latitudes = ds.latitudes.astype(np.float32)
         self.longitudes = ds.longitudes.astype(np.float32)
 
+        il, ir = (-90.0, 90.0)
+
+        self.latitudes = np.where(
+            self.latitudes >= ir,
+            180.0 - self.latitudes,
+            np.where(self.latitudes <= il, -180.0 - self.latitudes, self.latitudes),
+        )
+
+        il, ir = (-180.0, 180.0)
+
+        self.longitudes = np.where(
+            self.longitudes >= ir,
+            self.longitudes - 360.0,
+            np.where(self.longitudes <= il, self.longitudes + 360.0, self.longitudes),
+        )
+
         # TODO: define in base class
         self.geoinfo_idx = []
 


### PR DESCRIPTION
## Description

It has been observed that the model expects the data to be in the intervals [-90,90] for latitudes and [-180, 180] for longitudes. However the anemoi datasets that we have used until now have longitudes at the range of [0, 360].

The changes ensure that coordinates remain into the interval [-90,90] for latitudes and [-180, 180] for longitudes for the anemoi dataset. They also ensure that periodicity has been taken into consideration for the specific intervals.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/168

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [ ] I have not introduced new dependencies in the inference portion of the pipeline

### Documentation

-   [x] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [x] I have added comments to my code, particularly in hard-to-understand areas
