### PR TITLE
Ktezcan/dev/train mtm

### DIFF
--- a/src/weathergen/datasets/tokenizer_utils.py
+++ b/src/weathergen/datasets/tokenizer_utils.py
@@ -98,7 +98,8 @@ def hpy_cell_splits(coords: torch.tensor, hl: int):
     posr3 = s2tor3(thetas, phis)
 
     # extract information to split according to cells by first sorting and then finding split idxs
-    hpy_idxs_ord = np.argsort(hpy_idxs, stable=True)
+    # hpy_idxs_ord = np.argsort(hpy_idxs, stable=True) # KCT
+    hpy_idxs_ord = np.argsort(hpy_idxs, kind='mergesort')
     splits = np.flatnonzero(np.diff(hpy_idxs[hpy_idxs_ord]))
 
     # extract per cell data

--- a/src/weathergen/train/trainer_base.py
+++ b/src/weathergen/train/trainer_base.py
@@ -71,19 +71,23 @@ class Trainer_Base:
             cf.rank = rank
             cf.num_ranks = num_ranks
             return
+        
+        master_port = os.environ.get("MASTER_PORT", "29514")
 
         local_rank = int(os.environ.get("SLURM_LOCALID"))
         ranks_per_node = int(os.environ.get("SLURM_TASKS_PER_NODE", "1")[0])
-        rank = int(os.environ.get("SLURM_NODEID")) * ranks_per_node + local_rank
+        rank = int(os.environ.get("SLURM_PROCID")) 
         num_ranks = int(os.environ.get("SLURM_NTASKS"))
 
         dist.init_process_group(
             backend="nccl",
-            init_method="tcp://" + master_node + ":1345",
-            timeout=datetime.timedelta(seconds=10 * 8192),
+            init_method=f"tcp://{master_node}:{master_port}",
+            timeout=datetime.timedelta(seconds=60),
             world_size=num_ranks,
             rank=rank,
         )
+        
+        
 
         # communicate run id to all nodes
         run_id_int = torch.zeros(8, dtype=torch.int32).cuda()

--- a/train_mtm/overwrite_config.yaml
+++ b/train_mtm/overwrite_config.yaml
@@ -1,0 +1,24 @@
+
+streams_directory: "/users/ktezcan/projects/Meteoswiss/WeatherGenerator/config/streams/streams_era5_ts32"
+
+
+start_date: 201501010000
+end_date: 202012310000
+start_date_val: 202101010000
+end_date_val: 202112310000
+num_epochs: 256
+
+with_mixed_precision: True
+
+# training mode: "forecast" or "masking" (masked token modeling)
+# for "masking" to train with auto-encoder mode, forecast_offset should be 0
+training_mode: "masking"
+# masking rate when training mode is "masking"; ignored in foreacast mode
+masking_rate: 0.6
+# sample the masking rate (with normal distribution centered at masking_rate)
+masking_rate_sampling: True
+
+forecast_offset : 0
+
+with_ddp: True
+with_fsdp: True

--- a/train_mtm/paths.yaml
+++ b/train_mtm/paths.yaml
@@ -1,0 +1,7 @@
+
+# data_path_anemoi: "/iopsstor/scratch/cscs/fzanetta/data/anemoi"
+data_path_anemoi: "/iopsstor/scratch/cscs/ktezcan/data"
+model_path:  "/iopsstor/scratch/cscs/ktezcan/weathergen/models"
+run_path:  "/iopsstor/scratch/cscs/ktezcan/weathergen/results" 
+
+# data_path_obs: "/lus/h2resw01/fws4/lb/project/ai-ml/observations/v1"

--- a/train_mtm/runtrain_masktok_n64.sh
+++ b/train_mtm/runtrain_masktok_n64.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+#SBATCH --job-name=continuous_train
+#SBATCH --output=./runlogs/output_%j.txt
+#SBATCH --error=./runlogs/error_%j.txt
+#SBATCH --mem=120G
+#SBATCH --partition=normal
+#SBATCH --gres=gpu:4
+#SBATCH --nodes=64
+#SBATCH --ntasks-per-node=4
+#SBATCH --time=12:00:00
+
+#SBATCH --environment=wgen-pytorch
+#SBATCH -A a-a01
+
+
+export MASTER_ADDR="$(scontrol show hostnames "$SLURM_NODELIST" | head -n 1)"
+echo "MASTER_ADDR : $MASTER_ADDR"
+
+export MASTER_PORT=29514
+
+# export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
+
+export NCCL_DEBUG=INFO
+
+cd $HOME/projects/Meteoswiss/WeatherGenerator/
+
+source $HOME/projects/Meteoswiss/WeatherGenerator/.venv/bin/activate
+source /users/ktezcan/projects/Meteoswiss/WeatherGenerator/.venv/bin/activate
+pip install -e . --no-dependencies
+
+
+# srun bash -c "source /users/ktezcan/projects/Meteoswiss/WeatherGenerator/.venv/bin/activate && \
+#      python /users/ktezcan/projects/Meteoswiss/WeatherGenerator/personal/print_slurm_env_vars.py"
+
+srun bash -c "source /users/ktezcan/projects/Meteoswiss/WeatherGenerator/.venv/bin/activate && \
+     python /users/ktezcan/projects/Meteoswiss/WeatherGenerator/src/weathergen/__init__.py \
+     --private_config /users/ktezcan/projects/Meteoswiss/WeatherGenerator/personal/paths.yaml \
+     --config /users/ktezcan/projects/Meteoswiss/WeatherGenerator/personal/train_maskedtoken/overwrite_config.yaml"

--- a/train_mtm/streams_era5_ts32/era5.yml
+++ b/train_mtm/streams_era5_ts32/era5.yml
@@ -1,0 +1,36 @@
+# (C) Copyright 2024 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+ERA5 :
+  type : anemoi
+  filenames : ['aifs-ea-an-oper-0001-mars-o96-1979-2023-6h-v8.zarr']
+  # source : ['u_', 'v_', '10u', '10v']
+  # target : ['10u', '10v']
+  loss_weight : 1.
+  diagnostic : False
+  masking_rate : 0.6
+  masking_rate_none : 0.05
+  token_size : 32
+  embed : 
+    net : transformer
+    num_tokens : 1
+    num_heads : 8
+    dim_embed : 256
+    num_blocks : 2
+  embed_target_coords :
+    net : linear
+    dim_embed : 256
+  target_readout :
+    type : 'obs_value'  # token or obs_value
+    num_layers : 2
+    num_heads : 4
+    # sampling_rate : 0.2
+  pred_head :
+    ens_size : 1
+    num_layers : 1

--- a/train_mtm/venv_instructions.txt
+++ b/train_mtm/venv_instructions.txt
@@ -1,0 +1,7 @@
+create a new venv with uv venv --system-site-packages ./my-venv-name
+
+(you can pip install uv if you don't have it)
+
+install the packages (should be weathergen only in theory) uv pip install . -e
+
+now you can exit the job with exit and if you check the contents of the folder where you were working you should see that ./my-venv-nameshould have persisted!


### PR DESCRIPTION
This is not a real PR. This is just to quickly share the WIP changes for training on clariden.

See the contents of the new folder: train_mtm

1. Notice that the instructions for making the venv is in the folder.
2. My sbatch scripts are also in the folder, you can see how we set up the environment variables for NCCL. These have my paths, these need to be adjusted.
3. the change "hpy_idxs_ord = np.argsort(hpy_idxs, kind='mergesort')" is because we have numpy<2.0 in the container we use.

Feel free to reject/delete this PR.

Related to issue https://github.com/ecmwf/WeatherGenerator/issues/211. I am available again in the evening for questions. Thanks

