### PR TITLE
Langguth issue0232 hard coded relative paths in plot training and trainlogger

### DIFF
--- a/src/weathergen/utils/plot_training.py
+++ b/src/weathergen/utils/plot_training.py
@@ -9,17 +9,18 @@
 
 import argparse
 import logging
-import yaml
 import subprocess
 from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
+import yaml
 
 import weathergen.utils.config as config
 from weathergen.utils.train_logger import Metrics, TrainLogger
 
 ####################################################################################################
+
 
 def yaml_or_path(str_or_path: str) -> dict:
     """
@@ -34,21 +35,23 @@ def yaml_or_path(str_or_path: str) -> dict:
     Returns
     dict
         The parsed YAML content as a dictionary.
-    """ 
+    """
     # Load from file if it's a valid path
     if Path(str_or_path).is_file():
-        with open(str_or_path, 'r') as f:
+        with open(str_or_path) as f:
             data_dict = yaml.safe_load(f)
     else:
         try:
             data_dict = yaml.safe_load(str_or_path)
         except yaml.YAMLError as e:
-            raise argparse.ArgumentTypeError(f"Invalid YAML string or path: {e}")
+            raise argparse.ArgumentTypeError(f"Invalid YAML string or path: {e}") from e
 
     # Validate the structure: {run_id: [job_id, experiment_name]}
     if not isinstance(data_dict, dict):
-        raise argparse.ArgumentTypeError("Input must be a dictionary mapping run_id to [job_id, experiment_name].")
-    
+        raise argparse.ArgumentTypeError(
+            "Input must be a dictionary mapping run_id to [job_id, experiment_name]."
+        )
+
     for k, v in data_dict.items():
         if not (isinstance(v, list) and len(v) == 2):
             raise argparse.ArgumentTypeError(
@@ -56,6 +59,7 @@ def yaml_or_path(str_or_path: str) -> dict:
             )
 
     return data_dict
+
 
 ####################################################################################################
 def clean_plot_folder(plot_dir: Path = "./plots/"):

--- a/src/weathergen/utils/plot_training.py
+++ b/src/weathergen/utils/plot_training.py
@@ -21,6 +21,7 @@ from weathergen.utils.train_logger import Metrics, TrainLogger
 
 _logger = logging.getLogger(__name__)
 
+
 ####################################################################################################
 def _ensure_list(value):
     """
@@ -35,6 +36,7 @@ def _ensure_list(value):
         A list containing the input value if it was not a list, or the input value itself if it was already a list.
     """
     return value if isinstance(value, list) else [value]
+
 
 ####################################################################################################
 def _check_run_id_dict(run_id_dict: dict) -> bool:
@@ -57,6 +59,7 @@ def _check_run_id_dict(run_id_dict: dict) -> bool:
                 f"Each key must be a string and each value must be a list of [job_id, experiment_name], but got: {k}: {v}"
             )
 
+
 ####################################################################################################
 def _read_str_config(yaml_str: str) -> dict:
     """
@@ -78,6 +81,7 @@ def _read_str_config(yaml_str: str) -> dict:
 
     return config_dict
 
+
 ####################################################################################################
 def _read_yaml_config(yaml_file_path):
     """
@@ -98,16 +102,16 @@ def _read_yaml_config(yaml_file_path):
     dict
         A dictionary with run IDs as keys and a list of [job ID, experiment name] as values.
     """
-    with open(yaml_file_path, 'r') as f:
+    with open(yaml_file_path, "r") as f:
         data = yaml.safe_load(f)
 
     # Extract configuration for plotting training diagnostics
-    config_plot = data.get('train', {}).get('plot', {})
-    
-    # Init lists 
-    run_ids = _ensure_list(config_plot.get('run_ids', []))
-    job_ids = _ensure_list(config_plot.get('job_ids', []))
-    experiment_names = _ensure_list(config_plot.get('experiment_names', []))
+    config_plot = data.get("train", {}).get("plot", {})
+
+    # Init lists
+    run_ids = _ensure_list(config_plot.get("run_ids", []))
+    job_ids = _ensure_list(config_plot.get("job_ids", []))
+    experiment_names = _ensure_list(config_plot.get("experiment_names", []))
 
     # sanity checks
     assert len(run_ids) > 0, "At least one run_id must be provided."
@@ -553,7 +557,8 @@ if __name__ == "__main__":
     # python plot_training.py -rs "{run_id: [job_id, experiment_name]}" -m ./trained_models -o ./training_plots
 
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
-    parser = argparse.ArgumentParser(description="""Plot training diagnostics from logged data during training.
+    parser = argparse.ArgumentParser(
+        description="""Plot training diagnostics from logged data during training.
                                      An example YAML file looks like this:
                                      train:
                                         plot:
@@ -563,7 +568,8 @@ if __name__ == "__main__":
                                      A dictionary-string can also be used, e.g.:
                                      "{'abcde': ['123456', 'experiment1'],
                                        'fghij': ['654321', 'experiment2']}"
-                                     """)
+                                     """
+    )
 
     parser.add_argument(
         "-o", "--output_dir", default="./plots/", type=Path, help="Directory where plots are saved"
@@ -624,10 +630,9 @@ if __name__ == "__main__":
     model_base_dir = Path(args.model_base_dir)
     out_dir = Path(args.output_dir)
     streams = list(args.streams)
-    x_types_valid = ["step"]            # TODO: add "reltime" support when fix available
+    x_types_valid = ["step"]  # TODO: add "reltime" support when fix available
     if args.x_type not in x_types_valid:
         raise ValueError(f"x_type must be one of {x_types_valid}, but got {args.x_type}")
-
 
     runs_ids = args.rs if args.rs is not None else args.rf
 

--- a/src/weathergen/utils/plot_training.py
+++ b/src/weathergen/utils/plot_training.py
@@ -654,7 +654,7 @@ if __name__ == "__main__":
     plot_lr(runs_ids, runs_data, runs_active, plot_dir=out_dir)
 
     # plot performance
-    # plot_utilization(runs_ids, runs_data, runs_active, plot_dir=out_dir)
+    plot_utilization(runs_ids, runs_data, runs_active, plot_dir=out_dir)
 
     # compare different runs
     plot_loss_per_stream(

--- a/src/weathergen/utils/plot_training.py
+++ b/src/weathergen/utils/plot_training.py
@@ -23,6 +23,7 @@ _logger = logging.getLogger(__name__)
 
 ####################################################################################################
 
+
 def check_run_id_dict(run_id_dict: dict) -> bool:
     """
     Check if the run_id_dict is valid.
@@ -62,8 +63,9 @@ def read_yaml_file(file_path: Path) -> dict:
 
     # Validate the structure: {run_id: [job_id, experiment_name]}
     check_run_id_dict(data_dict)
-    
+
     return data_dict
+
 
 def read_yaml_string(yaml_string: str) -> dict:
     """
@@ -82,8 +84,9 @@ def read_yaml_string(yaml_string: str) -> dict:
 
     # Validate the structure: {run_id: [job_id, experiment_name]}
     check_run_id_dict(data_dict)
-    
+
     return data_dict
+
 
 ####################################################################################################
 def clean_plot_folder(plot_dir: Path = "./plots/"):
@@ -170,7 +173,9 @@ def plot_lr(
         ]
 
     if len(legend_str) < 1:
-        _logger.warning("Could not find any data for plotting the learning rates of the runs: ", runs_ids)
+        _logger.warning(
+            "Could not find any data for plotting the learning rates of the runs: ", runs_ids
+        )
         return
 
     plt.legend(legend_str)
@@ -256,7 +261,7 @@ def plot_utilization(
     plt.xlabel(x_axis)
     plt.tight_layout()
     rstr = "".join([f"{r}_" for r in runs_ids])
-    
+
     # save the plot
     plt_fname = plot_dir / f"{rstr}utilization.png"
     _logger.info(f"Saving utilization plot to '{plt_fname}'")
@@ -333,7 +338,8 @@ def plot_loss_per_stream(
                     # find the cols of the requested metric (e.g. mse) for all streams
                     # TODO: fix captialization
                     data_cols = filter(
-                        lambda c: err in c and stream_name.lower() in c.lower(), run_data_mode.columns
+                        lambda c: err in c and stream_name.lower() in c.lower(),
+                        run_data_mode.columns,
                     )
 
                     for col in data_cols:
@@ -383,7 +389,9 @@ def plot_loss_per_stream(
         rstr = "".join([f"{r}_" for r in runs_ids])
 
         # save the plot
-        plt_fname = plot_dir / "{}{}{}.png".format(rstr, "".join([f"{m}_" for m in modes]), stream_name)
+        plt_fname = plot_dir / "{}{}{}.png".format(
+            rstr, "".join([f"{m}_" for m in modes]), stream_name
+        )
         _logger.info(f"Saving loss per stream plot to '{plt_fname}'")
         plt.savefig(plt_fname)
         plt.close()
@@ -575,7 +583,7 @@ if __name__ == "__main__":
         )
 
     runs_ids = args.rs if args.rs is not None else args.rf
-    
+
     if args.delete == "True":
         clean_plot_folder(out_dir)
 
@@ -643,6 +651,6 @@ if __name__ == "__main__":
         run_id,
         runs_ids[run_id],
         run_data,
-        get_stream_names(run_id, model_path=model_base_dir),     # limit to available streams
+        get_stream_names(run_id, model_path=model_base_dir),  # limit to available streams
         plot_dir=out_dir,
     )

--- a/src/weathergen/utils/plot_training.py
+++ b/src/weathergen/utils/plot_training.py
@@ -8,12 +8,10 @@
 # nor does it submit to any jurisdiction.
 
 import argparse
-from typing import List, Dict
-import logging
-import pathlib
-from pathlib import Path
 import json as js
+import logging
 import subprocess
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -23,16 +21,15 @@ from weathergen.utils.train_logger import Metrics, TrainLogger
 
 
 ####################################################################################################
-def clean_plot_folder(
-        plot_dir: Path = "./plots/"):
+def clean_plot_folder(plot_dir: Path = "./plots/"):
     """
     Clean the plot folder by removing all png-files in it.
-    
+
     Parameters
     ----------
     plot_dir : Path
         Path to the plot directory
-"""
+    """
     for image in plot_dir.glob("*.png"):
         image.unlink()
 
@@ -61,14 +58,15 @@ def get_stream_names(run_id: str, model_path: Path | None = "./model"):
 
 ####################################################################################################
 def plot_lr(
-        runs_ids: Dict[str, List],
-        runs_data: List[Metrics],
-        runs_active: List[bool],
-        x_axis: str ="samples",
-        plot_dir: Path = Path("./plots")):
+    runs_ids: dict[str, list],
+    runs_data: list[Metrics],
+    runs_active: list[bool],
+    x_axis: str = "samples",
+    plot_dir: Path = Path("./plots"),
+):
     """
     Plot learning rate curves of training runs.
-    
+
     Parameters
     ----------
     runs_ids : dict
@@ -123,11 +121,12 @@ def plot_lr(
 
 ####################################################################################################
 def plot_utilization(
-        runs_ids: Dict[str, List],
-        runs_data: List[Metrics],
-        runs_active: List[bool],
-        x_axis: str = "samples",
-        plot_dir: Path = Path("./plots")):
+    runs_ids: dict[str, list],
+    runs_data: list[Metrics],
+    runs_active: list[bool],
+    x_axis: str = "samples",
+    plot_dir: Path = Path("./plots"),
+):
     """
     Plot compute utilization of training runs.
 
@@ -186,18 +185,18 @@ def plot_utilization(
     plt.xlabel(x_axis)
     plt.tight_layout()
     rstr = "".join([f"{r}_" for r in runs_ids])
-    plt.savefig(plot_dir/ f"{rstr}utilization.png")
+    plt.savefig(plot_dir / f"{rstr}utilization.png")
     plt.close()
 
 
 ####################################################################################################
 def plot_loss_per_stream(
-    modes: List[str],
-    runs_ids: Dict[str, list],
-    runs_data: List[Metrics],
-    runs_active: List[bool],
-    stream_names: List[str],
-    errs: List[str] = ["mse"],
+    modes: list[str],
+    runs_ids: dict[str, list],
+    runs_data: list[Metrics],
+    runs_active: list[bool],
+    stream_names: list[str],
+    errs: list[str] = ["mse"],
     x_axis: str = "samples",
     x_type: str = "step",
     x_scale_log: bool = False,
@@ -314,13 +313,13 @@ def plot_loss_per_stream(
 
 ####################################################################################################
 def plot_loss_per_run(
-    modes: List[str],
+    modes: list[str],
     run_id: str,
     run_desc: str,
     run_data: Metrics,
-    stream_names: List[str],
-    errs: List[str] = ["mse"],
-    x_axis: str ="samples",
+    stream_names: list[str],
+    errs: list[str] = ["mse"],
+    x_axis: str = "samples",
     x_scale_log: bool = False,
     plot_dir: Path = Path("./plots"),
 ):
@@ -416,22 +415,37 @@ def plot_loss_per_run(
 
 ####################################################################################################
 if __name__ == "__main__":
-
     # Example usage:
     # python plot_training.py -ids '{"qlz6n9eg": [12341234, "My experiments"]}' -m ./trained_models -o ./training_plots
 
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("-o", "--output_dir", default="./plots/", type=str,
-                        help="Directory where plots are saved")
-    parser.add_argument("-m", "--model_base_dir", default="./models/", type=str, 
-                        help="Base-directory where models are saved")
-    parser.add_argument("-d", "--delete", default=False, action="store_true", 
-                        help="Delete all plots in the output directory before plotting")
-    parser.add_argument("-ids", "--runs_ids", type=js.loads, required=True,
-                        help="JSON string with run ids as keys and list of SLURM job ids and descriptions as values")
-    
+    parser.add_argument(
+        "-o", "--output_dir", default="./plots/", type=str, help="Directory where plots are saved"
+    )
+    parser.add_argument(
+        "-m",
+        "--model_base_dir",
+        default="./models/",
+        type=str,
+        help="Base-directory where models are saved",
+    )
+    parser.add_argument(
+        "-d",
+        "--delete",
+        default=False,
+        action="store_true",
+        help="Delete all plots in the output directory before plotting",
+    )
+    parser.add_argument(
+        "-ids",
+        "--runs_ids",
+        type=js.loads,
+        required=True,
+        help="JSON string with run ids as keys and list of SLURM job ids and descriptions as values",
+    )
+
     args = parser.parse_args()
 
     model_base_dir = Path(args.model_base_dir)
@@ -458,7 +472,7 @@ if __name__ == "__main__":
     plot_lr(runs_ids, runs_data, runs_active, plot_dir=out_dir)
 
     # plot performance
-    #plot_utilization(runs_ids, runs_data, runs_active, plot_dir=plt_path)
+    plot_utilization(runs_ids, runs_data, runs_active, plot_dir=out_dir)
 
     # compare different runs
     plot_loss_per_stream(
@@ -469,7 +483,7 @@ if __name__ == "__main__":
         ["era5", "METEOSAT", "NPP"],
         x_type=x_type,
         x_scale_log=x_scale_log,
-        plot_dir = out_dir
+        plot_dir=out_dir,
     )
     plot_loss_per_stream(
         ["val"],
@@ -479,7 +493,7 @@ if __name__ == "__main__":
         ["era5", "METEOSAT", "NPP"],
         x_type=x_type,
         x_scale_log=x_scale_log,
-        plot_dir = out_dir
+        plot_dir=out_dir,
     )
     plot_loss_per_stream(
         ["train"],
@@ -489,13 +503,24 @@ if __name__ == "__main__":
         ["ERA5", "METEOSAT", "NPP"],
         x_type=x_type,
         x_scale_log=x_scale_log,
-        plot_dir = out_dir
+        plot_dir=out_dir,
     )
 
     # plot all cols for all run_ids
     for run_id, run_data in zip(runs_ids, runs_data, strict=False):
         plot_loss_per_run(
-            ["train", "val"], run_id, runs_ids[run_id], run_data, get_stream_names(run_id, model_path=model_base_dir),
-            plot_dir=out_dir)
-    plot_loss_per_run(["val"], run_id, runs_ids[run_id], run_data, get_stream_names(run_id, model_path=model_base_dir),
-                      plot_dir=out_dir)
+            ["train", "val"],
+            run_id,
+            runs_ids[run_id],
+            run_data,
+            get_stream_names(run_id, model_path=model_base_dir),
+            plot_dir=out_dir,
+        )
+    plot_loss_per_run(
+        ["val"],
+        run_id,
+        runs_ids[run_id],
+        run_data,
+        get_stream_names(run_id, model_path=model_base_dir),
+        plot_dir=out_dir,
+    )

--- a/src/weathergen/utils/plot_training.py
+++ b/src/weathergen/utils/plot_training.py
@@ -102,7 +102,7 @@ def _read_yaml_config(yaml_file_path):
     dict
         A dictionary with run IDs as keys and a list of [job ID, experiment name] as values.
     """
-    with open(yaml_file_path, "r") as f:
+    with open(yaml_file_path) as f:
         data = yaml.safe_load(f)
 
     # Extract configuration for plotting training diagnostics
@@ -121,7 +121,7 @@ def _read_yaml_config(yaml_file_path):
 
     config_dict = {
         run_id: [job_id, exp_name]
-        for run_id, job_id, exp_name in zip(run_ids, job_ids, experiment_names)
+        for run_id, job_id, exp_name in zip(run_ids, job_ids, experiment_names, strict=False)
     }
 
     # Validate the structure: {run_id: [job_id, experiment_name]}

--- a/src/weathergen/utils/plot_training.py
+++ b/src/weathergen/utils/plot_training.py
@@ -500,11 +500,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
-        "-o",
-        "--output_dir",
-        default="./plots/",
-        type=Path,
-        help="Directory where plots are saved"
+        "-o", "--output_dir", default="./plots/", type=Path, help="Directory where plots are saved"
     )
     parser.add_argument(
         "-m",
@@ -588,7 +584,7 @@ if __name__ == "__main__":
     plot_lr(runs_ids, runs_data, runs_active, plot_dir=out_dir)
 
     # plot performance
-    #plot_utilization(runs_ids, runs_data, runs_active, plot_dir=out_dir)
+    # plot_utilization(runs_ids, runs_data, runs_active, plot_dir=out_dir)
 
     # compare different runs
     plot_loss_per_stream(

--- a/src/weathergen/utils/train_logger.py
+++ b/src/weathergen/utils/train_logger.py
@@ -133,7 +133,7 @@ class TrainLogger:
 
     #######################################
     @staticmethod
-    def read(run_id, epoch=-1, model_path: str | None = None):
+    def read(run_id, model_path: str, epoch=-1):
         """
         Read data for run_id
         """
@@ -176,7 +176,7 @@ class TrainLogger:
             _logger.warning(f"Warning: no training data loaded for run_id={run_id}")
             log_train = np.array([])
 
-        log_train_df = read_metrics(cf, run_id, "train", cols1, results_path=result_dir_base)
+        log_train_df = read_metrics(cf, run_id, "train", cols1, result_dir_base)
 
         # validation
         # define cols for validation
@@ -205,7 +205,7 @@ class TrainLogger:
         except:
             print(f"Warning: no validation data loaded for run_id={run_id}")
             log_val = np.array([])
-        metrics_val_df = read_metrics(cf, run_id, "val", cols2, results_path=result_dir_base)
+        metrics_val_df = read_metrics(cf, run_id, "val", cols2, result_dir_base)
 
         # performance
         # define cols for performance monitoring
@@ -223,7 +223,7 @@ class TrainLogger:
             run_id,
             None,
             [_weathergen_timestamp, _performance_gpu, _performance_memory],
-            results_path=result_dir_base,
+            result_dir_base,
         )
 
         return Metrics(run_id, "train", log_train_df, metrics_val_df, metrics_system_df)
@@ -252,7 +252,7 @@ def read_metrics(
     run_id: RunId | None,
     stage: Stage | None,
     cols: list[str] | None,
-    results_path: Path = "./results/",
+    results_path: Path,
 ) -> pl.DataFrame:
     """
     Read metrics for run_id

--- a/src/weathergen/utils/train_logger.py
+++ b/src/weathergen/utils/train_logger.py
@@ -141,7 +141,7 @@ class TrainLogger:
         cf = config.load_model_config(run_id, epoch, model_path)
         run_id = cf.run_id
 
-        result_dir_base = Path(cf.run_path) 
+        result_dir_base = Path(cf.run_path)
         result_dir = result_dir_base / run_id
         fname_log_train = result_dir / f"{run_id}_train_log.txt"
         fname_log_val = result_dir / f"{run_id}_val_log.txt"
@@ -219,8 +219,11 @@ class TrainLogger:
             print(f"Warning: no performance data loaded for run_id={run_id}")
             log_perf = np.array([])
         metrics_system_df = read_metrics(
-            cf, run_id, None, [_weathergen_timestamp, _performance_gpu, _performance_memory], 
-            results_path=result_dir_base
+            cf,
+            run_id,
+            None,
+            [_weathergen_timestamp, _performance_gpu, _performance_memory],
+            results_path=result_dir_base,
         )
 
         return Metrics(run_id, "train", log_train_df, metrics_val_df, metrics_system_df)
@@ -245,7 +248,11 @@ class Metrics:
 
 
 def read_metrics(
-        cf: config.Config, run_id: RunId | None, stage: Stage | None, cols: list[str] | None, results_path: Path = "./results/"
+    cf: config.Config,
+    run_id: RunId | None,
+    stage: Stage | None,
+    cols: list[str] | None,
+    results_path: Path = "./results/",
 ) -> pl.DataFrame:
     """
     Read metrics for run_id

--- a/src/weathergen/utils/train_logger.py
+++ b/src/weathergen/utils/train_logger.py
@@ -133,15 +133,16 @@ class TrainLogger:
 
     #######################################
     @staticmethod
-    def read(run_id, epoch=-1):
+    def read(run_id, epoch=-1, model_path: str | None = None):
         """
         Read data for run_id
         """
 
-        cf = config.load_model_config(run_id, epoch, None)
+        cf = config.load_model_config(run_id, epoch, model_path)
         run_id = cf.run_id
 
-        result_dir = Path(cf.run_path) / run_id
+        result_dir_base = Path(cf.run_path) 
+        result_dir = result_dir_base / run_id
         fname_log_train = result_dir / f"{run_id}_train_log.txt"
         fname_log_val = result_dir / f"{run_id}_val_log.txt"
         fname_perf_val = result_dir / f"{run_id}_perf_log.txt"
@@ -175,7 +176,7 @@ class TrainLogger:
             _logger.warning(f"Warning: no training data loaded for run_id={run_id}")
             log_train = np.array([])
 
-        log_train_df = read_metrics(cf, run_id, "train", cols1)
+        log_train_df = read_metrics(cf, run_id, "train", cols1, results_path=result_dir_base)
 
         # validation
         # define cols for validation
@@ -204,7 +205,7 @@ class TrainLogger:
         except:
             print(f"Warning: no validation data loaded for run_id={run_id}")
             log_val = np.array([])
-        metrics_val_df = read_metrics(cf, run_id, "val", cols2)
+        metrics_val_df = read_metrics(cf, run_id, "val", cols2, results_path=result_dir_base)
 
         # performance
         # define cols for performance monitoring
@@ -218,7 +219,8 @@ class TrainLogger:
             print(f"Warning: no performance data loaded for run_id={run_id}")
             log_perf = np.array([])
         metrics_system_df = read_metrics(
-            cf, run_id, None, [_weathergen_timestamp, _performance_gpu, _performance_memory]
+            cf, run_id, None, [_weathergen_timestamp, _performance_gpu, _performance_memory], 
+            results_path=result_dir_base
         )
 
         return Metrics(run_id, "train", log_train_df, metrics_val_df, metrics_system_df)
@@ -243,7 +245,7 @@ class Metrics:
 
 
 def read_metrics(
-    cf: config.Config, run_id: RunId | None, stage: Stage | None, cols: list[str] | None
+        cf: config.Config, run_id: RunId | None, stage: Stage | None, cols: list[str] | None, results_path: Path = "./results/"
 ) -> pl.DataFrame:
     """
     Read metrics for run_id
@@ -258,7 +260,7 @@ def read_metrics(
         run_id = cf.run_id
 
     # TODO: this should be a config option
-    df = read_metrics_file(f"./results/{run_id}/metrics.json")
+    df = read_metrics_file(results_path / run_id / "metrics.json")
     if stage is not None:
         df = df.filter(pl.col("stage") == stage)
     df = df.drop("stage")


### PR DESCRIPTION
## Description

<!-- Provide a brief summary of the changes introduced in this pull request. -->

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Closes #232 
Closes #201 

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [x] I ran `plot_training.py` and it works now consistently  

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [x] I have not introduced new dependencies in the inference portion of the pipeline

### Documentation

-   [x] My code follows the style guidelines of this project
-   [x] I have updated the documentation and docstrings to reflect the changes
-   [x] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes

`plot_training.py` now runs from arbitrary directories since hard-coded relative paths are avoided and parsing is allowed instead. The default however makes use of the previous hard-coded relative paths for backward compatabilty.