### PR TITLE
remove secrets from config while parsing private config

### DIFF
--- a/src/weathergen/utils/config.py
+++ b/src/weathergen/utils/config.py
@@ -38,8 +38,6 @@ def _format_cf(config: Config) -> str:
     stream = io.StringIO()
     for key, value in config.items():
         match key:
-            case "secrets":
-                continue
             case "streams":
                 for rt in value:
                     for k, v in rt.items():
@@ -63,7 +61,6 @@ def save(config: Config, epoch: int | None):
     json_str = json.dumps(OmegaConf.to_container(config))
     with fname.open("w") as f:
         f.write(json_str)
-
 
 def load_model_config(run_id: str, epoch: int | None, model_path: str | None) -> Config:
     """
@@ -211,6 +208,7 @@ def _load_private_conf(private_home: Path | None) -> DictConfig:
     private_cf["model_path"] = (
         private_cf["model_path"] if "model_path" in private_cf.keys() else "./models"
     )
+    del private_cf["secrets"]
     return private_cf
 
 

--- a/src/weathergen/utils/config.py
+++ b/src/weathergen/utils/config.py
@@ -62,6 +62,7 @@ def save(config: Config, epoch: int | None):
     with fname.open("w") as f:
         f.write(json_str)
 
+
 def load_model_config(run_id: str, epoch: int | None, model_path: str | None) -> Config:
     """
     Load a configuration file from a given run_id and epoch.

--- a/src/weathergen/utils/config.py
+++ b/src/weathergen/utils/config.py
@@ -100,7 +100,8 @@ def load_config(
     *overwrites: Path | dict | Config,
 ) -> Config:
     """
-    Merge config information from multiple sources into one run_config.
+    Merge config information from multiple sources into one run_config. Anything in the
+    private configs "secrets" section will be discarted.
 
     Args:
         private_home: Configuration file containing platform dependent information and secretes

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -150,7 +150,9 @@ def config_fresh(private_config_file):
 
 
 def test_contains_private(config_fresh):
-    assert contains_keys(config_fresh, DUMMY_PRIVATE_CONF)
+    sanitized_private_conf = DUMMY_PRIVATE_CONF.copy()
+    del sanitized_private_conf["secrets"]
+    assert contains_keys(config_fresh, sanitized_private_conf)
 
 
 @pytest.mark.parametrize("overwrite_dict", DUMMY_OVERWRITES, indirect=True)
@@ -207,9 +209,8 @@ def test_from_cli(options, cf):
 
 def test_print_cf_no_secrets(config_fresh):
     output = config._format_cf(config_fresh)
-    print(output)
 
-    assert "53CR3T" not in output
+    assert "53CR3T" not in output and "secrets" not in config_fresh.keys()
 
 
 @pytest.mark.parametrize("streams_dir", VALID_STREAMS, indirect=True)


### PR DESCRIPTION
## Description

avoid leaking secrets by removing "secrets" key from private config during loading.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

#197 

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [x] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [x] I have not introduced new dependencies in the inference portion of the pipeline

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [x] My code follows the style guidelines of this project
-   [x] I have updated the documentation and docstrings to reflect the changes
-   [x] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->