### PR TITLE
Throw error on bad forecast engine config when forecast_steps > 0.

### DIFF
--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -172,7 +172,7 @@ class Model(torch.nn.Module):
         # forecasting engine
         if cf.forecast_steps > 0 and cf.fe_num_blocks == 0:
             raise ValueError("Empty forecast engine (fe_num_blocks = 0), but forecast_steps > 0")
-        
+
         self.fe_blocks = ForecastingEngine(cf, self.num_healpix_cells).create()
 
         ###############

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -170,6 +170,9 @@ class Model(torch.nn.Module):
 
         ###############
         # forecasting engine
+        if cf.forecast_steps > 0 and cf.fe_num_blocks == 0:
+            raise ValueError("Empty forecast engine (fe_num_blocks = 0), but forecast_steps > 0")
+        
         self.fe_blocks = ForecastingEngine(cf, self.num_healpix_cells).create()
 
         ###############


### PR DESCRIPTION
## Description

<!-- Provide a brief summary of the changes introduced in this pull request. -->

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

#215 

<!-- Alternatively, explain the motivation behind the changes and the context in which they are being made. -->

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [x] I have not introduced new dependencies in the inference portion of the pipeline

### Documentation

-   [x] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas

## Additional Notes

Introduces a check that forecasting engine is activated if `forecast_steps > 0`.