### PR TITLE
Add check for duplicate stream names and raise error before training …

### DIFF
--- a/src/weathergen/utils/config.py
+++ b/src/weathergen/utils/config.py
@@ -263,7 +263,9 @@ def load_streams(streams_directory: Path) -> list[Config]:
     _logger.info(f"Reading streams from {streams_directory}")
 
     # append streams to existing (only relevant for evaluation)
+    # append stream_names to a list to keep track of them, and check for duplicates
     streams = []
+    stream_names = []
     # exclude temp files starting with "." or "#" (eg. emacs, vim, macos savefiles)
     stream_files = sorted(streams_directory.rglob("[!.#]*.yml"))
     _logger.info(f"discover stream configs: {stream_files}")
@@ -286,6 +288,15 @@ def load_streams(streams_directory: Path) -> list[Config]:
             continue
 
         streams.append(stream_config)
+        stream_names.append(stream_name)
         _logger.info(f"Loaded stream config: {stream_name}")
+
+    # check for duplicates of stream names
+    if len(stream_names) != len(set(stream_names)):
+        duplicates = [name for name in set(stream_names) if stream_names.count(name) > 1]
+        msg = f"Duplicate stream names found: {duplicates}. Please ensure all stream names are unique."
+        raise ValueError(msg)
+
+    _logger.info(f"Loaded {len(streams)} streams from {streams_directory}")
 
     return streams


### PR DESCRIPTION
…if so

## Description

Changes to load_streams() in weathergen/utils/config.py to check if there are duplicate stream names in the stream config files used. If there are duplicates, an error is raised immediately before training begins and the duplicate stream name is given.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Closes #203 

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [x] I have not introduced new dependencies in the inference portion of the pipeline

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [x] I have added comments to my code, particularly in hard-to-understand areas

## Additional Notes

I am not yet clear on how we want to raise errors and making this consistent. I have tried to match the style in config.py.