### PR TITLE
recover num_ranks from previous run to calculate epoch_base

### DIFF
--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -54,6 +54,10 @@ class Trainer(Trainer_Base):
 
         self.devices = self.init_torch()
 
+        # Get num_ranks of previous run which is to be continued before
+        # num_ranks gets overwritten by current setting during init_ddp()
+        self.num_ranks_original = cf.num_ranks if "num_ranks" in cf.keys() else None
+
         self.init_ddp(cf)
 
         # read configuration of data streams
@@ -264,7 +268,15 @@ class Trainer(Trainer_Base):
         self.loss_fcts_val = [[getattr(losses, name), w] for name, w in cf.loss_fcts_val]
 
         # recover epoch when continuing run
-        epoch_base = int(self.cf.istep / len(self.data_loader))
+        if self.num_ranks_original is None:
+            epoch_base = int(self.cf.istep / len(self.data_loader))
+        else:
+            len_per_rank = (
+                (len(self.dataset) // self.num_ranks_original) // cf.batch_size
+            ) * cf.batch_size
+            epoch_base = int(
+                self.cf.istep / (min(len_per_rank, cf.samples_per_epoch) * self.num_ranks_original)
+            )
 
         # torch.autograd.set_detect_anomaly(True)
         if cf.forecast_policy is not None:


### PR DESCRIPTION
## Description

When continue a training run, previously used `num_ranks` is used to calculate `epoch_base`. 

## Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

This is supposed to fix #280 .

## Code Compatibility

-   [ ] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [ ] I have not introduced new dependencies in the inference portion of the pipeline

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->