### PR TITLE
Small change - CI - pinning the version of formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           # Install a specific version of uv.
-          version: "0.6.2"
+          version: "0.7.13"
 
       - name: Run ruff (black)
         # Do not attempt to install the default dependencies, this is much faster.
         # Run temporarily on a sub directory before the main restyling.
-        run: uv run --no-project --with "ruff==0.9.7" ruff format --check -n src/
+        run: uv run --no-project --with "ruff==0.9.7" ruff format --target-version py312 --check -n src/
 
       - name: Run ruff (flake8)
         # Do not attempt to install the default dependencies, this is much faster.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,12 @@ ignore = [
 # TODO: pytorch does not publish valid release timestamps, so sadly it does not work.
 # exclude-newer = "2025-03-14T00:00:00Z"
 
+# The minimum version of uv required.
+# It is tightly controlled because the format of uv.lock has changed 
+# over revisions, causing reformats to happen without reason.
+# Also, relatively recent versions are required to support workspaces.
+required-version = ">=0.7.0"
+
 # Following the recommendations from https://docs.astral.sh/uv/guides/integration/pytorch
 # The current setup is:
 # linux == GPU + flashattention


### PR DESCRIPTION
## Description

Some CI jobs are currently failing while the formatting is working correctly locally, see for example
https://github.com/ecmwf/WeatherGenerator/actions/runs/15703997206/job/44262234610?pr=284

This seems to be related to the fact that we do not pin the version of python that we are targetting for formatting. This is now explicitly set. I am also going to update the wiki.

## Type of Change

-   [X] Bug fix (non-breaking change which fixes an issue)
