### PR TITLE
changed the script name from evaluate to inference as it simply gener…

### DIFF
--- a/config/profiling/annotations.json
+++ b/config/profiling/annotations.json
@@ -31,7 +31,7 @@
         "domain": "WeatherGen",
         "module": "weathergen.train.trainer",
         "functions": [
-            "Trainer.evaluate",
+            "Trainer.inference",
             "Trainer.train",
             "Trainer.validate",
             "Trainer.compute_loss",

--- a/integration_tests/small1_test.py
+++ b/integration_tests/small1_test.py
@@ -1,7 +1,7 @@
 """
 Small test for the Weather Generator.
 This test must run on a GPU machine.
-It performs a training and evaluation of the Weather Generator model.
+It performs a training and inference of the Weather Generator model.
 
 Command:
 uv run pytest  ./integration_tests/small1.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import pytest
 
-from weathergen import evaluate_from_args, train_with_args
+from weathergen import inference_from_args, train_with_args
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +55,7 @@ def test_train(setup, test_run_id):
         f"{weathergen_home}/config/streams/streams_test/",
     )
 
-    evaluate_from_args(
+    inference_from_args(
         ["-start", "2022-10-10", "-end", "2022-10-11", "--samples", "10", "--epoch", "0"]
         + [
             "--from_run_id",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ Issues = "https://github.com/ecmwf/WeatherGenerator/issues"
 [project.scripts]
 train = "weathergen.run_train:train"
 train_continue = "weathergen.run_train:train_continue"
-evaluate = "weathergen.run_train:evaluate"
+inference = "weathergen.run_train:evaluate"
 plot = "weathergen.evaluate.plot:plot"
 plot_train = "weathergen.utils.plot_training:plot_train"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ Issues = "https://github.com/ecmwf/WeatherGenerator/issues"
 [project.scripts]
 train = "weathergen.run_train:train"
 train_continue = "weathergen.run_train:train_continue"
-inference = "weathergen.run_train:evaluate"
+inference = "weathergen.run_train:inference"
 plot = "weathergen.evaluate.plot:plot"
 plot_train = "weathergen.utils.plot_training:plot_train"
 

--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -8,7 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 """
-The entry point for training and evaluating weathergen-atmo
+The entry point for training and inference weathergen-atmo
 """
 
 import pdb
@@ -29,8 +29,8 @@ def inference():
 
 def inference_from_args(argl: list[str]):
     """
-    Evaluation function for WeatherGenerator model.
-    Entry point for calling the evaluation code from the command line.
+    Inference function for WeatherGenerator model.
+    Entry point for calling the inference code from the command line.
 
     When running integration tests, the arguments are directly provided.
     """

--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -22,24 +22,24 @@ from weathergen.train.trainer import Trainer
 from weathergen.utils.logger import init_loggers
 
 
-def evaluate():
+def inference():
     # By default, arguments from the command line are read.
-    evaluate_from_args(sys.argv[1:])
+    inference_from_args(sys.argv[1:])
 
 
-def evaluate_from_args(argl: list[str]):
+def inference_from_args(argl: list[str]):
     """
     Evaluation function for WeatherGenerator model.
     Entry point for calling the evaluation code from the command line.
 
     When running integration tests, the arguments are directly provided.
     """
-    parser = cli.get_evaluate_parser()
+    parser = cli.get_inference_parser()
     args = parser.parse_args(argl)
 
     init_loggers()
 
-    evaluate_overwrite = dict(
+    inference_overwrite = dict(
         shuffle=False,
         start_date_val=args.start_date,
         end_date_val=args.end_date,
@@ -54,7 +54,7 @@ def evaluate_from_args(argl: list[str]):
         args.from_run_id,
         args.epoch,
         *args.config,
-        evaluate_overwrite,
+        inference_overwrite,
         cli_overwrite,
     )
     cf = config.set_run_id(cf, args.run_id, args.reuse_run_id)
@@ -62,7 +62,7 @@ def evaluate_from_args(argl: list[str]):
     cf.run_history += [(args.from_run_id, cf.istep)]
 
     trainer = Trainer()
-    trainer.evaluate(cf, args.from_run_id, args.epoch)
+    trainer.inference(cf, args.from_run_id, args.epoch)
 
 
 ####################################################################################################

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -77,7 +77,7 @@ class Trainer(Trainer_Base):
         self.train_logger = TrainLogger(cf, self.path_run)
 
     ###########################################
-    def evaluate(self, cf, run_id_trained, epoch):
+    def inference(self, cf, run_id_trained, epoch):
         # general initalization
         self.init(cf)
 

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -124,11 +124,11 @@ class Trainer(Trainer_Base):
         if self.cf.rank == 0:
             config.save(self.cf, epoch=0)
 
-        _logger.info(f"Starting evaluation with id={self.cf.run_id}.")
+        _logger.info(f"Starting inference with id={self.cf.run_id}.")
 
-        # evaluate validation set
+        # inference validation set
         self.validate(epoch=0)
-        _logger.info(f"Finished evaluation run with id: {cf.run_id}")
+        _logger.info(f"Finished inference run with id: {cf.run_id}")
 
     ###########################################
     def run(self, cf, run_id_contd=None, epoch_contd=None):

--- a/src/weathergen/utils/cli.py
+++ b/src/weathergen/utils/cli.py
@@ -29,7 +29,7 @@ def get_continue_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def get_evaluate_parser() -> argparse.ArgumentParser:
+def get_inference_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(allow_abbrev=False)
 
     _add_model_loading_params(parser)

--- a/src/weathergen/utils/cli.py
+++ b/src/weathergen/utils/cli.py
@@ -40,29 +40,29 @@ def get_inference_parser() -> argparse.ArgumentParser:
         "-start",
         type=_format_date,
         default="2022-10-01",
-        help="Start date for evaluation. Format must be parsable with pd.to_datetime.",
+        help="Start date for inference. Format must be parsable with pd.to_datetime.",
     )
     parser.add_argument(
         "--end_date",
         "-end",
         type=_format_date,
         default="2022-12-01",
-        help="End date for evaluation. Format must be parsable with pd.to_datetime.",
+        help="End date for inference. Format must be parsable with pd.to_datetime.",
     )
     parser.add_argument(
-        "--samples", type=int, default=10000000, help="Number of evaluation samples."
+        "--samples", type=int, default=10000000, help="Number of inference samples."
     )
     parser.add_argument(  # behaviour changed => implies default=False
         "--save_samples",
         type=bool,
         default=True,
-        help="Toggle saving of samples from evaluation. Default True",
+        help="Toggle saving of samples from inference. Default True",
     )
     parser.add_argument(
         "--analysis_streams_output",
         nargs="+",
         default=["ERA5"],
-        help="Analysis output streams during evaluation.",
+        help="Analysis output streams during inference.",
     )
 
     return parser
@@ -122,7 +122,7 @@ def _add_model_loading_params(parser: argparse.ArgumentParser):
         "--from_run_id",
         required=True,
         help=(
-            "Start evaluation or continue training from the WeatherGenerator",
+            "Start inference or continue training from the WeatherGenerator",
             " model with the given run id.",
         ),
     )

--- a/src/weathergen/utils/config.py
+++ b/src/weathergen/utils/config.py
@@ -102,7 +102,7 @@ def load_config(
     Args:
         private_home: Configuration file containing platform dependent information and secretes
         from_run_id: Run id of the pretrained WeatherGenerator model
-        to continue training or evaluate
+        to continue training or inference
         epoch: epoch of the checkpoint to load. -1 indicates last checkpoint available.
         *overwrites: Additional overwrites from different sources
 
@@ -129,12 +129,12 @@ def set_run_id(config: Config, run_id: str | None, reuse_run_id: bool) -> Config
 
     Determining the run id should follow the following logic:
 
-    1. (default case): run train, train_continue or evaluate without any flags
+    1. (default case): run train, train_continue or inference without any flags
         => generate a new run_id for this run.
-    2. (assign run_id): run train, train_continue or evaluate with --run_id <RUNID> flag
+    2. (assign run_id): run train, train_continue or inference with --run_id <RUNID> flag
         => assign a run_id manually to this run.
         This is intend for outside tooling and should not be used manually.
-    3. (reuse run_id -> only for train_continue and evaluate):
+    3. (reuse run_id -> only for train_continue and inference):
         reuse the run_id from the run specified by --from_run_id <RUNID>.
         Since the run_id correct run_id is already loaded in the config nothing has to be assigned.
         This case will happen if --reuse_run_id is specified.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,13 +8,13 @@ DATE_FORMATS = ["2022-12-01T00:00:00", "20221201", "2022-12-01", "12.01.2022"]
 EXPECTED_DATE_STR = "202212010000"
 MODEL_LOADING_ARGS = ["from_run_id", "epoch", "reuse_run_id"]
 GENERAL_ARGS = ["config", "private_config", "options", "run_id"]
-MODEL_LOADING_PARSERS = [cli.get_continue_parser(), cli.get_evaluate_parser()]
+MODEL_LOADING_PARSERS = [cli.get_continue_parser(), cli.get_inference_parser()]
 BASIC_ARGLIST = ["--from_run_id", "test123"]
 
 
 @pytest.fixture
-def evaluate_parser():
-    return cli.get_evaluate_parser()
+def inference_parser():
+    return cli.get_inference_parser()
 
 
 def test_private_config_is_path():
@@ -60,21 +60,21 @@ def test_model_loading_has_params(parser):
 
 
 @pytest.mark.parametrize("streams", [["ERA5", "FOO"], ["BAR"]])
-def test_evaluate_analysis_streams_output(evaluate_parser, streams):
+def test_inference_analysis_streams_output(inference_parser, streams):
     arglist = BASIC_ARGLIST + ["--analysis_streams_output", *streams]
-    args = evaluate_parser.parse_args(arglist)
+    args = inference_parser.parse_args(arglist)
 
     assert args.analysis_streams_output == streams
 
 
-def test_evaluate_analysis_streams_output_empty(evaluate_parser):
+def test_inference_analysis_streams_output_empty(inference_parser):
     arglist = BASIC_ARGLIST + ["--analysis_streams_output", *[]]
 
     with pytest.raises(SystemExit):
-        evaluate_parser.parse_args(arglist)
+        inference_parser.parse_args(arglist)
 
 
-def test_evaluate_defaults(evaluate_parser):
+def test_inference_defaults(inference_parser):
     default_args = [
         "start_date",
         "end_date",
@@ -83,11 +83,11 @@ def test_evaluate_defaults(evaluate_parser):
         "epoch",
         "private_config",
     ]
-    default_values = [evaluate_parser.get_default(arg) for arg in default_args]
+    default_values = [inference_parser.get_default(arg) for arg in default_args]
     # apply custom type
     default_values[:2] = [cli._format_date(date) for date in default_values[:2]]
 
-    args = evaluate_parser.parse_args(BASIC_ARGLIST)
+    args = inference_parser.parse_args(BASIC_ARGLIST)
 
     assert all(
         [
@@ -98,24 +98,24 @@ def test_evaluate_defaults(evaluate_parser):
 
 
 @pytest.mark.parametrize("date", DATE_FORMATS)
-def test_evaluate_start_date(evaluate_parser, date):
-    args = evaluate_parser.parse_args(BASIC_ARGLIST + ["--start_date", date])
+def test_inference_start_date(inference_parser, date):
+    args = inference_parser.parse_args(BASIC_ARGLIST + ["--start_date", date])
 
     assert args.start_date == EXPECTED_DATE_STR
 
 
-def test_evaluate_start_date_invalid(evaluate_parser):
+def test_inference_start_date_invalid(inference_parser):
     with pytest.raises(SystemExit):
-        evaluate_parser.parse_args(BASIC_ARGLIST + ["--start_date", "foobar"])
+        inference_parser.parse_args(BASIC_ARGLIST + ["--start_date", "foobar"])
 
 
 @pytest.mark.parametrize("date", DATE_FORMATS)
-def test_evaluate_end_date(evaluate_parser, date):
-    args = evaluate_parser.parse_args(BASIC_ARGLIST + ["--end_date", date])
+def test_inference_end_date(inference_parser, date):
+    args = inference_parser.parse_args(BASIC_ARGLIST + ["--end_date", date])
 
     assert args.end_date == EXPECTED_DATE_STR
 
 
-def test_evaluate_end_date_invalid(evaluate_parser):
+def test_inference_end_date_invalid(inference_parser):
     with pytest.raises(SystemExit):
-        evaluate_parser.parse_args(BASIC_ARGLIST + ["--end_date", "foobar"])
+        inference_parser.parse_args(BASIC_ARGLIST + ["--end_date", "foobar"])


### PR DESCRIPTION
Renaming of the evaluate script to inference

## Description

Currently, evaluate script produces samples which are being later evaluated using other scripts. Just to align with the name, the renaming has been done

## Type of Change

-   [ ] Naming issue

## Issue Number 373

https://github.com/ecmwf/WeatherGenerator/issues/373

## Code Compatibility

-   [ ] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I ran the `uv run inference`  on a least one GPU node in JUWELS booster and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [ ] uv environment needs to be sync with the updated toml file
-   [ ] Accordingly, all the script inside the private repository has been updated  (https://gitlab.jsc.fz-juelich.de/esde/WeatherGenerator-private/-/tree/ankit_issue_373_rename_evaluate_to_inference)

<!-- List any new dependencies that are required for this change and the justification to add them. -->

<!-- Describe any major updates to the documentation -->

## Additional Notes

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->