### PR TITLE
added default forecasting config for finetuning

### DIFF
--- a/config/forecating_finetuning_config.yml
+++ b/config/forecating_finetuning_config.yml
@@ -1,0 +1,4 @@
+forecast_steps: 1
+fe_num_blocks: 4
+forecast_policy: "fixed"
+training_mode: "forecast"


### PR DESCRIPTION
## Description

This is a dummy PR to keep track of the workable configuration for training on ERA5.

- [ ]  `config/default_config.yml`
- [ ]  `forecasting_finetuning_config.yml` ( overwrite over default config for finetuning forecast experiments)
- [ ]  `config/streams/streams_anemoi/era5.yml`


## Issue Number #382 

The motivation behind this PR to keep track on the config that is working for all the collaborators across different HPCs

