### PR TITLE
Introduce tuples instead for strings to avoid TypeError

### DIFF
--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -252,8 +252,12 @@ class Trainer(Trainer_Base):
                 "cf.lr_steps_warmup and cf.lr_steps_cooldown",
                 f" were larger than cf.lr_steps={cf.lr_steps}",
             )
-            s += f". The value have been adjusted to cf.lr_steps_warmup={cf.lr_steps_warmup} and "
-            s += f" cf.lr_steps_cooldown={cf.lr_steps_cooldown} so that steps_decay={steps_decay}."
+            s += (
+                f". The value have been adjusted to cf.lr_steps_warmup={cf.lr_steps_warmup} and ",
+            )
+            s += (
+                f" cf.lr_steps_cooldown={cf.lr_steps_cooldown} so that steps_decay={steps_decay}.",
+            )
             _logger.warning(s)
         self.lr_scheduler = LearningRateScheduler(
             self.optimizer,


### PR DESCRIPTION
## Description

<!-- Provide a brief summary of the changes introduced in this pull request. -->

## Type of Change

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/391

## Code Compatibility

-   [X] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [x] I have not introduced new dependencies in the inference portion of the pipeline

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [x] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->