### PR TITLE
[346] Passing options through the slurm script

### DIFF
--- a/src/weathergen/utils/config.py
+++ b/src/weathergen/utils/config.py
@@ -112,7 +112,17 @@ def load_config(
         - overwrites (also in ascending order)
     """
     private_config = _load_private_conf(private_home)
-    overwrite_configs = [_load_overwrite_conf(overwrite) for overwrite in overwrites]
+    overwrite_configs: list[Config] = []
+    for overwrite in overwrites:
+        if isinstance(overwrite, (str, Path)):
+            # Because of the way we pass extra configs through slurm,
+            # all the paths may be concatenated with ":"
+            p = str(overwrite).split(":")
+            for path in p:
+                overwrite_configs.append(_load_overwrite_conf(Path(path)))
+        else:
+            # If it is a dict or DictConfig, we can directly use it
+            overwrite_configs.append(_load_overwrite_conf(overwrite))
 
     if from_run_id is None:
         base_config = _load_default_conf()


### PR DESCRIPTION
## Description

Allows the passing of options through the slurm script. Because of the way arguments are passed through slurm, we need to accept `--config a:b:c` on top of `--config a --config b ...`

Checked on hpc2020.

## Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

<!-- Link the Issue number this change addresses, ideally in one of the "magic format" such as Closes #XYZ -->

<!-- Alternatively, explain the motivation behind the changes and the context in which they are being made. -->

## Code Compatibility

-   [ ] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [ ] I have not introduced new dependencies in the inference portion of the pipeline

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->