### PR TITLE
fix obs dataset names in stream_mixed

### DIFF
--- a/config/streams/streams_mixed/geos_1.yml
+++ b/config/streams/streams_mixed/geos_1.yml
@@ -7,7 +7,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-METEOSAT-X, SEVIRI :
+SEVIRI :
   type : obs
   filenames : ['observations-od-ai-0001-2018-2023-meteosat-11-seviri-v1.zarr']
   loss_weight : 1.0

--- a/config/streams/streams_mixed/npp_atms.yml
+++ b/config/streams/streams_mixed/npp_atms.yml
@@ -7,7 +7,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-NPP, ATMS :
+NPPATMS :
   type : obs
   filenames : ['observations-ea-ofb-0001-2012-2023-npp-atms-radiances-v2.zarr']
   loss_weight : 1.0

--- a/config/streams/streams_mixed/synop.yml
+++ b/config/streams/streams_mixed/synop.yml
@@ -3,7 +3,7 @@
 # 1 : geostationay satellites
 # 2 : conventional observations
 
-Surface Combined :
+SurfaceCombined :
   type : obs
   filenames : ['observations-ea-ofb-0001-1979-2023-combined-surface-v2.zarr']
   loss_weight : 1.0


### PR DESCRIPTION
## Description

fix streams names for NPP ATMS, SEVIRI and SYNOP in steam_mixed to avoid key error not found crash. 

## Type of Change

-   [ *] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

related to this issue: https://github.com/ecmwf/WeatherGenerator/issues/430

## Code Compatibility

-   [* ] I have performed a self-review of my code

### Code Performance and Testing

-   [ *] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [ *] I have not introduced new dependencies in the inference portion of the pipeline
