### PR TITLE
Re-enabled option to run plot_training as script and fixed -rf argument

### DIFF
--- a/src/weathergen/utils/plot_training.py
+++ b/src/weathergen/utils/plot_training.py
@@ -627,8 +627,8 @@ def plot_train(args=None):
         "--run_ids_dict",
         type=_read_str_config,
         dest="rs",
-        help="Dictionary-string of form '{run_id: [job_id, experiment_name]}'" + \
-              "for training runs to plot",
+        help="Dictionary-string of form '{run_id: [job_id, experiment_name]}'"
+        + "for training runs to plot",
     )
 
     run_id_group.add_argument(
@@ -726,7 +726,6 @@ def plot_train(args=None):
 
 
 if __name__ == "__main__":
-
     args = sys.argv[1:]  # get CLI args
 
     plot_train(args)

--- a/src/weathergen/utils/plot_training.py
+++ b/src/weathergen/utils/plot_training.py
@@ -7,10 +7,10 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-import sys
 import argparse
 import logging
 import subprocess
+import sys
 from pathlib import Path
 
 import matplotlib.pyplot as plt

--- a/src/weathergen/utils/plot_training.py
+++ b/src/weathergen/utils/plot_training.py
@@ -7,6 +7,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+import sys
 import argparse
 import logging
 import subprocess
@@ -556,7 +557,7 @@ def plot_loss_per_run(
     plt.close()
 
 
-def plot_train():
+def plot_train(args=None):
     # Example usage:
     # When providing a YAML for configuring the run IDs:
     # python plot_training.py -rf eval_run.yml -m ./trained_models -o ./training_plots
@@ -626,23 +627,20 @@ def plot_train():
         "--run_ids_dict",
         type=_read_str_config,
         dest="rs",
-        help=(
-            "Dictionary-string of form '{run_id: [job_id, experiment_name]}'",
-            " for training runs to plot",
-        ),
+        help="Dictionary-string of form '{run_id: [job_id, experiment_name]}'" + \
+              "for training runs to plot",
     )
 
     run_id_group.add_argument(
         "-rf",
         "--run_ids_file",
         dest="rf",
-        default="./config/runs_plot_train.yml",
         type=_read_yaml_config,
         help="YAML file configuring the training run ids to plot",
     )
 
     # parse the command line arguments
-    args = parser.parse_args()
+    args = parser.parse_args(args)
 
     model_base_dir = Path(args.model_base_dir)
     out_dir = Path(args.output_dir)
@@ -725,3 +723,10 @@ def plot_train():
         get_stream_names(run_id, model_path=model_base_dir),  # limit to available streams
         plot_dir=out_dir,
     )
+
+
+if __name__ == "__main__":
+
+    args = sys.argv[1:]  # get CLI args
+
+    plot_train(args)

--- a/src/weathergen/utils/plot_training.py
+++ b/src/weathergen/utils/plot_training.py
@@ -22,6 +22,8 @@ from weathergen.utils.train_logger import Metrics, TrainLogger
 
 _logger = logging.getLogger(__name__)
 
+DEFAULT_RUN_FILE = Path("./config/runs_plot_train.yml")
+
 
 ####################################################################################################
 def _ensure_list(value):
@@ -623,18 +625,18 @@ def plot_train(args=None):
 
     run_id_group = parser.add_mutually_exclusive_group()
     run_id_group.add_argument(
-        "-rs",
-        "--run_ids_dict",
+        "-fd",
+        "--from_dict",
         type=_read_str_config,
-        dest="rs",
+        dest="fd",
         help="Dictionary-string of form '{run_id: [job_id, experiment_name]}'"
         + "for training runs to plot",
     )
 
     run_id_group.add_argument(
-        "-rf",
-        "--run_ids_file",
-        dest="rf",
+        "-fy",
+        "--from_yaml",
+        dest="fy",
         type=_read_yaml_config,
         help="YAML file configuring the training run ids to plot",
     )
@@ -649,7 +651,17 @@ def plot_train(args=None):
     if args.x_type not in x_types_valid:
         raise ValueError(f"x_type must be one of {x_types_valid}, but got {args.x_type}")
 
-    runs_ids = args.rs if args.rs is not None else args.rf
+    # Post-processing default logic for config from YAML-file
+    if args.fd is None and args.fy is None:
+        if DEFAULT_RUN_FILE.exists():
+            args.fy = _read_yaml_config(DEFAULT_RUN_FILE)
+        else:
+            raise ValueError(
+                f"Please provide a run_id dictionary or a YAML file with run_ids, "
+                f"or create a default file at {DEFAULT_RUN_FILE}."
+            )
+
+    runs_ids = args.fd if args.fd is not None else args.fy
 
     if args.delete == "True":
         clean_plot_folder(out_dir)


### PR DESCRIPTION
## Description

`plot_training.py` can now be run as scrit from the CLI again without breaking further integration into other workflows.
Furthermore, the dafault in the mutually exclusive argument `-rf` has been removed. This broke the code when the default config YAML-file (using a relatve path) was not available. 

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Fixes #443 

<!-- Alternatively, explain the motivation behind the changes and the context in which they are being made. -->

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [x] I have not introduced new dependencies in the inference portion of the pipeline

### Documentation

-   [x] My code follows the style guidelines of this project
-   [x] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas

## Additional Notes

N/A