### PR TITLE
Update config parameters lr and grad_clip

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -92,7 +92,7 @@ shuffle: True
 
 lr_scaling_policy: "sqrt"
 lr_start: 0.000001
-lr_max: 0.00005
+lr_max: 0.0002
 lr_final_decay: 0.000001
 lr_final: 0.0
 lr_steps_warmup: 256

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -92,7 +92,7 @@ shuffle: True
 
 lr_scaling_policy: "sqrt"
 lr_start: 0.000001
-lr_max: 0.0002
+lr_max: 0.0001
 lr_final_decay: 0.000001
 lr_final: 0.0
 lr_steps_warmup: 256


### PR DESCRIPTION
## Description

Ablations were run to test whether we can increase the learning rate with a more conservative gradient norm clipping value.
Results are posted in issue #544. 
After discussing within the ERA5 performance meeting, we concluded that a learning rate of 2e-4 might be slightly too big.
Should we at least double the learning rate and agree on `lr_max: 1e-4, grad_clip: 1.0`? 
cc @clessig @sophie-xhonneux 

## Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Closes #544 

<!-- Link the Issue number this change addresses, ideally in one of the "magic format" such as Closes #XYZ -->

<!-- Alternatively, explain the motivation behind the changes and the context in which they are being made. -->

## Code Compatibility

-   [ ] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [ ] I have not introduced new dependencies in the inference portion of the pipeline

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->