### PR TITLE
Fix to peek_tar_channels 

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/fast_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/fast_evaluation.py
@@ -33,25 +33,27 @@ _DEFAULT_RESULT_PATH = _REPO_ROOT / "results"
 
 
 ### Auxiliary functions
-def peek_tar_channels(zio: ZarrIO, stream: str) -> list[str]:
+def peek_tar_channels(zio: ZarrIO, stream: str, fstep: int = 0) -> list[str]:
     """
     Peek the channels of a target stream in a ZarrIO object.
 
     Parameters
     ----------
-    zio : ZarrIO
+    zio : 
         The ZarrIO object containing the tar stream.
-    stream : str
+    stream : 
         The name of the tar stream to peek.
+    fstep :  
+        The forecast step to peek. Default is 0.
     Returns
     -------
-    channels : list
+    channels : 
         A list of channel names in the tar stream.
     """
     if not isinstance(zio, ZarrIO):
         raise TypeError("zio must be an instance of ZarrIO")
 
-    dummy_out = zio.get_data(0, stream, 0)
+    dummy_out = zio.get_data(0, stream, fstep)
     channels = dummy_out.target.channels
     _logger.debug(f"Peeked channels for stream {stream}: {channels}")
 
@@ -88,7 +90,7 @@ def calc_scores_per_stream(
     samples = sorted([int(sample) for sample in zio.samples])
     nsamples = len(samples)
 
-    channels_stream = peek_tar_channels(zio, stream)
+    channels_stream = peek_tar_channels(zio, stream, forecast_steps[0])
     # filter channels if provided
     channels = (
         [ch for ch in channels_stream if ch in to_list(channels)]


### PR DESCRIPTION
## Description

Fix to `peek_tar_channels`in fast evaluation-pipeline to allow situations where no data for fstep=0 is available.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Closes #538 

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [x] I have not introduced new dependencies in the inference portion of the pipeline

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [x] My code follows the style guidelines of this project
-   [x] I have updated the documentation and docstrings to reflect the changes
-   [x] I have added comments to my code, particularly in hard-to-understand areas
