### PR TITLE
remove overwriting of cf.streams from path for inference and train_co…

### DIFF
--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -62,7 +62,7 @@ def inference_from_args(argl: list[str]):
 
     cf.run_history += [(args.from_run_id, cf.istep)]
     if args.streams_directory is not None:
-        cf.streams= config.load_streams(Path(args.streams_directory))
+        cf.streams = config.load_streams(Path(args.streams_directory))
     cf = config.set_paths(cf)
     trainer = Trainer()
     trainer.inference(cf, args.from_run_id, args.epoch)
@@ -116,7 +116,7 @@ def train_continue() -> None:
     # track history of run to ensure traceability of results
     cf.run_history += [(args.from_run_id, cf.istep)]
     if args.streams_directory is not None:
-        cf.streams= config.load_streams(Path(args.streams_directory))
+        cf.streams = config.load_streams(Path(args.streams_directory))
     cf = config.set_paths(cf)
 
     if args.finetune_forecast:

--- a/src/weathergen/utils/cli.py
+++ b/src/weathergen/utils/cli.py
@@ -23,14 +23,14 @@ def get_continue_parser() -> argparse.ArgumentParser:
         help=(
             "Fine tune for forecasting. It overwrites some of the Config settings. "
             "Overwrites specified with --config take precedence."
-        ))
+        ),
+    )
     parser.add_argument(
         "--streams_directory",
         type=str,
         default=None,
         help="Override path for streams_directory.",
     )
-    
 
     return parser
 


### PR DESCRIPTION

## Description

While doing inference from the pre-trained model, the config parameter for the streams are read from yml file in the directory rather from the json file generated during the pre-trained model
 
## Type of Change

Removed `cf.streams = config.load_streams(Path(cf.streams_directory))` which overwrite the original `streams` in the config from the json. 


## Issue Number
closes #324 
closes #569 