### PR TITLE
'Handle list input to forecast_steps (Closes #573)'

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/fast_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/fast_evaluation.py
@@ -39,15 +39,15 @@ def peek_tar_channels(zio: ZarrIO, stream: str, fstep: int = 0) -> list[str]:
 
     Parameters
     ----------
-    zio : 
+    zio :
         The ZarrIO object containing the tar stream.
-    stream : 
+    stream :
         The name of the tar stream to peek.
-    fstep :  
+    fstep :
         The forecast step to peek. Default is 0.
     Returns
     -------
-    channels : 
+    channels :
         A list of channel names in the tar stream.
     """
     if not isinstance(zio, ZarrIO):

--- a/packages/evaluate/src/weathergen/evaluate/fast_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/fast_evaluation.py
@@ -39,15 +39,15 @@ def peek_tar_channels(zio: ZarrIO, stream: str, fstep: int = 0) -> list[str]:
 
     Parameters
     ----------
-    zio :
+    zio : 
         The ZarrIO object containing the tar stream.
-    stream :
+    stream : 
         The name of the tar stream to peek.
-    fstep :
+    fstep :  
         The forecast step to peek. Default is 0.
     Returns
     -------
-    channels :
+    channels : 
         A list of channel names in the tar stream.
     """
     if not isinstance(zio, ZarrIO):

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -240,11 +240,13 @@ class Model(torch.nn.Module):
         ###############
         # forecasting engine
         if isinstance(cf.forecast_steps, int):
-            assert not(cf.forecast_steps > 0 and cf.fe_num_blocks == 0), ("Empty forecast engine " 
-            "(fe_num_blocks = 0), but forecast_steps > 0")
+            assert not (cf.forecast_steps > 0 and cf.fe_num_blocks == 0), (
+                "Empty forecast engine (fe_num_blocks = 0), but forecast_steps > 0"
+            )
         else:
-            assert not(min(cf.forecast_steps) > 0 and cf.fe_num_blocks == 0), ("Empty forecast "
-            "engine (fe_num_blocks = 0), but forecast_steps[i] > 0 for some i")
+            assert not (min(cf.forecast_steps) > 0 and cf.fe_num_blocks == 0), (
+                "Empty forecast engine (fe_num_blocks = 0), but forecast_steps[i] > 0 for some i"
+            )
 
         self.fe_blocks = ForecastingEngine(cf, self.num_healpix_cells).create()
 

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -177,12 +177,16 @@ class Model(torch.nn.Module):
         # forecasting engine
         if isinstance(cf.forecast_steps, int):
             if cf.forecast_steps > 0 and cf.fe_num_blocks == 0:
-                raise ValueError("Empty forecast engine (fe_num_blocks = 0), but forecast_steps > 0")
+                raise ValueError(
+                    "Empty forecast engine (fe_num_blocks = 0), but forecast_steps > 0"
+                )
         else:
             if min(cf.forecast_steps) > 0 and cf.fe_num_blocks == 0:
-                raise ValueError("Empty forecast engine (fe_num_blocks = 0), "
-                "but forecast_steps[i] > 0 for some i")
-        
+                raise ValueError(
+                    "Empty forecast engine (fe_num_blocks = 0), "
+                    "but forecast_steps[i] > 0 for some i"
+                )
+
         self.fe_blocks = ForecastingEngine(cf, self.num_healpix_cells).create()
 
         ###############

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -175,9 +175,14 @@ class Model(torch.nn.Module):
 
         ###############
         # forecasting engine
-        if cf.forecast_steps > 0 and cf.fe_num_blocks == 0:
-            raise ValueError("Empty forecast engine (fe_num_blocks = 0), but forecast_steps > 0")
-
+        if isinstance(cf.forecast_steps, int):
+            if cf.forecast_steps > 0 and cf.fe_num_blocks == 0:
+                raise ValueError("Empty forecast engine (fe_num_blocks = 0), but forecast_steps > 0")
+        else:
+            if min(cf.forecast_steps) > 0 and cf.fe_num_blocks == 0:
+                raise ValueError("Empty forecast engine (fe_num_blocks = 0), "
+                "but forecast_steps[i] > 0 for some i")
+        
         self.fe_blocks = ForecastingEngine(cf, self.num_healpix_cells).create()
 
         ###############

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -176,16 +176,11 @@ class Model(torch.nn.Module):
         ###############
         # forecasting engine
         if isinstance(cf.forecast_steps, int):
-            if cf.forecast_steps > 0 and cf.fe_num_blocks == 0:
-                raise ValueError(
-                    "Empty forecast engine (fe_num_blocks = 0), but forecast_steps > 0"
-                )
+            assert not(cf.forecast_steps > 0 and cf.fe_num_blocks == 0), ("Empty forecast engine " 
+            "(fe_num_blocks = 0), but forecast_steps > 0")
         else:
-            if min(cf.forecast_steps) > 0 and cf.fe_num_blocks == 0:
-                raise ValueError(
-                    "Empty forecast engine (fe_num_blocks = 0), "
-                    "but forecast_steps[i] > 0 for some i"
-                )
+            assert not(min(cf.forecast_steps) > 0 and cf.fe_num_blocks == 0), ("Empty forecast "
+            "engine (fe_num_blocks = 0), but forecast_steps[i] > 0 for some i")
 
         self.fe_blocks = ForecastingEngine(cf, self.num_healpix_cells).create()
 


### PR DESCRIPTION
## Description

Fix the assertion that checks forecast_step size is 0 when no forecast blocks are zero for the case of a list input (instead of int) (Closes #573)  

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Closes #573 

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [x] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

Only ran `uv run train' for one epoch. If desired behaviour change is visible after first epoch, further testing may be needed.

### Dependencies

-   [x] I have ensured that the code is still pip-installable after the changes and runs
-   [x] I have tested that new dependencies themselves are pip-installable.
-   [x] I have not introduced new dependencies in the inference portion of the pipeline


### Documentation

-   [x] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [x] I have added comments to my code, particularly in hard-to-understand areas


## Additional Notes

I fixed the bug under the assumption that lists are appropriately handled in the remainder of the code. From a superficial review, this seems to be the case. Main reason for raising this is that I am new to the project. This is my first PR.