### PR TITLE
[569] Load eagerly the stream content in order

### DIFF
--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -115,7 +115,7 @@ def train_continue() -> None:
 
     # track history of run to ensure traceability of results
     cf.run_history += [(args.from_run_id, cf.istep)]
-    cf.streams = config.load_streams(Path(cf.streams_directory))
+    # cf.streams = config.load_streams(Path(cf.streams_directory))
     cf = config.set_paths(cf)
 
     if args.finetune_forecast:

--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -115,7 +115,6 @@ def train_continue() -> None:
 
     # track history of run to ensure traceability of results
     cf.run_history += [(args.from_run_id, cf.istep)]
-    # cf.streams = config.load_streams(Path(cf.streams_directory))
     cf = config.set_paths(cf)
 
     if args.finetune_forecast:

--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -61,7 +61,6 @@ def inference_from_args(argl: list[str]):
     cf = config.set_run_id(cf, args.run_id, args.reuse_run_id)
 
     cf.run_history += [(args.from_run_id, cf.istep)]
-    cf.streams = config.load_streams(Path(cf.streams_directory))
     cf = config.set_paths(cf)
 
     trainer = Trainer()

--- a/src/weathergen/utils/config.py
+++ b/src/weathergen/utils/config.py
@@ -121,10 +121,14 @@ def load_config(
             # all the paths may be concatenated with ":"
             p = str(overwrite).split(":")
             for path in p:
-                overwrite_configs.append(_load_overwrite_conf(Path(path)))
+                c = _load_overwrite_conf(Path(path))
+                c = _load_streams_in_config(c)
+                overwrite_configs.append(c)
         else:
             # If it is a dict or DictConfig, we can directly use it
-            overwrite_configs.append(_load_overwrite_conf(overwrite))
+            c = _load_overwrite_conf(overwrite)
+            c = _load_streams_in_config(c)
+            overwrite_configs.append(c)
 
     if from_run_id is None:
         base_config = _load_default_conf()
@@ -133,6 +137,21 @@ def load_config(
 
     # use OmegaConf.unsafe_merge if too slow
     return OmegaConf.merge(base_config, private_config, *overwrite_configs)
+
+
+def _load_streams_in_config(config: Config) -> Config:
+    """If the config contains a streams_directory, loads the streams and returns the config with the streams set."""
+    streams_directory = config.get("streams_directory", None)
+    config = config.copy()
+    if streams_directory is not None:
+        streams_directory = Path(streams_directory)
+        if not streams_directory.is_dir():
+            msg = f"Streams directory {streams_directory} does not exist."
+            raise FileNotFoundError(msg)
+
+        _logger.info(f"Loading streams from {streams_directory}")
+        config.streams = load_streams(streams_directory)
+    return config
 
 
 def set_run_id(config: Config, run_id: str | None, reuse_run_id: bool) -> Config:

--- a/src/weathergen/utils/config.py
+++ b/src/weathergen/utils/config.py
@@ -140,7 +140,8 @@ def load_config(
 
 
 def _load_streams_in_config(config: Config) -> Config:
-    """If the config contains a streams_directory, loads the streams and returns the config with the streams set."""
+    """If the config contains a streams_directory, loads the streams and returns the config with
+    the streams set."""
     streams_directory = config.get("streams_directory", None)
     config = config.copy()
     if streams_directory is not None:


### PR DESCRIPTION
## Description

Fixes #569 
Alternative to #578  .

## Type of Change

I tried it with various options such as:

```
# Loads the streams from run ug8o7tm3
uv run train_continue --from_run_id ug8o7tm3

# Overwrite all streams with the content of `streams_anemoi_old`
uv run train_continue --from_run_id ug8o7tm3 --options 'streams_directory="./config/streams/streams_anemoi_old"

# Loads the streams default in default_config.yml
uv run train

# Overwrite all streams with the content of `streams_anemoi_old` , the rest of the config comes from default_config.yml
uv run train --options 'streams_directory="./config/streams/streams_anemoi_old"


```

This _should_ also support overriding specific config in the streams, if you know the position of your stream. I have not tried it though.

``` 
# loads the streams from run ug8o7tm3, but changes the masking strategy
uv run train_continue --from_run_id ug8o7tm3 --options 'streams.0.ERA5.masking_rate=0.1'
```

