### PR TITLE
Mlangguth/develop/issue 586

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/plot_inference.py
+++ b/packages/evaluate/src/weathergen/evaluate/plot_inference.py
@@ -59,7 +59,6 @@ if __name__ == "__main__":
     scores_dict = defaultdict(lambda: defaultdict(dict))
 
     for run_id, run in runs.items():
-
         plotter = Plotter(cfg, run_id)
         _logger.info(f"RUN {run_id}: Getting data...")
 
@@ -69,7 +68,7 @@ if __name__ == "__main__":
             _logger.info(f"RUN {run_id}: Processing stream {stream}...")
 
             stream_dict = run["streams"][stream]
-           
+
             if stream_dict.get("plotting"):
                 _logger.info(f"RUN {run_id}: Plotting stream {stream}...")
                 plots = plot_data(cfg, run_id, stream, stream_dict)

--- a/packages/evaluate/src/weathergen/evaluate/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotter.py
@@ -281,7 +281,7 @@ class Plotter:
             ]
             name = "_".join(filter(None, parts))
             fname = f"{self.out_plot_dir.joinpath(name)}.{self.image_format}"
-            _logger.info(f"Saving map to {fname}")
+            _logger.debug(f"Saving map to {fname}")
             plt.savefig(fname)
             plt.close()
             plot_names.append(name)

--- a/packages/evaluate/src/weathergen/evaluate/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotter.py
@@ -245,10 +245,9 @@ class Plotter:
             ax.coastlines()
             da = self.select_from_da(data, select_var).compute()
 
+            marker_size = marker_size_base
             if scale_marker_size:
-                marker_size = (marker_size_base + 1.0) * np.cos(np.radians(da["lat"]))
-            else:
-                marker_size = marker_size_base
+                marker_size = (marker_size + 1.0) * np.cos(np.radians(da["lat"]))
 
             scatter_plt = ax.scatter(
                 da["lon"],
@@ -281,7 +280,9 @@ class Plotter:
                 str(self.fstep).zfill(3),
             ]
             name = "_".join(filter(None, parts))
-            plt.savefig(f"{self.out_plot_dir.joinpath(name)}.{self.image_format}")
+            fname = f"{self.out_plot_dir.joinpath(name)}.{self.image_format}"
+            _logger.info(f"Saving map to {fname}")
+            plt.savefig(fname)
             plt.close()
             plot_names.append(name)
 
@@ -375,7 +376,7 @@ class LinePlots:
         x_dim:
             Dimension to be used for the x-axis. The code will average over all other dimensions.
         y_dim:
-            Name of the dimension to be used for the y-axis (default is "value")
+            Name of the dimension to be used for the y-axis.
         print_summary:
             If True, print a summary of the values from the graph.
         """
@@ -426,3 +427,49 @@ class LinePlots:
         name = "_".join(filter(None, parts))
         plt.savefig(f"{self.out_plot_dir.joinpath(name)}.{self.image_format}")
         plt.close()
+
+
+class DefaultMarkerSize:
+    """
+    Utility class for managing default configuration values, such as marker sizes
+    for various data streams.
+    """
+
+    _marker_size_stream = {
+        "era5": 2.5,
+        "imerg": 0.25,
+        "cerra": 0.1,
+    }
+
+    _default_marker_size = 0.5
+
+    @classmethod
+    def get_marker_size(cls, stream_name: str) -> float:
+        """
+        Get the default marker size for a given stream name.
+
+        Parameters
+        ----------
+        stream_name : str
+            The name of the stream.
+
+        Returns
+        -------
+        float
+            The default marker size for the stream.
+        """
+        return cls._marker_size_stream.get(
+            stream_name.lower(), cls._default_marker_size
+        )
+
+    @classmethod
+    def list_streams(cls):
+        """
+        List all streams with defined marker sizes.
+
+        Returns
+        -------
+        list[str]
+            List of stream names.
+        """
+        return list(cls._marker_size_stream.keys())

--- a/packages/evaluate/src/weathergen/evaluate/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotter.py
@@ -23,8 +23,13 @@ class Plotter:
     def __init__(self, cfg: dict, model_id: str = ""):
         """
         Initialize the Plotter class.
-        :param cfg: config from the yaml file
-        :param model_id: if a model_id is given, the output will be saved in a folder called as the model_id
+
+        Parameters
+        ----------
+        cfg: 
+            Configuration dictionary containing all information for the plotting.
+        model_id: 
+            If a model_id is given, the output will be saved in a folder called as the model_id.
         """
 
         self.cfg = cfg
@@ -49,7 +54,14 @@ class Plotter:
     def update_data_selection(self, select: dict):
         """
         Set the selection for the plots. This will be used to filter the data for plotting.
-        :param select: dictionary containing the selection parameters
+
+        Parameters
+        ----------
+        select:
+            Dictionary containing the selection criteria. Expected keys are:
+                - "sample": Sample identifier
+                - "stream": Stream identifier
+                - "forecast_step": Forecast step identifier 
         """
         self.select = select
 
@@ -78,9 +90,7 @@ class Plotter:
 
     def clean_data_selection(self):
         """
-        :param sample: sample name
-        :param stream: stream name
-        :param fstep: forecasting step
+        Clean the data selection by resetting all selected values.
         """
         self.sample = None
         self.stream = None
@@ -91,9 +101,17 @@ class Plotter:
     def select_from_da(self, da: xr.DataArray, selection: dict) -> xr.DataArray:
         """
         Select data from an xarray DataArray based on given selectors.
-        :param da: xarray DataArray to select data from.
-        :param selection: Dictionary of selectors where keys are coordinate names and values are the values to select.
-        :return: xarray DataArray with selected data.
+
+        Parameters
+        ----------
+        da:
+            xarray DataArray to select data from.
+        selection: 
+            Dictionary of selectors where keys are coordinate names and values are the values to select.
+        
+        Returns
+        -------
+            xarray DataArray with selected data.
         """
         for key, value in selection.items():
             if key in da.coords and key not in da.dims:
@@ -111,15 +129,26 @@ class Plotter:
         variables: list,
         select: dict,
         tag: str = "",
-        number: str = "",
     ) -> list[str]:
         """
         Plot histogram of target vs predictions for a set of variables.
 
-        :param target: target sample for a specific (stream, sample, fstep)
-        :param preds: predictions sample for a specific (stream, sample, fstep)
-        :param variables: list of variables to be plotted
-        :param label: any tag you want to add to the plot
+        Parameters
+        ----------
+        target: xr.DataArray
+            Target sample for a specific (stream, sample, fstep)
+        preds: xr.DataArray
+            Predictions sample for a specific (stream, sample, fstep)
+        variables: list
+            List of variables to be plotted
+        select: dict
+            Selection to be applied to the DataArray
+        tag: str
+            Any tag you want to add to the plot        
+        
+        Returns
+        -------
+            List of plot names for the saved histograms.
         """
         plot_names = []
 
@@ -171,17 +200,29 @@ class Plotter:
         """
         Plot 2D map for a dataset
 
-        :param data: DataArray for a specific (stream, sample, fstep)
-        :param variables: list of variables to be plotted
-        :param label: any tag you want to add to the plot
-        :param select: selection to be applied to the DataArray
-        :param tag: any tag you want to add to the plot
-        :param map_kwargs: additional keyword arguments for the map
-                           Known keys are:
-                            - marker_size: base size of the marker (default is 1)
-                            - scale_marker_size: if True, the marker size will be scaled based on latitude (default is False)
-                            - marker: marker style (default is 'o') 
-                           Unknown keys will be passed to the scatter plot function.
+        Parameters
+        ----------
+        data: xr.DataArray
+            DataArray for a specific (stream, sample, fstep)
+        variables: list
+            List of variables to be plotted
+        label: str
+            Any tag you want to add to the plot
+        select: dict
+            Selection to be applied to the DataArray
+        tag: str
+            Any tag you want to add to the plot
+        map_kwargs: dict
+            Additional keyword arguments for the map.
+            Known keys are:
+                - marker_size: base size of the marker (default is 1)
+                - scale_marker_size: if True, the marker size will be scaled based on latitude (default is False)
+                - marker: marker style (default is 'o')
+            Unknown keys will be passed to the scatter plot function.
+        
+        Returns
+        -------
+            List of plot names for the saved maps.
         """
         map_kwargs_save = map_kwargs.copy()     
         # check for known keys in map_kwargs
@@ -264,9 +305,17 @@ class LinePlots:
     ) -> tuple[list, list]:
         """
         Check if the lengths of data and labels match.
-        :param data: DataArray or list of DataArrays to be plotted
-        :param labels: Label or list of labels for each dataset
-        :return: data_list, label_list - lists of data and labels
+
+        Parameters
+        ----------
+        data: 
+            DataArray or list of DataArrays to be plotted
+        labels:
+            Label or list of labels for each dataset
+
+        Returns
+        -------
+            data_list, label_list - lists of data and labels
         """
         assert type(data) == xr.DataArray or type(data) == list, (
             "Compare::plot - Data should be of type xr.DataArray or list"
@@ -309,12 +358,21 @@ class LinePlots:
     ) -> None:
         """
         Plot a line graph comparing multiple datasets.
-        :param data: DataArray or list of DataArrays to be plotted
-        :param labels: Label or list of labels for each dataset
-        :param tag: Tag to be added to the plot title and filename
-        :param x_dim: Dimension to be used for the x-axis. The code will average over all other dimensions. (default is "forecast_step")
-        :param y_dim: Name of the dimension to be used for the y-axis (default is "value")
-        :return: None
+
+        Parameters
+        ----------
+        data:
+            DataArray or list of DataArrays to be plotted
+        labels:
+            Label or list of labels for each dataset
+        tag:
+            Tag to be added to the plot title and filename
+        x_dim:
+            Dimension to be used for the x-axis. The code will average over all other dimensions.
+        y_dim:
+            Name of the dimension to be used for the y-axis (default is "value")
+        print_summary:
+            If True, print a summary of the values from the graph.
         """
 
         data_list, label_list = self._check_lengths(data, labels)

--- a/packages/evaluate/src/weathergen/evaluate/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotter.py
@@ -26,9 +26,9 @@ class Plotter:
 
         Parameters
         ----------
-        cfg: 
+        cfg:
             Configuration dictionary containing all information for the plotting.
-        model_id: 
+        model_id:
             If a model_id is given, the output will be saved in a folder called as the model_id.
         """
 
@@ -61,7 +61,7 @@ class Plotter:
             Dictionary containing the selection criteria. Expected keys are:
                 - "sample": Sample identifier
                 - "stream": Stream identifier
-                - "forecast_step": Forecast step identifier 
+                - "forecast_step": Forecast step identifier
         """
         self.select = select
 
@@ -106,9 +106,9 @@ class Plotter:
         ----------
         da:
             xarray DataArray to select data from.
-        selection: 
+        selection:
             Dictionary of selectors where keys are coordinate names and values are the values to select.
-        
+
         Returns
         -------
             xarray DataArray with selected data.
@@ -144,8 +144,8 @@ class Plotter:
         select: dict
             Selection to be applied to the DataArray
         tag: str
-            Any tag you want to add to the plot        
-        
+            Any tag you want to add to the plot
+
         Returns
         -------
             List of plot names for the saved histograms.
@@ -195,7 +195,12 @@ class Plotter:
         return plot_names
 
     def map(
-        self, data: xr.DataArray, variables: list, select: dict, tag: str = "", map_kwargs: dict = {}
+        self,
+        data: xr.DataArray,
+        variables: list,
+        select: dict,
+        tag: str = "",
+        map_kwargs: dict | None = None,
     ) -> list[str]:
         """
         Plot 2D map for a dataset
@@ -219,12 +224,12 @@ class Plotter:
                 - scale_marker_size: if True, the marker size will be scaled based on latitude (default is False)
                 - marker: marker style (default is 'o')
             Unknown keys will be passed to the scatter plot function.
-        
+
         Returns
         -------
             List of plot names for the saved maps.
         """
-        map_kwargs_save = map_kwargs.copy()     
+        map_kwargs_save = map_kwargs.copy() if map_kwargs is not None else {}
         # check for known keys in map_kwargs
         marker_size_base = map_kwargs_save.pop("marker_size", 1)
         scale_marker_size = map_kwargs_save.pop("scale_marker_size", False)
@@ -241,7 +246,7 @@ class Plotter:
             da = self.select_from_da(data, select_var).compute()
 
             if scale_marker_size:
-                marker_size = (marker_size_base + 1.)*np.cos(np.radians(da["lat"]))
+                marker_size = (marker_size_base + 1.0) * np.cos(np.radians(da["lat"]))
             else:
                 marker_size = marker_size_base
 
@@ -253,8 +258,8 @@ class Plotter:
                 s=marker_size,
                 marker=marker,
                 transform=ccrs.PlateCarree(),
-                linewidths=0.,                   # only markers, avoids aliasing for very small markers
-                **map_kwargs_save
+                linewidths=0.0,  # only markers, avoids aliasing for very small markers
+                **map_kwargs_save,
             )
             plt.colorbar(
                 scatter_plt, ax=ax, orientation="horizontal", label=f"Variable: {var}"
@@ -308,7 +313,7 @@ class LinePlots:
 
         Parameters
         ----------
-        data: 
+        data:
             DataArray or list of DataArrays to be plotted
         labels:
             Label or list of labels for each dataset

--- a/packages/evaluate/src/weathergen/evaluate/utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils.py
@@ -301,15 +301,11 @@ def plot_data(cfg: str, run_id: str, stream: str, stream_dict: dict) -> list[str
         maps_config["marker_size"] = DefaultMarkerSize.get_marker_size(stream)
 
     # Check if histograms should be plotted
-    if hasattr(plot_settings, "plot_histograms"):
-        if isinstance(plot_settings.plot_histograms, bool):
-            plot_histograms = plot_settings.plot_histograms
-        else:
-            raise TypeError(
-                "plot_histograms must be a boolean or a dictionary with configuration."
-            )
-    else:
-        plot_histograms = False
+    plot_histograms = plot_settings.get("plot_histograms", False)
+    if not isinstance(plot_settings.plot_histograms, bool):
+        raise TypeError(
+            "plot_histograms must be a boolean or a dictionary with configuration."
+        )
 
     if plot_fsteps == "all":
         plot_fsteps = None

--- a/packages/evaluate/src/weathergen/evaluate/utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils.py
@@ -43,12 +43,12 @@ def get_data(
 ) -> WeatherGeneratorOutput:
     """
     Retrieve prediction and target data for a given run from the Zarr store.
-    
+
     Parameters
     ----------
     cfg :
         Configuration dictionary containing all information for the evaluation.
-    run_id : 
+    run_id :
         Run identifier.
     stream :
         Stream name to retrieve data for.
@@ -164,11 +164,11 @@ def calc_scores_per_stream(
         Configuration dictionary containing all information for the evaluation.
     run_id :
         Run identifier.
-    stream :    
+    stream :
         Stream name to calculate scores for.
     metrics :
         List of metric names to calculate.
-    
+
     Returns
     -------
     Tuple of xarray DataArray containing the scores and the number of points per sample.
@@ -345,9 +345,13 @@ def plot_data(cfg: str, run_id: str, stream: str, stream_dict: dict) -> list[str
             }
 
             if plot_maps:
-                map_tar = plotter.map(tars, plot_chs, data_selection, "target", maps_config)
+                map_tar = plotter.map(
+                    tars, plot_chs, data_selection, "target", maps_config
+                )
 
-                map_pred = plotter.map(preds, plot_chs, data_selection, "preds", maps_config)
+                map_pred = plotter.map(
+                    preds, plot_chs, data_selection, "preds", maps_config
+                )
                 plots.extend([map_tar, map_pred])
 
             if plot_histograms:
@@ -471,7 +475,7 @@ def plot_summary(cfg: dict, scores_dict: dict, print_summary: bool):
         Configuration dictionary containing all information for the evaluation.
     scores_dict :
         Dictionary containing scores for each metric and stream.
-    print_summary 
+    print_summary
         If True, print a summary of the evaluation results.
     """
     _logger.info("Plotting summary of evaluation results...")
@@ -532,6 +536,7 @@ def plot_summary(cfg: dict, scores_dict: dict, print_summary: bool):
                         print_summary=print_summary,
                     )
 
+
 def get_default_markersize(stream_name: str) -> float:
     """
     Get the default marker size for a given stream name.
@@ -549,14 +554,13 @@ def get_default_markersize(stream_name: str) -> float:
     """
     s = stream_name.lower()
 
-    if s == "era5":
-        return 1.
-    elif s == "imerg":
-        return 0.25
-    elif s == "cerra":
-        return 0.1
-    else:
-        return 0.5
+    resolution_map = {
+        "era5": 1.0,
+        "imerg": 0.25,
+        "cerra": 0.1,
+    }
+    return resolution_map.get(s, 0.5)
+
 
 ############# Utility functions ############
 

--- a/packages/evaluate/src/weathergen/evaluate/utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils.py
@@ -304,7 +304,7 @@ def plot_data(cfg: str, run_id: str, stream: str, stream_dict: dict) -> list[str
     plot_histograms = plot_settings.get("plot_histograms", False)
     if not isinstance(plot_settings.plot_histograms, bool):
         raise TypeError(
-            "plot_histograms must be a boolean or a dictionary with configuration."
+            "plot_histograms must be a boolean."
         )
 
     if plot_fsteps == "all":


### PR DESCRIPTION
## Description

The option to configure the marker size as well as the marker type has been introduced for the map plots.
Additionally, the marker size can also be scaled based on the latitude of the plotted data points.

Furthermore, the doc-strings in `utils.py` and `plotter.py` of the `evaluate`-package have been updated to follow the code standard.

## Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Closes #586 

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [x] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

The newly introduced option to parse config-parameters to the map-plots is backward compatible.
Thus, both works:
```
[...]
    plot_maps: 
[...]
```
which triggers default behaviour (standard marker size is set), and
```
    plot_maps: true
        marker_size: 0.5
[...]
```
which sets the `marker_size` in the scatter plot to 0.5.

### Dependencies

-   [x] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [x] I have not introduced new dependencies in the inference portion of the pipeline

### Documentation

-   [x] My code follows the style guidelines of this project
-   [x] I have updated the documentation and docstrings to reflect the changes
-   [x] I have added comments to my code, particularly in hard-to-understand areas

## Additional Notes

Note that it is also now posible to omit `plot_maps` and `plot_histograms`. 
With the older code version, an error was raised due to these lines: [here](https://github.com/ecmwf/WeatherGenerator/blob/d19f08bdd6ef995451fd659777a9c0e6d59962f1/packages/evaluate/src/weathergen/evaluate/utils.py#L282) and [here](https://github.com/ecmwf/WeatherGenerator/blob/d19f08bdd6ef995451fd659777a9c0e6d59962f1/packages/evaluate/src/weathergen/evaluate/utils.py#L288).