### PR TITLE
Iluise/develop/plotting issues

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/plot_inference.py
+++ b/packages/evaluate/src/weathergen/evaluate/plot_inference.py
@@ -113,6 +113,6 @@ if __name__ == "__main__":
 
 
 # plot summary
-if cfg.summary_plots:
+if scores_dict and cfg.summary_plots:
     _logger.info("Started creating summary plots..")
     plot_summary(cfg, scores_dict, print_summary=cfg.print_summary)

--- a/packages/evaluate/src/weathergen/evaluate/plot_inference.py
+++ b/packages/evaluate/src/weathergen/evaluate/plot_inference.py
@@ -59,7 +59,6 @@ if __name__ == "__main__":
     scores_dict = defaultdict(lambda: defaultdict(dict))
 
     for run_id, run in runs.items():
-
         plotter = Plotter(cfg, run_id)
         _logger.info(f"RUN {run_id}: Getting data...")
 
@@ -69,7 +68,7 @@ if __name__ == "__main__":
             _logger.info(f"RUN {run_id}: Processing stream {stream}...")
 
             stream_dict = run["streams"][stream]
-           
+
             if stream_dict.get("plotting"):
                 _logger.info(f"RUN {run_id}: Plotting stream {stream}...")
                 plots = plot_data(cfg, run_id, stream, stream_dict)

--- a/packages/evaluate/src/weathergen/evaluate/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotter.py
@@ -236,10 +236,10 @@ class LinePlots:
             "line_plots"
         )
         if not os.path.exists(self.out_plot_dir):
-            _logger.info(f"creating dir {self.out_plot_dir}")
+            _logger.info(f"Creating dir {self.out_plot_dir}")
             os.makedirs(self.out_plot_dir, exist_ok=True)
 
-        _logger.info(f"saving summary plots to: {self.out_plot_dir}")
+        _logger.info(f"Saving summary plots to: {self.out_plot_dir}")
 
     def _check_lengths(
         self, data: xr.DataArray | list, labels: str | list

--- a/packages/evaluate/src/weathergen/evaluate/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotter.py
@@ -199,7 +199,7 @@ class Plotter:
                 scatter_plt, ax=ax, orientation="horizontal", label=f"Variable: {var}"
             )
             plt.title(
-                f"{self.stream}, {var} : fstep = {self.fstep:03} ({da['valid_time'][0].values})"
+                f"{self.stream}, {var} : fstep = {self.fstep:03} ({da['valid_time'][0].values.astype('datetime64[s]')})"
             )
             ax.set_global()
             ax.gridlines(draw_labels=False, linestyle="--", color="black", linewidth=1)
@@ -238,6 +238,8 @@ class LinePlots:
         if not os.path.exists(self.out_plot_dir):
             _logger.info(f"creating dir {self.out_plot_dir}")
             os.makedirs(self.out_plot_dir, exist_ok=True)
+        
+        _logger.info(f"saving summary plots to: {self.out_plot_dir}")
 
     def _check_lengths(
         self, data: xr.DataArray | list, labels: str | list

--- a/packages/evaluate/src/weathergen/evaluate/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotter.py
@@ -238,7 +238,7 @@ class LinePlots:
         if not os.path.exists(self.out_plot_dir):
             _logger.info(f"creating dir {self.out_plot_dir}")
             os.makedirs(self.out_plot_dir, exist_ok=True)
-        
+
         _logger.info(f"saving summary plots to: {self.out_plot_dir}")
 
     def _check_lengths(

--- a/packages/evaluate/src/weathergen/evaluate/utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils.py
@@ -120,9 +120,10 @@ def get_data(
                 )
                 available_channels = da_tars_fs.channel.values
                 existing_channels = [ch for ch in channels if ch in available_channels]
-                _logger.warning(
-                    f"The following channels were not found: {list(set(channels) - set(existing_channels))}. Skipping them."
-                )
+                if len(existing_channels) < len(channels):
+                    _logger.warning(
+                        f"The following channels were not found: {list(set(channels) - set(existing_channels))}. Skipping them."
+                    )
 
                 da_tars_fs = da_tars_fs.sel(channel=existing_channels)
                 da_preds_fs = da_preds_fs.sel(channel=existing_channels)

--- a/packages/evaluate/src/weathergen/evaluate/utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils.py
@@ -120,7 +120,9 @@ def get_data(
                 )
                 available_channels = da_tars_fs.channel.values
                 existing_channels = [ch for ch in channels if ch in available_channels]
-                _logger.warning(f"The following channels were not found: {list(set(channels) - set(existing_channels))}. Skipping them.")
+                _logger.warning(
+                    f"The following channels were not found: {list(set(channels) - set(existing_channels))}. Skipping them."
+                )
 
                 da_tars_fs = da_tars_fs.sel(channel=existing_channels)
                 da_preds_fs = da_preds_fs.sel(channel=existing_channels)
@@ -429,7 +431,8 @@ def plot_summary(cfg: dict, scores_dict: dict, print_summary: bool):
                 value
                 for run_id in runs
                 for stream in scores_dict.get(metric).keys()
-                if run_id in scores_dict.get(metric, {}).get(stream, {}) #check if run_id exists
+                if run_id
+                in scores_dict.get(metric, {}).get(stream, {})  # check if run_id exists
                 for value in np.atleast_1d(
                     scores_dict[metric][stream][run_id]["channel"].values
                 )

--- a/packages/evaluate/src/weathergen/evaluate/utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils.py
@@ -118,8 +118,12 @@ def get_data(
                 _logger.debug(
                     f"Restricting targets and predictions to channels {channels} for stream {stream}..."
                 )
-                da_tars_fs = da_tars_fs.sel(channel=channels)
-                da_preds_fs = da_preds_fs.sel(channel=channels)
+                available_channels = da_tars_fs.channel.values
+                existing_channels = [ch for ch in channels if ch in available_channels]
+                _logger.warning(f"The following channels were not found: {list(set(channels) - set(existing_channels))}. Skipping them.")
+
+                da_tars_fs = da_tars_fs.sel(channel=existing_channels)
+                da_preds_fs = da_preds_fs.sel(channel=existing_channels)
 
             da_tars.append(da_tars_fs)
             da_preds.append(da_preds_fs)
@@ -424,7 +428,8 @@ def plot_summary(cfg: dict, scores_dict: dict, print_summary: bool):
             set(
                 value
                 for run_id in runs
-                for stream in runs[run_id]["streams"]
+                for stream in scores_dict.get(metric).keys()
+                if run_id in scores_dict.get(metric, {}).get(stream, {}) #check if run_id exists
                 for value in np.atleast_1d(
                     scores_dict[metric][stream][run_id]["channel"].values
                 )


### PR DESCRIPTION
## Description

Quick fixes to 

1) avoid a crash when one channel is not in the list
2) avoid a crash when one run is plotting only
3) clearly state the location where the summary plots are saved

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

closes https://github.com/ecmwf/WeatherGenerator/issues/624
closes https://github.com/ecmwf/WeatherGenerator/issues/617

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [x] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [x] I have not introduced new dependencies in the inference portion of the pipeline

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->