### PR TITLE
replace hard-coded dropout_rate in EmbeddingEngine with config value

### DIFF
--- a/src/weathergen/model/embeddings.py
+++ b/src/weathergen/model/embeddings.py
@@ -30,6 +30,7 @@ class StreamEmbedTransformer(torch.nn.Module):
         dim_out,
         num_blocks,
         num_heads,
+        dropout_rate=0.0,
         norm_type="LayerNorm",
         embed_size_centroids=64,
         unembed_mode="full",
@@ -64,7 +65,7 @@ class StreamEmbedTransformer(torch.nn.Module):
                 MultiSelfAttentionHead(
                     self.dim_embed,
                     self.num_heads,
-                    dropout_rate=0.1,
+                    dropout_rate=dropout_rate,
                     with_qk_lnorm=True,
                     with_flash=True,
                 )
@@ -74,7 +75,7 @@ class StreamEmbedTransformer(torch.nn.Module):
                     self.dim_embed,
                     self.dim_embed,
                     hidden_factor=2,
-                    dropout_rate=0.1,
+                    dropout_rate=dropout_rate,
                     with_residual=True,
                 )
             )

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -58,6 +58,7 @@ class EmbeddingEngine:
                         dim_out=self.cf.ae_local_dim_embed,
                         num_blocks=si["embed"]["num_blocks"],
                         num_heads=si["embed"]["num_heads"],
+                        dropout_rate=self.cf.embed_dropout_rate,
                         norm_type=self.cf.norm_type,
                         embed_size_centroids=self.cf.embed_size_centroids,
                         unembed_mode=self.cf.embed_unembed_mode,


### PR DESCRIPTION
## Description

replace two hard-coded values in the StreamEmbedTransformer with the corresponding parameter in the config.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Closes #643 <!-- Link the Issue number this change addresses, ideally in one of the "magic format" such as Closes #XYZ -->

<!-- Alternatively, explain the motivation behind the changes and the context in which they are being made. -->

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [x] I have not introduced new dependencies in the inference portion of the pipeline

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [x] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->