### PR TITLE
Make compare_run_config.py usable again

### DIFF
--- a/src/weathergen/utils/compare_run_configs.py
+++ b/src/weathergen/utils/compare_run_configs.py
@@ -11,8 +11,8 @@ import argparse
 import logging
 from pathlib import Path
 
-from pprint import pprint
 from dictdiffer import diff
+
 from config import load_model_config
 
 logging.basicConfig(level=logging.INFO)
@@ -23,18 +23,26 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-r1", "--run_id_1", required=True)
     parser.add_argument("-r2", "--run_id_2", required=True)
-    parser.add_argument("-m1", "--model_directory_1", type=Path, default=None, 
-                        help="Path to model directory for -r1/--run_id_1")
-    parser.add_argument("-m2", "--model_directory_2", type=Path, default=None, 
-                        help="Path to model directory for -r2/--run_id_2")
+    parser.add_argument(
+        "-m1",
+        "--model_directory_1",
+        type=Path,
+        default=None,
+        help="Path to model directory for -r1/--run_id_1",
+    )
+    parser.add_argument(
+        "-m2",
+        "--model_directory_2",
+        type=Path,
+        default=None,
+        help="Path to model directory for -r2/--run_id_2",
+    )
     args = parser.parse_args()
 
     cf1 = load_model_config(args.run_id_1, None, args.model_directory_1)
     cf2 = load_model_config(args.run_id_2, None, args.model_directory_2)
-    
+
     result = list(diff(cf1.__dict__, cf2.__dict__))
 
-
     for tag, path, details in result:
-        _logger.info((f"{tag.upper()} at {path}: {details}"))
-
+        _logger.info(f"{tag.upper()} at {path}: {details}")

--- a/src/weathergen/utils/compare_run_configs.py
+++ b/src/weathergen/utils/compare_run_configs.py
@@ -9,10 +9,13 @@
 
 import argparse
 import logging
+from pathlib import Path
 
-import dictdiffer
-from obslearn.utils.config import Config
+from pprint import pprint
+from dictdiffer import diff
+from config import load_model_config
 
+logging.basicConfig(level=logging.INFO)
 _logger = logging.getLogger(__name__)
 
 
@@ -20,19 +23,18 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-r1", "--run_id_1", required=True)
     parser.add_argument("-r2", "--run_id_2", required=True)
+    parser.add_argument("-m1", "--model_directory_1", type=Path, default=None, 
+                        help="Path to model directory for -r1/--run_id_1")
+    parser.add_argument("-m2", "--model_directory_2", type=Path, default=None, 
+                        help="Path to model directory for -r2/--run_id_2")
     args = parser.parse_args()
 
-    cf1 = Config.load(args.run_id_1)
-    cf2 = Config.load(args.run_id_2)
-    # print(cf1.__dict__)
-    result = dictdiffer.diff(cf1.__dict__, cf2.__dict__)
-    for item in list(result):
-        # TODO: if streams_directory differs than we need to manually compare streams using name
-        # since index-based comparison by dictdiffer is meaningless
+    cf1 = load_model_config(args.run_id_1, None, args.model_directory_1)
+    cf2 = load_model_config(args.run_id_2, None, args.model_directory_2)
+    
+    result = list(diff(cf1.__dict__, cf2.__dict__))
 
-        # # for streams, translate index in list of streams to stream name
-        # if item[1][0] == 'streams' :
-        #   name = cf1.streams[item[1][1]]['name']
-        #   item[1][1] = name
 
-        _logger.info(f"Difference {item[1]} :: {item[2]}")
+    for tag, path, details in result:
+        _logger.info((f"{tag.upper()} at {path}: {details}"))
+


### PR DESCRIPTION
## Description

compare_run_config.py has been updated to make use of the helper function `load_model_config` from `config.py`.
Furthermore, the option to handle runs from different models directory location has been added.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Closes #660 

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [x] I have not introduced new dependencies in the inference portion of the pipeline

### Documentation

-   [x] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [x] I have added comments to my code, particularly in hard-to-understand areas