### PR TITLE
Make uv aware of changes in the evaluate-package code base

### DIFF
--- a/packages/evaluate/pyproject.toml
+++ b/packages/evaluate/pyproject.toml
@@ -21,6 +21,11 @@ dev = [
  "ruff==0.9.7",
 ]
 
+[tool.uv.cache-keys]
+files = [
+  "pyproject.toml",
+  "src/weathergen/evaluate",
+]
 
 
 [tool.ruff.lint]


### PR DESCRIPTION
## Description

This PR changes the `pyproject.toml`-file of the `evaluate`-package to ensure that changes to the packages's code base can be integrated (see issue description in #680).
With the revised `pyproject.toml`, changes become effective by adding the `--reinstall`-flag:
```
uv run --reinstall -- plot_inference.py <my_config_file>
```
This ensures that uv's caching procedures are circumvented.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Close #680

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

### Dependencies

-   [x] I have ensured that the code is still pip-installable after the changes and runs
-   [x] I have tested that new dependencies themselves are pip-installable.
-   [ ] I have not introduced new dependencies in the inference portion of the pipeline

### Documentation

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas