### PR TITLE
Set default value for config file

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
@@ -33,13 +33,20 @@ def evaluate() -> None:
     parser.add_argument(
         "--config",
         type=str,
-        help="Path to the configuration yaml file for plotting. e.g. config/plottig_config.yaml",
+        help="Path to the configuration yaml file for plotting. e.g. config/eval_config.yml",
+        default="config/eval_config.yml"
     )
 
     args = parser.parse_args()
 
     # configure logging
     logging.basicConfig(level=logging.INFO)
+
+    assert Path(args.config).exists(), (
+        "The evaluation configuration file does not exist. Its "
+        "default location would be 'config/eval_config.yml'. Either create it and restart "
+        "evaluation, or pass the config file with the --config argument."
+    )
 
     # load configuration
     cfg = OmegaConf.load(args.config)

--- a/uv.lock
+++ b/uv.lock
@@ -2345,6 +2345,7 @@ dependencies = [
     { name = "torch", version = "2.6.0+cu124", source = { registry = "https://download.pytorch.org/whl/cu124" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "tqdm" },
     { name = "weathergen-common" },
+    { name = "weathergen-evaluate" },
     { name = "wheel" },
     { name = "zarr" },
 ]
@@ -2380,6 +2381,7 @@ requires-dist = [
     { name = "torch", marker = "sys_platform == 'macosx'", specifier = "==2.6.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "tqdm" },
     { name = "weathergen-common", editable = "packages/common" },
+    { name = "weathergen-evaluate", editable = "packages/evaluate" },
     { name = "wheel" },
     { name = "zarr", specifier = "~=2.17" },
 ]


### PR DESCRIPTION
## Description

Added a default value to the `run_evaluate.py` to deliver `eval_config.yml` if no `--config` argument is passed.

## Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [-] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

resolves #693 

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I ran `uv run evaluate` and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

