### PR TITLE
Fixed convergence of training

### DIFF
--- a/src/weathergen/model/attention.py
+++ b/src/weathergen/model/attention.py
@@ -16,9 +16,7 @@ from torch.nn.attention.flex_attention import create_block_mask, flex_attention
 from weathergen.model.norms import AdaLayerNorm, RMSNorm
 
 
-####################################################################################################
 class MultiSelfAttentionHeadVarlen(torch.nn.Module):
-    #########################################
     def __init__(
         self,
         dim_embed,
@@ -39,8 +37,8 @@ class MultiSelfAttentionHeadVarlen(torch.nn.Module):
         self.num_heads = num_heads
         self.dropout_rate = dropout_rate
         self.with_flash = with_flash
-        self.with_residual = with_residual
         self.softcap = softcap
+        self.with_residual = with_residual
 
         assert dim_embed % num_heads == 0
         self.dim_head_proj = dim_embed // num_heads if dim_head_proj is None else dim_head_proj
@@ -52,6 +50,8 @@ class MultiSelfAttentionHeadVarlen(torch.nn.Module):
 
         if dim_aux is not None:
             self.lnorm = AdaLayerNorm(dim_embed, dim_aux, norm_eps=norm_eps)
+        else:
+            self.lnorm = norm(dim_embed, eps=norm_eps)
         self.proj_heads_q = torch.nn.Linear(dim_embed, num_heads * self.dim_head_proj, bias=False)
         self.proj_heads_k = torch.nn.Linear(dim_embed, num_heads * self.dim_head_proj, bias=False)
         self.proj_heads_v = torch.nn.Linear(dim_embed, num_heads * self.dim_head_proj, bias=False)
@@ -68,13 +68,13 @@ class MultiSelfAttentionHeadVarlen(torch.nn.Module):
 
         assert with_flash, "Only flash attention supported at the moment"
 
-    #########################################
     def forward(self, x, x_lens, ada_ln_aux=None):
-        x_in = x
-        x = x if ada_ln_aux is None else self.lnorm(x, ada_ln_aux)
+        if self.with_residual:
+            x_in = x
+        x = self.lnorm(x) if ada_ln_aux is None else self.lnorm(x, ada_ln_aux)
 
-        ## project onto heads and q,k,v and
-        #  ensure these are 4D tensors as required for flash attention
+        # project onto heads and q,k,v and
+        # ensure these are 4D tensors as required for flash attention
         s = [x.shape[0], self.num_heads, -1]
         qs = self.lnorm_q(self.proj_heads_q(x).reshape(s)).to(self.dtype)
         ks = self.lnorm_k(self.proj_heads_k(x).reshape(s)).to(self.dtype)
@@ -94,17 +94,14 @@ class MultiSelfAttentionHeadVarlen(torch.nn.Module):
             dropout_p=self.dropout_rate,
         )
 
-        x = self.proj_out(outs.flatten(-2, -1))
-
+        out = self.proj_out(outs.flatten(-2, -1))
         if self.with_residual:
-            x = x_in + x
+            out = out + x_in
 
-        return x
+        return out
 
 
-####################################################################################################
 class MultiSelfAttentionHeadVarlenFlex(torch.nn.Module):
-    #########################################
     def __init__(
         self,
         dim_embed,
@@ -124,6 +121,7 @@ class MultiSelfAttentionHeadVarlenFlex(torch.nn.Module):
         self.num_heads = num_heads
         self.with_flash = with_flash
         self.softcap = softcap
+        self.with_residual = with_residual
 
         assert dim_embed % num_heads == 0
         self.dim_head_proj = dim_embed // num_heads if dim_head_proj is None else dim_head_proj
@@ -158,9 +156,9 @@ class MultiSelfAttentionHeadVarlenFlex(torch.nn.Module):
 
         self.compiled_flex_attention = torch.compile(att, dynamic=False)
 
-    #########################################
     def forward(self, x, x_lens=None):
-        x_in = x
+        if self.with_residual:
+            x_in = x
         x = self.lnorm(x)
 
         ## project onto heads and q,k,v and
@@ -172,16 +170,14 @@ class MultiSelfAttentionHeadVarlenFlex(torch.nn.Module):
 
         outs = self.compiled_flex_attention(qs, ks, vs).transpose(1, 2).squeeze()
 
-        x = self.proj_out(outs.flatten(-2, -1))
+        out = self.dropout(self.proj_out(outs.flatten(-2, -1)))
         if self.with_residual:
-            x = x_in + x
+            out = out + x_in
 
-        return x
+        return out
 
 
-####################################################################################################
 class MultiSelfAttentionHeadLocal(torch.nn.Module):
-    #########################################
     def __init__(
         self,
         dim_embed,
@@ -190,6 +186,7 @@ class MultiSelfAttentionHeadLocal(torch.nn.Module):
         block_factor,
         dim_head_proj=None,
         dropout_rate=0.0,
+        with_residual=True,
         with_qk_lnorm=True,
         with_flash=True,
         norm_type="LayerNorm",
@@ -203,6 +200,7 @@ class MultiSelfAttentionHeadLocal(torch.nn.Module):
         self.num_heads = num_heads
         self.with_flash = with_flash
         self.softcap = softcap
+        self.with_residual = with_residual
 
         assert dim_embed % num_heads == 0
         self.dim_head_proj = dim_embed // num_heads if dim_head_proj is None else dim_head_proj
@@ -241,9 +239,9 @@ class MultiSelfAttentionHeadLocal(torch.nn.Module):
         # compile for efficiency
         self.flex_attention = torch.compile(flex_attention, dynamic=False)
 
-    #########################################
     def forward(self, x, ada_ln_aux=None):
-        x_in = x
+        if self.with_residual:
+            x_in = x
         x = self.lnorm(x) if ada_ln_aux is None else self.lnorm(x, ada_ln_aux)
 
         # project onto heads
@@ -254,12 +252,14 @@ class MultiSelfAttentionHeadLocal(torch.nn.Module):
 
         outs = self.flex_attention(qs, ks, vs, block_mask=self.block_mask).transpose(1, 2)
 
-        return x_in + self.proj_out(self.dropout(outs.flatten(-2, -1)))
+        out = self.proj_out(self.dropout(outs.flatten(-2, -1)))
+        if self.with_residual:
+            out = x_in + out
+
+        return out
 
 
-####################################################################################################
 class MultiCrossAttentionHeadVarlen(torch.nn.Module):
-    #########################################
     def __init__(
         self,
         dim_embed_q,
@@ -293,6 +293,9 @@ class MultiCrossAttentionHeadVarlen(torch.nn.Module):
 
         if dim_aux is not None:
             self.lnorm_in_q = AdaLayerNorm(dim_embed_q, dim_aux, norm_eps=norm_eps)
+        else:
+            self.lnorm_in_q = norm(dim_embed_q, eps=norm_eps)
+        self.lnorm_in_kv = norm(dim_embed_kv, eps=norm_eps)
 
         self.proj_heads_q = torch.nn.Linear(dim_embed_q, num_heads * self.dim_head_proj, bias=False)
         self.proj_heads_k = torch.nn.Linear(
@@ -310,17 +313,15 @@ class MultiCrossAttentionHeadVarlen(torch.nn.Module):
         lnorm = norm if with_qk_lnorm else torch.nn.Identity
         self.lnorm_q = lnorm(self.dim_head_proj, eps=norm_eps)
         self.lnorm_k = lnorm(self.dim_head_proj, eps=norm_eps)
-        self.lnorm_kv = lnorm(dim_embed_kv, eps=norm_eps)
 
         self.dtype = attention_dtype
         assert with_flash, "Only flash attention supported at the moment"
 
-    #########################################
-    def forward(self, x_q, x_kv, x_lens=None, x_kv_lens=None, ada_ln_aux=None):
+    def forward(self, x_q, x_kv, x_q_lens=None, x_kv_lens=None, ada_ln_aux=None):
         if self.with_residual:
             x_q_in = x_q
-        x_q = x_q if ada_ln_aux is None else self.lnorm_in_q(x_q, ada_ln_aux)
-        x_kv = self.lnorm_kv(x_kv)
+        x_q = self.lnorm_in_q(x_q) if ada_ln_aux is None else self.lnorm_in_q(x_q, ada_ln_aux)
+        x_kv = self.lnorm_in_kv(x_kv)
 
         ## project onto heads and q,k,v and
         #  ensure these are 4D tensors as required for flash attention
@@ -331,7 +332,7 @@ class MultiCrossAttentionHeadVarlen(torch.nn.Module):
         vs = self.proj_heads_v(x_kv).reshape(s)
 
         if x_kv_lens is not None:
-            cum_x_q_lens = torch.cumsum(x_lens, 0, dtype=torch.int32)
+            cum_x_q_lens = torch.cumsum(x_q_lens, 0, dtype=torch.int32)
             cum_x_kv_lens = torch.cumsum(x_kv_lens, 0, dtype=torch.int32)
             outs = flash_attn_varlen_func(
                 qs,
@@ -339,7 +340,7 @@ class MultiCrossAttentionHeadVarlen(torch.nn.Module):
                 vs,
                 cum_x_q_lens,
                 cum_x_kv_lens,
-                x_lens.max(),
+                x_q_lens.max(),
                 x_kv_lens.max(),
                 softcap=self.softcap,
                 dropout_p=self.dropout_rate,
@@ -354,19 +355,8 @@ class MultiCrossAttentionHeadVarlen(torch.nn.Module):
 
         return outs
 
-    #########################################
-    def attention(self, q, k, v):
-        scaling = 1.0 / torch.sqrt(torch.tensor(q.shape[-1]))
-        return torch.matmul(self.softmax(scaling * self.score(q, k)), v)
 
-    #########################################
-    def score(self, q, k):
-        return torch.matmul(q, torch.transpose(k, -2, -1))
-
-
-####################################################################################################
 class MultiCrossAttentionHeadVarlenSlicedQ(torch.nn.Module):
-    #########################################
     def __init__(
         self,
         dim_embed_q,
@@ -432,7 +422,6 @@ class MultiCrossAttentionHeadVarlenSlicedQ(torch.nn.Module):
         self.dtype = attention_dtype
         assert with_flash, "Only flash attention supported at the moment"
 
-    #########################################
     def forward(self, x_q, x_kv, x_q_lens=None, x_kv_lens=None, ada_ln_aux=None):
         if self.with_residual:
             x_q_in = x_q
@@ -461,13 +450,14 @@ class MultiCrossAttentionHeadVarlenSlicedQ(torch.nn.Module):
                     vs,
                     cum_x_q_lens,
                     cum_x_kv_lens,
-                    x_q_lens.max().item(),
-                    x_kv_lens.max().item(),
+                    x_q_lens.max(),
+                    x_kv_lens.max(),
                     softcap=self.softcap,
                     dropout_p=self.dropout_rate,
                 )
             ]
 
+        # outs = self.dropout( self.proj_out( torch.stack(outs).transpose(1,0).flatten( -2, -1)) )
         outs = self.proj_out(torch.stack(outs).transpose(1, 0).flatten(-2, -1))
         if self.with_residual:
             outs = x_q_in + outs.reshape(x_q_in.shape)
@@ -475,19 +465,16 @@ class MultiCrossAttentionHeadVarlenSlicedQ(torch.nn.Module):
         return outs
 
 
-####################################################################################################
 class MultiSelfAttentionHead(torch.nn.Module):
-    #########################################
     def __init__(
         self,
         dim_embed,
         num_heads,
         dim_head_proj=None,
         dropout_rate=0.0,
-        with_qk_lnorm=True,
         with_residual=True,
+        with_qk_lnorm=True,
         with_flash=True,
-        softcap=0.0,
         norm_type="LayerNorm",
         dim_aux=None,
         norm_eps=1e-5,
@@ -499,9 +486,7 @@ class MultiSelfAttentionHead(torch.nn.Module):
         self.with_flash = with_flash
         self.dropout_rate = dropout_rate
         self.with_residual = with_residual
-        self.softcap = softcap
 
-        assert with_flash, "You have to use flash attention"
         assert dim_embed % num_heads == 0
         self.dim_head_proj = dim_embed // num_heads if dim_head_proj is None else dim_head_proj
 
@@ -513,137 +498,50 @@ class MultiSelfAttentionHead(torch.nn.Module):
         if dim_aux is not None:
             self.lnorm = AdaLayerNorm(dim_embed, dim_aux, norm_eps=norm_eps)
         else:
-            self.lnorm = norm(dim_embed)
+            self.lnorm = norm(dim_embed, eps=norm_eps)
         self.proj_heads_q = torch.nn.Linear(dim_embed, num_heads * self.dim_head_proj, bias=False)
         self.proj_heads_k = torch.nn.Linear(dim_embed, num_heads * self.dim_head_proj, bias=False)
         self.proj_heads_v = torch.nn.Linear(dim_embed, num_heads * self.dim_head_proj, bias=False)
         self.proj_out = torch.nn.Linear(dim_embed, dim_embed, bias=False)
+        self.dropout = (
+            torch.nn.Dropout(p=dropout_rate) if dropout_rate > 0.0 else torch.nn.Identity()
+        )
 
         lnorm = norm if with_qk_lnorm else torch.nn.Identity
-        self.lnorm_q = lnorm(self.dim_head_proj)
-        self.lnorm_k = lnorm(self.dim_head_proj)
+        self.lnorm_q = lnorm(self.dim_head_proj, eps=norm_eps)
+        self.lnorm_k = lnorm(self.dim_head_proj, eps=norm_eps)
 
         self.dtype = attention_dtype
+        if with_flash:
+            self.att = torch.nn.functional.scaled_dot_product_attention
+        else:
+            self.att = self.attention
+            self.softmax = torch.nn.Softmax(dim=-1)
 
-    #########################################
     def forward(self, x, ada_ln_aux=None):
-        x_in = x
-        # x = self.lnorm(x) if ada_ln_aux is None else self.lnorm(x, ada_ln_aux)
+        if self.with_residual:
+            x_in = x
+        x = self.lnorm(x) if ada_ln_aux is None else self.lnorm(x, ada_ln_aux)
 
         ## project onto heads and q,k,v and
         #  ensure these are 4D tensors as required for flash attention
-        q_shape = [*([x.shape[0], 1] if len(x.shape) == 2 else x.shape[:-1]), self.num_heads, -1]
-        kv_shape = [
-            *([x.shape[0], 1] if len(x.shape) == 2 else x.shape[:-1]),
-            self.num_heads,
-            -1,
-        ]
-        qs = self.lnorm_q(self.proj_heads_q(x).reshape(q_shape)).to(self.dtype)
-        ks = self.lnorm_k(self.proj_heads_k(x).reshape(kv_shape)).to(self.dtype)
-        vs = self.proj_heads_v(x).reshape(kv_shape).to(self.dtype)
+        s = [*([x.shape[0], 1] if len(x.shape) == 2 else x.shape[:-1]), self.num_heads, -1]
+        qs = self.lnorm_q(self.proj_heads_q(x).reshape(s)).to(self.dtype)
+        ks = self.lnorm_k(self.proj_heads_k(x).reshape(s)).to(self.dtype)
+        vs = self.proj_heads_v(x).reshape(s).to(self.dtype)
 
         # ordering of tensors (seq, heads, embed) (which differs from torch's flash attention implt)
-        outs = flash_attn_func(qs, ks, vs, softcap=self.softcap, dropout_p=self.dropout_rate)
+        outs = flash_attn_func(qs, ks, vs, dropout_p=self.dropout_rate)
 
+        # return x_in + self.dropout( self.proj_out( outs.flatten( -2, -1)) )
+        out = self.proj_out(outs.flatten(-2, -1))
         if self.with_residual:
-            x = x_in + self.proj_out(outs.flatten(-2, -1))
-        else:
-            x = self.proj_out(outs.flatten(-2, -1))
+            out = out + x_in
 
-        return x
+        return out
 
 
-####################################################################################################
 class MultiCrossAttentionHead(torch.nn.Module):
-    #########################################
-    def __init__(
-        self,
-        dim_embed_q,
-        dim_embed_kv,
-        num_heads,
-        dim_head_proj=None,
-        dropout_rate=0.0,
-        with_qk_lnorm=True,
-        with_residual=True,
-        with_flash=True,
-        softcap=0.0,
-        norm_type="LayerNorm",
-        dim_aux=None,
-        norm_eps=1e-5,
-        attention_dtype=torch.bfloat16,
-    ):
-        super(MultiCrossAttentionHead, self).__init__()
-
-        self.num_heads = num_heads
-        self.with_flash = with_flash
-        self.dropout_rate = dropout_rate
-        self.with_residual = with_residual
-        self.softcap = softcap
-
-        assert with_flash, "You have to use flash attention"
-        assert dim_embed_kv % num_heads == 0
-        self.dim_head_proj_kv = (
-            dim_embed_kv // num_heads if dim_head_proj is None else dim_head_proj
-        )
-        self.dim_head_proj_q = dim_embed_q // num_heads if dim_head_proj is None else dim_head_proj
-
-        if norm_type == "LayerNorm":
-            norm = partial(torch.nn.LayerNorm, elementwise_affine=False, eps=norm_eps)
-        else:
-            norm = RMSNorm
-
-        if dim_aux is not None:
-            self.lnorm = AdaLayerNorm(dim_embed_kv, dim_aux, norm_eps=norm_eps)
-        else:
-            self.lnorm = norm(dim_embed_kv)
-        self.proj_heads_q = torch.nn.Linear(
-            dim_embed_q, num_heads * self.dim_head_proj_q, bias=False
-        )
-        self.proj_heads_k = torch.nn.Linear(
-            dim_embed_kv, num_heads * self.dim_head_proj_kv, bias=False
-        )
-        self.proj_heads_v = torch.nn.Linear(
-            dim_embed_kv, num_heads * self.dim_head_proj_kv, bias=False
-        )
-        self.proj_out = torch.nn.Linear(dim_embed_kv, dim_embed_kv, bias=False)
-
-        lnorm = norm if with_qk_lnorm else torch.nn.Identity
-        self.lnorm_q = lnorm(self.dim_head_proj_q)
-        self.lnorm_k = lnorm(self.dim_head_proj_kv)
-
-        self.dtype = attention_dtype
-
-    #########################################
-    def forward(self, q, x, ada_ln_aux=None):
-        x_in = x
-        # x = self.lnorm(x) if ada_ln_aux is None else self.lnorm(x, ada_ln_aux)
-
-        ## project onto heads and q,k,v and
-        #  ensure these are 4D tensors as required for flash attention
-        q_shape = [*([x.shape[0], 1] if len(x.shape) == 2 else x.shape[:-1]), self.num_heads, -1]
-        kv_shape = [
-            *([x.shape[0], 1] if len(x.shape) == 2 else x.shape[:-1]),
-            self.num_heads,
-            -1,
-        ]
-        qs = self.lnorm_q(self.proj_heads_q(x).reshape(q_shape)).to(self.dtype)
-        ks = self.lnorm_k(self.proj_heads_k(x).reshape(kv_shape)).to(self.dtype)
-        vs = self.proj_heads_v(x).reshape(kv_shape).to(self.dtype)
-
-        # ordering of tensors (seq, heads, embed) (which differs from torch's flash attention implt)
-        outs = flash_attn_func(qs, ks, vs, softcap=self.softcap, dropout_p=self.dropout_rate)
-
-        if self.with_residual:
-            x = x_in + self.proj_out(outs.flatten(-2, -1))
-        else:
-            x = self.proj_out(outs.flatten(-2, -1))
-
-        return x
-
-
-####################################################################################################
-class MultiCrossAttentionHeadSPDA(torch.nn.Module):
-    #########################################
     def __init__(
         self,
         dim_embed_q,
@@ -702,8 +600,8 @@ class MultiCrossAttentionHeadSPDA(torch.nn.Module):
             x_q_in = x_q
         x_q, x_kv = self.lnorm_in_q(x_q), self.lnorm_in_kv(x_kv)
 
-        ## project onto heads and q,k,v and
-        #  ensure these are 4D tensors as required for flash attention
+        # project onto heads and q,k,v and
+        # ensure these are 4D tensors as required for flash attention
         s = [x_q.shape[0], -1, self.num_heads, self.dim_head_proj]
         qs = self.lnorm_q(self.proj_heads_q(x_q).reshape(s)).to(self.dtype).transpose(-3, -2)
         s = [x_kv.shape[0], -1, self.num_heads, self.dim_head_proj]
@@ -719,12 +617,3 @@ class MultiCrossAttentionHeadSPDA(torch.nn.Module):
             outs = x_q_in + outs
 
         return outs
-
-    #########################################
-    def attention(self, q, k, v):
-        scaling = 1.0 / torch.sqrt(torch.tensor(q.shape[-1]))
-        return torch.matmul(self.softmax(scaling * self.score(q, k)), v)
-
-    #########################################
-    def score(self, q, k):
-        return torch.matmul(q, torch.transpose(k, -2, -1))

--- a/src/weathergen/model/blocks.py
+++ b/src/weathergen/model/blocks.py
@@ -16,6 +16,7 @@ from weathergen.model.attention import (
 )
 from weathergen.model.layers import MLP
 from weathergen.model.norms import AdaLayerNormLayer
+from weathergen.utils.config import get_dtype
 
 
 class SelfAttentionBlock(nn.Module):
@@ -199,22 +200,40 @@ class OriginalPredictionBlock(nn.Module):
         self.tr_mlp_hidden_factor = tr_mlp_hidden_factor
 
         self.block = nn.ModuleList()
+
         # Multi-Cross Attention Head
         self.block.append(
             MultiCrossAttentionHeadVarlen(
                 dim_in,
-                dim_kv,
-                num_heads,
+                self.cf.ae_global_dim_embed,
+                self.cf.streams[0]["target_readout"]["num_heads"],
                 dim_head_proj=self.tr_dim_head_proj,
                 with_residual=True,
-                **attention_kwargs,
+                with_qk_lnorm=True,
+                dropout_rate=0.1,  # Assuming dropout_rate is 0.1
+                with_flash=self.cf.with_flash_attention,
+                norm_type=attention_kwargs["norm_type"],
+                softcap=0.0,
+                dim_aux=dim_aux,
+                norm_eps=attention_kwargs["norm_eps"],
+                attention_dtype=get_dtype(self.cf.attention_dtype),
             )
         )
 
         # Optional Self-Attention Head
         if self.cf.pred_self_attention:
             self.block.append(
-                MultiSelfAttentionHeadVarlen(dim_in, num_heads=num_heads, **attention_kwargs)
+                MultiSelfAttentionHeadVarlen(
+                    dim_in,
+                    num_heads=self.cf.streams[0]["target_readout"]["num_heads"],
+                    dropout_rate=0.1,  # Assuming dropout_rate is 0.1
+                    with_qk_lnorm=True,
+                    with_flash=self.cf.with_flash_attention,
+                    norm_type=self.cf.norm_type,
+                    dim_aux=dim_aux,
+                    norm_eps=self.cf.norm_eps,
+                    attention_dtype=get_dtype(self.cf.attention_dtype),
+                )
             )
 
         # MLP Block
@@ -222,12 +241,12 @@ class OriginalPredictionBlock(nn.Module):
             MLP(
                 dim_in,
                 dim_out,
-                with_residual=(self.cf.pred_dyadic_dims or self.tro_type == "obs_value"),
+                with_residual=True,
                 hidden_factor=self.tr_mlp_hidden_factor,
                 dropout_rate=0.1,  # Assuming dropout_rate is 0.1
-                norm_type=attention_kwargs["norm_type"],
-                dim_aux=dim_aux,
-                norm_eps=mlp_norm_eps,
+                norm_type=self.cf.norm_type,
+                dim_aux=(dim_aux if self.cf.pred_mlp_adaln else None),
+                norm_eps=self.cf.mlp_norm_eps,
             )
         )
 

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -28,6 +28,7 @@ from weathergen.model.engines import (
     Local2GlobalAssimilationEngine,
     LocalAssimilationEngine,
     TargetPredictionEngine,
+    TargetPredictionEngineClassic,
 )
 from weathergen.model.layers import MLP
 from weathergen.model.utils import get_num_parameters
@@ -331,7 +332,12 @@ class Model(torch.nn.Module):
                 self.pred_adapter_kv.append(torch.nn.Identity())
 
             # target prediction engines
-            tte = TargetPredictionEngine(
+            TTE = (
+                TargetPredictionEngine
+                if cf.decoder_type != "PerceiverIOCoordConditioning"
+                else TargetPredictionEngineClassic
+            )
+            tte = TTE(
                 cf,
                 dims_embed,
                 dim_coord_in,
@@ -720,18 +726,13 @@ class Model(torch.nn.Module):
             Prediction output tokens in physical representation for each target_coords.
         """
 
-        # fp32, i32 = torch.float32, torch.int32
         batch_size = (
             self.cf.batch_size_per_gpu if self.training else self.cf.batch_size_validation_per_gpu
         )
 
         s = [batch_size, self.num_healpix_cells, self.cf.ae_local_num_queries, tokens.shape[-1]]
         tokens_stream = (tokens.reshape(s) + model_params.pe_global).flatten(0, 1)
-        tokens_stream = (
-            tokens_stream[model_params.hp_nbours.flatten()]
-            .flatten(0, 1)
-            .reshape(self.num_healpix_cells, 9, -1)
-        )
+        tokens_stream = tokens_stream[model_params.hp_nbours.flatten()].flatten(0, 1)
 
         # pair with tokens from assimilation engine to obtain target tokens
         preds_tokens = []
@@ -759,6 +760,7 @@ class Model(torch.nn.Module):
                     ]
                 )
 
+            # skip when coordinate embeddings yields nan (i.e. the coord embedding network diverged)
             if torch.isnan(tc_tokens).any():
                 nn = si["name"]
                 logger.warning(
@@ -769,6 +771,8 @@ class Model(torch.nn.Module):
                 )
                 preds_tokens += [torch.tensor([], device=tc_tokens.device)]
                 continue
+
+            # skip empty lengths
             if tc_tokens.shape[0] == 0:
                 preds_tokens += [torch.tensor([], device=tc_tokens.device)]
                 continue

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -332,12 +332,12 @@ class Model(torch.nn.Module):
                 self.pred_adapter_kv.append(torch.nn.Identity())
 
             # target prediction engines
-            TTE = (
+            tte_version = (
                 TargetPredictionEngine
                 if cf.decoder_type != "PerceiverIOCoordConditioning"
                 else TargetPredictionEngineClassic
             )
-            tte = TTE(
+            tte = tte_version(
                 cf,
                 dims_embed,
                 dim_coord_in,


### PR DESCRIPTION
Restored old prediction had functionally. Other adjustments/reverts, in particular in attention.

## Description

In the plots below, the improvements compared to the older runs might be due to changes in the loss computation. Overall, the important point is that training does not stagnate early.

**ERA5 only:**
old: naoj54ch and precursors 
fixed: e0xdl678g 
broken: IIcmk8th

<img width="3000" height="2100" alt="bafgq0yu_av4qh6pm_naoj54ch_e6x9ripj_llcmk8th_ef9hl74a_ie3g4yfp_c8fsgz42_e0xdl78g_val_ERA5" src="https://github.com/user-attachments/assets/ee8f3c2a-0fc4-4fb1-9ef7-8bb505401430" />

**ERA5 + CERRA:**
old: txwqvm83 and precursors
fixed: i6ezkO
broken: cl46szaf / x2y9ktqe and precursors

<img width="3000" height="2100" alt="bozdnseb_evq2wki6_tn0lkmbz_yt9i2mlp_rz3l5tse_rcsxyrz8_txwqvm83_tozg0we5_i6eczfk0_x2y9ktqe_cl46szqf_fg581pox_val_CERRA" src="https://github.com/user-attachments/assets/2556517c-a80b-43ef-948d-8db603a409fa" />

<img width="3000" height="2100" alt="bozdnseb_evq2wki6_tn0lkmbz_yt9i2mlp_rz3l5tse_rcsxyrz8_txwqvm83_tozg0we5_i6eczfk0_x2y9ktqe_cl46szqf_fg581pox_val_ERA5" src="https://github.com/user-attachments/assets/570a318b-bcca-43a4-9936-2aa748ce44d7" />


**ERA5 + SEVIRI:**
old: fcaplwhi / owfhi8nm 
fixed: gwrvips3 / yi3jxhuw

<img width="3000" height="2100" alt="i3q0jytf_kxgvdam2_ssucopnf_f5n4b7kx_seqvotd1_fcaplwhi_owfhi8nm_k4o2ked7_gwrvips3_yi3jxhuw_val_ERA5" src="https://github.com/user-attachments/assets/971450fb-09b2-46ab-ba46-28ae4a36ca63" />

<img width="3000" height="2100" alt="i3q0jytf_kxgvdam2_ssucopnf_f5n4b7kx_seqvotd1_fcaplwhi_owfhi8nm_k4o2ked7_gwrvips3_yi3jxhuw_train_SEVIRI" src="https://github.com/user-attachments/assets/fc60ff99-2c80-44bb-950f-6236f0fee707" />


## Type of Change

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Closes #695 

## Code Compatibility

-   [X] I have performed a self-review of my code

### Code Performance and Testing

-   [X] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [ ] I have not introduced new dependencies in the inference portion of the pipeline

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->