### PR TITLE
Merge compare_run_configs.py with markdown table version

### DIFF
--- a/src/weathergen/utils/compare_run_configs.py
+++ b/src/weathergen/utils/compare_run_configs.py
@@ -20,6 +20,8 @@ _logger = logging.getLogger(__name__)
 
 
 if __name__ == "__main__":
+    # switch to yml config based arg parsing to facilitate comparison between more than two runs
+    # Think about compatibility with the plot train config
     parser = argparse.ArgumentParser()
     parser.add_argument("-r1", "--run_id_1", required=True)
     parser.add_argument("-r2", "--run_id_2", required=True)
@@ -38,10 +40,11 @@ if __name__ == "__main__":
         help="Path to model directory for -r2/--run_id_2",
     )
     args = parser.parse_args()
-
+    #  retain this way of loading configs
     cf1 = load_model_config(args.run_id_1, None, args.model_directory_1)
     cf2 = load_model_config(args.run_id_2, None, args.model_directory_2)
 
+    # Integrate new comparison code from here
     result = list(diff(cf1.__dict__, cf2.__dict__))
 
     for tag, path, details in result:


### PR DESCRIPTION
## Description

- Add support for comparing multiple configs
- Show comparison in markdown table format:

|                                  | h0i6mca2                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | vixjzshw                                                                                   | uht31qd4                                                                                   |
|----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
| data_loader_rng_seed             | **1754237782**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | **1754238714**                                                                             | **1754236537**                                                                             |
| run_id                           | **h0i6mca2**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | **vixjzshw**                                                                               | **uht31qd4**                                                                               |
| streams[0].source                | **['u_137', 'u_136', 'u_135', 'u_133', 'u_131', 'u_129', 'u_127', 'u_124', 'u_121', 'u_118', 'u_114', 'u_110', 'u_106', 'u_102', 'v_137', 'v_136', 'v_135', 'v_133', 'v_131', 'v_129', 'v_127', 'v_124', 'v_121', 'v_118', 'v_114', 'v_110', 'v_106', 'v_102', 't_137', 't_136', 't_135', 't_133', 't_131', 't_129', 't_127', 't_124', 't_121', 't_118', 't_114', 't_110', 't_106', 't_102', 'q_137', 'q_136', 'q_135', 'q_133', 'q_131', 'q_129', 'q_127', 'q_124', 'q_121', 'q_118', 'q_114', 'q_110', 'q_106', 'q_102', 'z', '10u', '10v', '2t']** | **['z', '10u', '10v', '2t']**                                                              | **['z', '10u', '10v', '2t']**                                                              |
| streams[0].train_source_channels | **['10u', '10v', '2t', 'q_102', 'q_106', 'q_110', 'q_114', 'q_118', 'q_121', 'q_124', 'q_127', 'q_129', 'q_131', 'q_133', 'q_135', 'q_136', 'q_137', 't_102', 't_106', 't_110', 't_114', 't_118', 't_121', 't_124', 't_127', 't_129', 't_131', 't_133', 't_135', 't_136', 't_137', 'u_102', 'u_106', 'u_110', 'u_114', 'u_118', 'u_121', 'u_124', 'u_127', 'u_129', 'u_131', 'u_133', 'u_135', 'u_136', 'u_137', 'v_102', 'v_106', 'v_110', 'v_114', 'v_118', 'v_121', 'v_124', 'v_127', 'v_129', 'v_131', 'v_133', 'v_135', 'v_136', 'v_137']**      | **['10u', '10v', '2t']**                                                                   | **['10u', '10v', '2t']**                                                                   |
| streams[0].val_source_channels   | **['10u', '10v', '2t', 'q_102', 'q_106', 'q_110', 'q_114', 'q_118', 'q_121', 'q_124', 'q_127', 'q_129', 'q_131', 'q_133', 'q_135', 'q_136', 'q_137', 't_102', 't_106', 't_110', 't_114', 't_118', 't_121', 't_124', 't_127', 't_129', 't_131', 't_133', 't_135', 't_136', 't_137', 'u_102', 'u_106', 'u_110', 'u_114', 'u_118', 'u_121', 'u_124', 'u_127', 'u_129', 'u_131', 'u_133', 'u_135', 'u_136', 'u_137', 'v_102', 'v_106', 'v_110', 'v_114', 'v_118', 'v_121', 'v_124', 'v_127', 'v_129', 'v_131', 'v_133', 'v_135', 'v_136', 'v_137']**      | **['10u', '10v', '2t']**                                                                   | **['10u', '10v', '2t']**                                                                   |
| streams[1].source                | **['10u']**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | **['10u']**                                                                                | **['2t', '10u', '10v', 't_850', 'u_850', 'v_850', 'q_850', 'z_500']**                      |
| streams[1].train_source_channels | **['10u']**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | **['10u']**                                                                                | **['q_850', 't_850', 'u_850', 'v_850', 'z_500', '10u', '10v', '2t']**                      |
| streams[1].val_source_channels   | **['10u']**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | **['10u']**                                                                                | **['q_850', 't_850', 'u_850', 'v_850', 'z_500', '10u', '10v', '2t']**                      |
| ae_adapter_dropout_rate          | 0.1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 0.1                                                                                        | 0.1                                                                                        |
| ae_adapter_embed                 | 128                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 128                                                                                        | 128                                                                                        |
| ae_adapter_num_heads             | 16                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 16                                                                                         | 16                                                                                         |
| ae_adapter_with_qk_lnorm         | True                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | True                                                                                       | True                                                                                       |                                                                                                                                   

## Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/676

## Code Compatibility

-   [ ] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [ ] I have not introduced new dependencies in the inference portion of the pipeline

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->