### PR TITLE
Enable passing arguments to evaluation script through function call

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
@@ -10,6 +10,7 @@
 
 import argparse
 import logging
+import sys
 from collections import defaultdict
 from pathlib import Path
 
@@ -27,6 +28,11 @@ _logger = logging.getLogger(__name__)
 
 
 def evaluate() -> None:
+    # By default, arguments from the command line are read.
+    evaluate_from_args(sys.argv[1:])
+
+
+def evaluate_from_args(argl: list[str]) -> None:
     parser = argparse.ArgumentParser(
         description="Fast evaluation of WeatherGenerator runs."
     )
@@ -36,7 +42,7 @@ def evaluate() -> None:
         help="Path to the configuration yaml file for plotting. e.g. config/plottig_config.yaml",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argl)
 
     # configure logging
     logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## Description

Currently, evaluation can be run form cli using uv run evaluation --config <my_config_file>.
In some situations, we may want to run evaluation by calling the evaluation function in a python script and pass the arguments through the function.
This PR adds a buffer function which passes the command line argument to the actual function such as in `run_train.py`.


## Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Closes #712

<!-- Link the Issue number this change addresses, ideally in one of the "magic format" such as Closes #XYZ -->

<!-- Alternatively, explain the motivation behind the changes and the context in which they are being made. -->

## Code Compatibility

-   [ ] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [ ] I have not introduced new dependencies in the inference portion of the pipeline

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->