### PR TITLE
Detect if channels for plotting differ from JSON and recompute if necessary (Closes #701)

### DIFF
--- a/config/plot_config.yml
+++ b/config/plot_config.yml
@@ -1,0 +1,31 @@
+verbose: true
+results_dir : "./results/"
+output_plotting_dir: "./plots/"
+output_scores_dir : "./jsons/"
+image_format : "png" #options: "png", "pdf", "svg", "eps", "jpg" ..
+dpi_val : 300
+summary_plots : true
+print_summary: false #print out score values on screen. it can be verbose
+
+evaluation:
+  metrics  : ["rmse", "l1", "mse"]
+
+#MTM models
+
+run_ids :
+  hi5dkezx:
+    label: "Original Embedding (default levels)"
+    epoch: 0
+    rank: 0
+    streams:
+      ERA5:
+        channels: ["v_95"]
+        evaluation:
+          forecast_step: "all"
+          sample: "all"
+        plotting: 
+          sample: [0]
+          forecast_step: [1, 2, 3]
+          plot_maps: false
+          plot_histograms: false 
+     

--- a/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
@@ -84,7 +84,6 @@ def evaluate() -> None:
                     for metric in metrics:
                 
                         try:
-                            
                             metric_data = retrieve_metric_from_json(
                                 out_scores_dir,
                                 run_id,
@@ -93,19 +92,15 @@ def evaluate() -> None:
                                 metric,
                                 run.epoch,
                             )
-                            scores_dict[metric][region][stream][run_id] = metric_data
-                            # print(cfg[run_id][stream]["channels"].values)
-                            # print(metric_data["channel"].values)
-                            print(cfg[run_id][stream]["channels"].values)
-                            exit()
-                            for ch in cfg[run_id][stream]["channels"].values:
-                                print(file=f'assessing channel {ch}')
-                                exit()
+                            channels = cfg["run_ids"][run_id]["streams"][stream].get("channels")
+                            for ch in channels:
                                 if ch not in metric_data["channel"].values:
-                                    print(f'channel {ch} not present')
-                                    raise ValueError(f"Channel {ch} does not appear in saved scores. Scores will be recomputed.")
+                                    _logger.info(f'Channel {ch} does not appear in saved scores. Scores will be recomputed.')
+                                    raise ValueError()
+                            scores_dict[metric][region][stream][run_id] = metric_data
                             # scores_dict[metric][region][stream][run_id] = metric_data
                         except (FileNotFoundError, KeyError, ValueError):
+                            _logger.info('Exception caught...')
                             metrics_to_compute.append(metric)
 
                     print(f'metrics to compute: {metrics_to_compute}')
@@ -126,10 +121,14 @@ def evaluate() -> None:
                         )
 
                     for metric in metrics_to_compute:
-                        scores_dict[metric][stream][run_id] = all_metrics.sel(
+                        scores_dict[metric][region][stream][run_id] = all_metrics.sel(
                             {"metric": metric}
                         )
+                    print(scores_dict)
     # plot summary
+    
+
+
     if scores_dict and cfg.summary_plots:
         _logger.info("Started creating summary plots..")
         plot_summary(cfg, scores_dict, print_summary=cfg.print_summary)

--- a/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
@@ -78,11 +78,9 @@ def evaluate() -> None:
                 _logger.info(f"Retrieve or compute scores for {run_id} - {stream}...")
 
                 for region in regions:
-                    
                     metrics_to_compute = []
 
                     for metric in metrics:
-                
                         try:
                             metric_data = retrieve_metric_from_json(
                                 out_scores_dir,
@@ -92,18 +90,22 @@ def evaluate() -> None:
                                 metric,
                                 run.epoch,
                             )
-                            channels = cfg["run_ids"][run_id]["streams"][stream].get("channels")
+                            channels = cfg["run_ids"][run_id]["streams"][stream].get(
+                                "channels"
+                            )
                             for ch in channels:
                                 if ch not in metric_data["channel"].values:
-                                    _logger.info(f'Channel {ch} does not appear in saved scores. Scores will be recomputed.')
+                                    _logger.info(
+                                        f"Channel {ch} does not appear in saved scores. Scores will be recomputed."
+                                    )
                                     raise ValueError()
                             scores_dict[metric][region][stream][run_id] = metric_data
                             # scores_dict[metric][region][stream][run_id] = metric_data
                         except (FileNotFoundError, KeyError, ValueError):
-                            _logger.info('Exception caught...')
+                            _logger.info("Exception caught...")
                             metrics_to_compute.append(metric)
 
-                    print(f'metrics to compute: {metrics_to_compute}')
+                    print(f"metrics to compute: {metrics_to_compute}")
 
                     if metrics_to_compute:
                         all_metrics, points_per_sample = calc_scores_per_stream(
@@ -126,8 +128,6 @@ def evaluate() -> None:
                         )
                     print(scores_dict)
     # plot summary
-    
-
 
     if scores_dict and cfg.summary_plots:
         _logger.info("Started creating summary plots..")

--- a/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
@@ -78,10 +78,13 @@ def evaluate() -> None:
                 _logger.info(f"Retrieve or compute scores for {run_id} - {stream}...")
 
                 for region in regions:
+                    
                     metrics_to_compute = []
 
                     for metric in metrics:
+                
                         try:
+                            
                             metric_data = retrieve_metric_from_json(
                                 out_scores_dir,
                                 run_id,
@@ -91,8 +94,21 @@ def evaluate() -> None:
                                 run.epoch,
                             )
                             scores_dict[metric][region][stream][run_id] = metric_data
+                            # print(cfg[run_id][stream]["channels"].values)
+                            # print(metric_data["channel"].values)
+                            print(cfg[run_id][stream]["channels"].values)
+                            exit()
+                            for ch in cfg[run_id][stream]["channels"].values:
+                                print(file=f'assessing channel {ch}')
+                                exit()
+                                if ch not in metric_data["channel"].values:
+                                    print(f'channel {ch} not present')
+                                    raise ValueError(f"Channel {ch} does not appear in saved scores. Scores will be recomputed.")
+                            # scores_dict[metric][region][stream][run_id] = metric_data
                         except (FileNotFoundError, KeyError, ValueError):
                             metrics_to_compute.append(metric)
+
+                    print(f'metrics to compute: {metrics_to_compute}')
 
                     if metrics_to_compute:
                         all_metrics, points_per_sample = calc_scores_per_stream(

--- a/uv.lock
+++ b/uv.lock
@@ -2345,6 +2345,7 @@ dependencies = [
     { name = "torch", version = "2.6.0+cu124", source = { registry = "https://download.pytorch.org/whl/cu124" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "tqdm" },
     { name = "weathergen-common" },
+    { name = "weathergen-evaluate" },
     { name = "wheel" },
     { name = "zarr" },
 ]
@@ -2380,6 +2381,7 @@ requires-dist = [
     { name = "torch", marker = "sys_platform == 'macosx'", specifier = "==2.6.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "tqdm" },
     { name = "weathergen-common", editable = "packages/common" },
+    { name = "weathergen-evaluate", editable = "packages/evaluate" },
     { name = "wheel" },
     { name = "zarr", specifier = "~=2.17" },
 ]


### PR DESCRIPTION
## Description

Detect if channels for plotting differ from JSON and recompute if necessary (Closes #701 ). If one channel is not present in previous config, all will be recomputed. 

## Type of Change

-   [x ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

#701 

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

Changes only affects running of `run_evaluation.py`.
### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [ ] I have not introduced new dependencies in the inference portion of the pipeline


### Documentation

-   [x] My code follows the style guidelines of this project
-   [x] I have updated the documentation and docstrings to reflect the changes
-   [x] I have added comments to my code, particularly in hard-to-understand areas


## Additional Notes

New issue opened for allowing forecast steps to be adjusted (#717).