### PR TITLE
Update handling of `run_path` and `model_path` (Closes #716)

### DIFF
--- a/src/weathergen/utils/config.py
+++ b/src/weathergen/utils/config.py
@@ -342,18 +342,20 @@ def load_streams(streams_directory: Path) -> list[Config]:
 def set_paths(config: Config) -> Config:
     """Set the configs run_path model_path attributes to default values if not present."""
     config = config.copy()
-    config.run_path = _get_config_attribute(config=config, 
-                                            attribute_name="run_path", fallback="results")
-    config.model_path = _get_config_attribute(config=config,
-                                              attribute_name="model_path", fallback="models")
+    config.run_path = _get_config_attribute(
+        config=config, attribute_name="run_path", fallback="results"
+    )
+    config.model_path = _get_config_attribute(
+        config=config, attribute_name="model_path", fallback="models"
+    )
 
     return config
 
 
 def _get_config_attribute(config: Config, attribute_name: str, fallback: str) -> str:
     """Get an attribute from a Config. If not, fall back to path_shared_working_dir concatenated
-    with the desired fallback path. Raise an error if neither the attribute nor 
-    is specified.""" 
+    with the desired fallback path. Raise an error if neither the attribute nor
+    is specified."""
     attribute = OmegaConf.select(config, attribute_name)
     fallback_root = OmegaConf.select(config, "path_shared_working_dir")
     assert attribute is not None or fallback_root is not None, (


### PR DESCRIPTION
## Description

Update handling of run_path and model_path to allow them to be specified even if `path_shared_working_dir` is not (Closes #716).

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

#716 

<!-- Link the Issue number this change addresses, ideally in one of the "magic format" such as Closes #XYZ -->

<!-- Alternatively, explain the motivation behind the changes and the context in which they are being made. -->

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

UNTESTED

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [ ] I have not introduced new dependencies in the inference portion of the pipeline


### Documentation

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas


## Additional Notes

Alternatively, must always specify `path_shared_working_dir` in private config.