### PR TITLE
Mk/develop/fix plot train 727

### DIFF
--- a/src/weathergen/utils/config.py
+++ b/src/weathergen/utils/config.py
@@ -67,7 +67,10 @@ def load_model_config(run_id: str, epoch: int | None, model_path: str | None) ->
         fname = Path(run_id)
         _logger.info(f"Loading config from provided full run_id path: {fname}")
     else:
-        # Load model config here...
+        # Load model config here. In case model_path is not provided, get it from private conf
+        if model_path is None:
+            pconf = _load_private_conf(private_home=None)
+            model_path = pconf.get("model_path", pconf.get("path_shared_working_dir") + "models")
         model_path = Path(model_path)
         fname = model_path / run_id / _get_model_config_file_name(run_id, epoch)
 

--- a/src/weathergen/utils/config.py
+++ b/src/weathergen/utils/config.py
@@ -70,7 +70,11 @@ def load_model_config(run_id: str, epoch: int | None, model_path: str | None) ->
         # Load model config here. In case model_path is not provided, get it from private conf
         if model_path is None:
             pconf = _load_private_conf(private_home=None)
-            model_path = pconf.get("model_path", pconf.get("path_shared_working_dir") + "models")
+            # _get_config_attribute(config: Config, attribute_name: str, fallback: str)
+            # model_path = pconf.get("model_path", pconf.get("path_shared_working_dir") + "models")
+            model_path = _get_config_attribute(
+                config=pconf, attribute_name="model_path", fallback="models"
+            )
         model_path = Path(model_path)
         fname = model_path / run_id / _get_model_config_file_name(run_id, epoch)
 
@@ -356,9 +360,9 @@ def set_paths(config: Config) -> Config:
 
 
 def _get_config_attribute(config: Config, attribute_name: str, fallback: str) -> str:
-    """Get an attribute from a Config. If not, fall back to path_shared_working_dir concatenated
-    with the desired fallback path. Raise an error if neither the attribute nor
-    is specified."""
+    """Get an attribute from a Config. If not available, fall back to path_shared_working_dir
+    concatenated with the desired fallback path. Raise an error if neither the attribute nor a
+    fallback is specified."""
     attribute = OmegaConf.select(config, attribute_name)
     fallback_root = OmegaConf.select(config, "path_shared_working_dir")
     assert attribute is not None or fallback_root is not None, (


### PR DESCRIPTION
## Description

If model_path is not provided in `uv run plot_train`, it is retrieved from the private config. Thus, running `uv run plot_train` works now, also with `{RUN_ID}_train_metrics.json` files from other HPCs.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Fixes #727 

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory
