### PR TITLE
Improve perf s2tor3

### DIFF
--- a/src/weathergen/datasets/utils.py
+++ b/src/weathergen/datasets/utils.py
@@ -59,11 +59,17 @@ def s2tor3(lats, lons):
     Note: mathematics convention with lats in [0,pi] and lons in [0,2pi] is used
           (which is not problematic for lons but for lats care is required)
     """
-    x = torch.sin(lats) * torch.cos(lons)
-    y = torch.sin(lats) * torch.sin(lons)
-    z = torch.cos(lats)
-    out = torch.stack([x, y, z])
-    return out.permute([*list(np.arange(len(out.shape))[:-1] + 1), 0])
+    # Calculate common terms once to avoid redundant computations.
+    sin_lats = torch.sin(lats)
+    cos_lats = torch.cos(lats)
+    
+    # Calculate the x, y, and z coordinates using vectorized operations.
+    x = sin_lats * torch.cos(lons)
+    y = sin_lats * torch.sin(lons)
+    z = cos_lats
+
+    # Stack the x, y, and z tensors along the last dimension.
+    return torch.stack([x, y, z], dim=-1)
 
 
 ####################################################################################################


### PR DESCRIPTION
## Description
Improved and vectorized the `s2tor3` function.
<!-- Provide a brief summary of the changes introduced in this pull request. -->

## Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Closes #733 

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory
-   [x] I ran the `/WeatherGenerator-private/hpc/launch-slurm.py   --slurm-script /p/project1/hclimrep/$USER/WeatherGenerator private/hpc/juwels_booster/weathergen_train_multi_workers_profiling.sh   --config /p/project1/hclimrep/$USER/WeatherGenerator/config/multi_workers_profiling.yml`  and it is working. 

The corresponding branch name of ` WeatherGenerator-private` is `profiling_slurm`. 
<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [ ] I have not introduced new dependencies in the inference portion of the pipeline

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes
To assess and improve performance, two types of tests were conducted:

- Single-worker data loading test
Since Nsight Systems can only capture the main Python process, this test was designed to profile the data loader in more detail. It is used to identify potential bottlenecks. Here you can see the results against develop branch:
<br>
<br>

**Vectorized version of s2tor3**
<img width="1445" height="604" alt="Screenshot from 2025-08-13 18-40-08" src="https://github.com/user-attachments/assets/af4d8a64-e465-45d5-9458-88ac17439f79" />

<br>
<br>

<br>
<br>

**Naive implementation of s2tor3 (develop branch)**
<br>
<br>
<img width="1586" height="679" alt="Screenshot from 2025-08-13 12-50-44" src="https://github.com/user-attachments/assets/51e17798-ca07-465b-a6ae-7531341707b4" />
<br>
<br>

As shown in iteration 3, an improvement can be confirmed (13.239 vs. 13.071 s).

<br>

- Multi-worker data loading test
Since the actual training is performed using multiple workers, this test was designed to evaluate whether the code shows improvements compared to the develop branch. For this test, data loading time and GPU compute time were measured for the first 128 iterations, with at least 3 runs using different seeds. The reported results are the average of at least 3 runs. In this test, the data loader submodules are not visible in Nsys.

**Vectorized version of s2tor3**
<br>
`0: 2025-08-13 10:56:01,826 3790862 trainer.py:604 : INFO     : Average Data Loading Time (first 128 batches): 0.3878 s`
<br>
<br>
**Naive implementation of r3tos2 (develop branch)**
<br>
`0: 2025-08-13 12:23:13,417 1894484 trainer.py:604 : INFO     : Average Data Loading Time (first 128 batches): 0.4213 s`

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->