### PR TITLE
Allow for more forcast step embeddings

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -45,7 +45,7 @@ forecast_delta_hrs: 0
 forecast_steps: 0
 forecast_policy: null
 forecast_freeze_model: False
-forecast_att_dense_rate: 0.25
+forecast_att_dense_rate: 1.0
 fe_num_blocks: 0
 fe_num_heads: 16
 fe_dropout_rate: 0.1

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -250,7 +250,7 @@ class GlobalAssimilationEngine:
 
 
 class ForecastingEngine:
-    def __init__(self, cf: Config, num_healpix_cells: int) -> None:
+    def __init__(self, cf: Config, num_healpix_cells: int, aux_channels: int) -> None:
         """
         Initialize the ForecastingEngine with the configuration.
 
@@ -259,6 +259,7 @@ class ForecastingEngine:
         """
         self.cf = cf
         self.num_healpix_cells = num_healpix_cells
+        self.aux_channels = aux_channels
         self.fe_blocks = torch.nn.ModuleList()
 
     def create(self) -> torch.nn.ModuleList:
@@ -280,7 +281,7 @@ class ForecastingEngine:
                             with_qk_lnorm=self.cf.fe_with_qk_lnorm,
                             with_flash=self.cf.with_flash_attention,
                             norm_type=self.cf.norm_type,
-                            dim_aux=1,
+                            dim_aux=self.aux_channels,
                             norm_eps=self.cf.norm_eps,
                             attention_dtype=get_dtype(self.cf.attention_dtype),
                         )
@@ -296,7 +297,7 @@ class ForecastingEngine:
                             with_qk_lnorm=self.cf.fe_with_qk_lnorm,
                             with_flash=self.cf.with_flash_attention,
                             norm_type=self.cf.norm_type,
-                            dim_aux=1,
+                            dim_aux=self.aux_channels,
                             norm_eps=self.cf.norm_eps,
                             attention_dtype=get_dtype(self.cf.attention_dtype),
                         )
@@ -309,7 +310,7 @@ class ForecastingEngine:
                         with_residual=True,
                         dropout_rate=self.cf.fe_dropout_rate,
                         norm_type=self.cf.norm_type,
-                        dim_aux=1,
+                        dim_aux=self.aux_channels,
                         norm_eps=self.cf.mlp_norm_eps,
                     )
                 )

--- a/src/weathergen/model/positional_encoding.py
+++ b/src/weathergen/model/positional_encoding.py
@@ -11,6 +11,39 @@ import math
 
 import numpy as np
 import torch
+import torch.nn
+
+
+class PositionalEmbedding(torch.nn.Module):
+    def __init__(self, num_channels, max_positions=10000, endpoint=False):
+        super().__init__()
+        self.num_channels = num_channels
+        self.max_positions = max_positions
+        self.endpoint = endpoint
+
+    def forward(self, x):
+        freqs = torch.arange(
+            start=0, end=self.num_channels // 2, dtype=torch.float32, device=x.device
+        )
+        freqs = freqs / (self.num_channels // 2 - (1 if self.endpoint else 0))
+        freqs = (1 / self.max_positions) ** freqs
+        x = x.ger(freqs.to(x.dtype))
+        x = torch.cat([x.cos(), x.sin()], dim=1)
+        return x
+
+
+# ----------------------------------------------------------------------------
+
+
+class FourierEmbedding(torch.nn.Module):
+    def __init__(self, num_channels, scale=16):
+        super().__init__()
+        self.register_buffer("freqs", torch.randn(num_channels // 2) * scale)
+
+    def forward(self, x):
+        x = x.ger((2 * np.pi * self.freqs).to(x.dtype))
+        x = torch.cat([x.cos(), x.sin()], dim=1)
+        return x
 
 
 ####################################################################################################


### PR DESCRIPTION
## Description

allow more choices when embedding the forecast step

## Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

None

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

I tested with `--options forecast_offset=1 training_mode='forecast' istep=0 num_epochs=8 forecast_policy=fixed forecast_steps=2 fe_num_blocks=8`


### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [ ] I have not introduced new dependencies in the inference portion of the pipeline

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->