### PR TITLE
fix plotting for partially filled forecast steps

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils.py
@@ -116,7 +116,7 @@ def get_data(
         else:
             points_per_sample = None
 
-        fsteps_final = fsteps
+        fsteps_final = []
 
         for fstep in fsteps:
             _logger.info(f"RUN {run_id} - {stream}: Processing fstep {fstep}...")
@@ -141,9 +141,9 @@ def get_data(
                     _logger.info(
                         f"Skipping {stream} sample {sample} forecast step: {fstep}. Dataset is empty."
                     )
-                    fsteps_final.remove(fstep)
                     continue
-
+                
+                fsteps_final.append(fstep)
                 da_tars_fs.append(target.squeeze())
                 da_preds_fs.append(pred.squeeze())
                 pps.append(npoints)
@@ -172,11 +172,11 @@ def get_data(
                     da_tars_fs = da_tars_fs.sel(channel=existing_channels)
                     da_preds_fs = da_preds_fs.sel(channel=existing_channels)
 
-            da_tars.append(da_tars_fs)
-            da_preds.append(da_preds_fs)
+                da_tars.append(da_tars_fs)
+                da_preds.append(da_preds_fs)
             if return_counts:
                 points_per_sample.loc[{"forecast_step": fstep}] = np.array(pps)
-
+        
         # Safer than a list
         da_tars = {fstep: da for fstep, da in zip(fsteps_final, da_tars, strict=False)}
         da_preds = {


### PR DESCRIPTION
## Description

the code crashes in case the first forecast step is missing, but one of the subsequent ones is filled. 

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

closes https://github.com/ecmwf/WeatherGenerator/issues/825

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [x] I have ensured that the code is still pip-installable after the changes and runs
-   [x] I have tested that new dependencies themselves are pip-installable.
-   [x] I have not introduced new dependencies in the inference portion of the pipeline

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [x] My code follows the style guidelines of this project
-   [x] I have updated the documentation and docstrings to reflect the changes
-   [x] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->