### PR TITLE
Fix Issue 835

### DIFF
--- a/src/weathergen/model/layers.py
+++ b/src/weathergen/model/layers.py
@@ -9,8 +9,23 @@
 
 
 import torch
+import torch.nn as nn
 
 from weathergen.model.norms import AdaLayerNorm, RMSNorm
+
+
+class NamedLinear(torch.nn.Module):
+    def __init__(self, name: str | None = None, **kwargs):
+        super(NamedLinear, self).__init__()
+        self.linear = nn.Linear(**kwargs)
+        if name is not None:
+            self.name = name
+
+    def reset_parameters(self):
+        self.linear.reset_parameters()
+
+    def forward(self, x):
+        return self.linear(x)
 
 
 class MLP(torch.nn.Module):

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -30,7 +30,7 @@ from weathergen.model.engines import (
     TargetPredictionEngine,
     TargetPredictionEngineClassic,
 )
-from weathergen.model.layers import MLP
+from weathergen.model.layers import MLP, NamedLinear
 from weathergen.model.utils import get_num_parameters
 from weathergen.utils.config import Config, get_dtype
 from weathergen.utils.logger import logger
@@ -301,7 +301,12 @@ class Model(torch.nn.Module):
             # embedding network for coordinates
             if etc["net"] == "linear":
                 self.embed_target_coords.append(
-                    torch.nn.Linear(dim_coord_in, dims_embed[0], bias=False)
+                    NamedLinear(
+                        f"embed_target_coords_{stream_name}",
+                        in_features=dim_coord_in,
+                        out_features=dims_embed[0],
+                        bias=False,
+                    )
                 )
             elif etc["net"] == "mlp":
                 self.embed_target_coords.append(


### PR DESCRIPTION
Enable freezing the target coord embedding when it is just a simple layer

## Description

<!-- Provide a brief summary of the changes introduced in this pull request. -->

## Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Closes #835

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [ ] I have not introduced new dependencies in the inference portion of the pipeline

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

`.*coord.*` now freezes the target coordinate embedding layer

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->