### PR TITLE
Iluise/develop/refactor eval reader

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/io_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io_reader.py
@@ -1,0 +1,345 @@
+# (C) Copyright 2025 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import omegaconf as oc
+import xarray as xr
+from tqdm import tqdm
+
+from weathergen.common.io import ZarrIO
+from weathergen.evaluate.plot_utils import (
+    plot_metric_region,
+)
+from weathergen.evaluate.plotter import LinePlots, Plotter
+from weathergen.evaluate.score import VerifiedData, get_score
+from weathergen.evaluate.score_utils import RegionBoundingBox, to_list
+from weathergen.utils.config import _REPO_ROOT, load_config, load_model_config
+
+_logger = logging.getLogger(__name__)
+_logger.setLevel(logging.INFO)
+
+
+@dataclass
+class WeatherGeneratorOutput:
+    target: dict
+    prediction: dict
+    points_per_sample: xr.DataArray | None
+
+class Reader(object):
+    def __init__(self, eval_cfg: dict, run_id: str, private_paths: dict = None):
+        """
+        Generic data reader class.
+
+        Parameters
+        ----------
+        eval_cfg : dir
+            config with plotting and evaluation options for that run id
+        run_id : str
+            run id of the model
+        private_paths: lists
+            list of private paths for the supported HPC
+        """
+        self.eval_cfg = eval_cfg
+        self.run_id = run_id
+        self.private_paths = private_paths
+
+        self.streams = eval_cfg.streams.keys()
+        self.epoch = eval_cfg.epoch
+        self.rank = eval_cfg.rank
+
+        # If results_base_dir and model_base_dir are not provided, default paths are used
+        self.model_base_dir = self.eval_cfg.get("model_base_dir", None)
+
+        # Load model configuration and set (run-id specific) directories
+        self.inference_cfg = self.get_inference_config() 
+
+        self.results_base_dir = self.eval_cfg.get(
+                "results_base_dir", None
+            )  # base directory where results will be stored
+
+        if not self.results_base_dir:
+            self.results_base_dir = Path(self.inference_cfg["run_path"])
+            logging.info(
+                f"Results directory obtained from model config: {self.results_base_dir}"
+            )
+        else:
+            logging.info(f"Results directory parsed: {self.results_base_dir}")
+
+        self.runplot_base_dir = Path(
+            self.eval_cfg.get("runplot_base_dir", self.results_base_dir)
+        )  # base directory where map plots and histograms will be stored
+
+        self.metrics_base_dir = Path(
+            self.eval_cfg.get("metrics_base_dir", self.results_base_dir)
+        )  # base directory where score files will be stored
+
+        self.results_dir, self.runplot_dir = (
+            Path(self.results_base_dir) / self.run_id,
+            Path(self.runplot_base_dir) / self.run_id,
+        )
+        # for backward compatibility allow metric_dir to be specified in the run config
+        self.metrics_dir = Path(
+            self.eval_cfg.get("metrics_dir", self.metrics_base_dir / self.run_id / "evaluation")
+            )
+        
+        self.fname_zarr = self.results_dir.joinpath(
+            f"validation_epoch{self.epoch:05d}_rank{self.rank:04d}.zarr"
+        )
+
+        if not self.fname_zarr.exists() or not self.fname_zarr.is_dir():
+            _logger.error(f"Zarr file {self.fname_zarr} does not exist or is not a directory.")
+            raise FileNotFoundError(
+                f"Zarr file {self.fname_zarr} does not exist or is not a directory."
+            )
+
+
+    def get_inference_config(self):
+        """
+        load the config associated to the inference run (different from the eval_cfg which contains plot and evaluaiton options.)
+
+        Returns
+        -------
+        dict
+            configuration file from the inference run
+        """
+        try: 
+            if self.private_paths:
+                _logger.info(
+                    f"Loading config for run {self.run_id} from private paths: {self.private_paths}"
+                )
+                return load_config(self.private_paths, self.run_id, self.epoch)
+            else:
+                _logger.info(
+                    f"Loading config for run {self.run_id} from model directory: {self.model_base_dir}"
+                )
+                return load_model_config(self.run_id, self.epoch, self.model_base_dir)
+        except AssertionError:
+            _logger.warning("Model config not found. inference config will be empty.")
+            return {}
+
+    def get_stream(self, stream: str):
+        """
+        returns the dictionary associated to a particular stream 
+
+        Parameters
+        ----------
+        stream: str
+            the stream name 
+
+        Returns
+        -------
+        dict 
+            the config dictionary associated to that stream  
+        """
+        return self.eval_cfg.streams.get(stream, {})
+
+
+    def get_data(self, 
+        stream: str,
+        region: str = "global",
+        samples: list[int] = None,
+        fsteps: list[str] = None,
+        channels: list[str] = None,
+        return_counts: bool = False,
+    ) -> WeatherGeneratorOutput:
+        """
+        Retrieve prediction and target data for a given run from the Zarr store.
+
+        Parameters
+        ----------
+        cfg :
+            Configuration dictionary containing all information for the evaluation.
+        results_dir : Path
+            Directory where the inference results are stored. Expected scheme `<results_base_dir>/<run_id>`.
+        stream :
+            Stream name to retrieve data for.
+        region :
+            Region name to retrieve data for.
+        samples :
+            List of sample indices to retrieve. If None, all samples are retrieved.
+        fsteps :
+            List of forecast steps to retrieve. If None, all forecast steps are retrieved.
+        channels :
+            List of channel names to retrieve. If None, all channels are retrieved.
+        return_counts :
+            If True, also return the number of points per sample.
+
+        Returns
+        -------
+        WeatherGeneratorOutput
+            A dataclass containing:
+            - target: Dictionary of xarray DataArrays for targets, indexed by forecast step.
+            - prediction: Dictionary of xarray DataArrays for predictions, indexed by forecast step.
+            - points_per_sample: xarray DataArray containing the number of points per sample, if `return_counts` is True.
+        """
+        
+        bbox = RegionBoundingBox.from_region_name(region)
+
+        with ZarrIO(self.fname_zarr) as zio:
+            stream_cfg = self.get_stream(stream)
+            all_channels = self.get_channels(stream)
+            _logger.info(f"RUN {self.run_id}: Processing stream {stream}...")
+
+            fsteps = self.get_forecast_steps() if fsteps is None else fsteps
+
+            # TODO: Avoid conversion of fsteps and sample to integers (as obtained from the ZarrIO)
+            fsteps = sorted([int(fstep) for fstep in fsteps])
+            samples = sorted(
+                [int(sample) for sample in self.get_samples()] if samples is None else samples
+            )
+            channels = channels or stream_cfg.get("channels", all_channels)
+            channels = to_list(channels)
+
+            da_tars, da_preds = [], []
+
+            if return_counts:
+                points_per_sample = xr.DataArray(
+                    np.full((len(fsteps), len(samples)), np.nan),
+                    coords={"forecast_step": fsteps, "sample": samples},
+                    dims=("forecast_step", "sample"),
+                    name=f"points_per_sample_{stream}",
+                )
+            else:
+                points_per_sample = None
+
+            fsteps_final = []
+
+            for fstep in fsteps:
+                _logger.info(f"RUN {self.run_id} - {stream}: Processing fstep {fstep}...")
+                da_tars_fs, da_preds_fs = [], []
+                pps = []
+
+                for sample in tqdm(
+                    samples, desc=f"Processing {self.run_id} - {stream} - {fstep}"
+                ):
+                    out = zio.get_data(sample, stream, fstep)
+                    target, pred = out.target.as_xarray(), out.prediction.as_xarray()
+
+                    if region != "global":
+                        _logger.debug(
+                            f"Applying bounding box mask for region '{region}' to targets and predictions..."
+                        )
+                        target = bbox.apply_mask(target)
+                        pred = bbox.apply_mask(pred)
+
+                    npoints = len(target.ipoint)
+                    if npoints == 0:
+                        _logger.info(
+                            f"Skipping {stream} sample {sample} forecast step: {fstep}. Dataset is empty."
+                        )
+                        continue
+
+                    da_tars_fs.append(target.squeeze())
+                    da_preds_fs.append(pred.squeeze())
+                    pps.append(npoints)
+
+                if len(da_tars_fs) > 0:
+                    fsteps_final.append(fstep)
+
+                _logger.debug(
+                    f"Concatenating targets and predictions for stream {stream}, forecast_step {fstep}..."
+                )
+
+                if da_tars_fs:
+                    da_tars_fs = xr.concat(da_tars_fs, dim="ipoint")
+                    da_preds_fs = xr.concat(da_preds_fs, dim="ipoint")
+
+                    if set(channels) != set(all_channels):
+                        _logger.debug(
+                            f"Restricting targets and predictions to channels {channels} for stream {stream}..."
+                        )
+                        available_channels = da_tars_fs.channel.values
+                        existing_channels = [
+                            ch for ch in channels if ch in available_channels
+                        ]
+                        if len(existing_channels) < len(channels):
+                            _logger.warning(
+                                f"The following channels were not found: {list(set(channels) - set(existing_channels))}. Skipping them."
+                            )
+
+                        da_tars_fs = da_tars_fs.sel(channel=existing_channels)
+                        da_preds_fs = da_preds_fs.sel(channel=existing_channels)
+
+                    da_tars.append(da_tars_fs)
+                    da_preds.append(da_preds_fs)
+                if return_counts:
+                    points_per_sample.loc[{"forecast_step": fstep}] = np.array(pps)
+
+            # Safer than a list
+            da_tars = {fstep: da for fstep, da in zip(fsteps_final, da_tars, strict=False)}
+            da_preds = {
+                fstep: da for fstep, da in zip(fsteps_final, da_preds, strict=False)
+            }
+
+            return WeatherGeneratorOutput(
+                target=da_tars, prediction=da_preds, points_per_sample=points_per_sample
+            )
+
+    ######## reader utils ########
+
+    def get_samples(self):
+        with ZarrIO(self.fname_zarr) as zio:
+            return set(int(s) for s in zio.samples)
+    
+    def get_forecast_steps(self):
+        with ZarrIO(self.fname_zarr) as zio:
+            return set(int(f) for f in zio.forecast_steps)
+
+    #TODO: get this from config
+    def get_channels(self, stream: str) -> list[str]:
+        """
+        Peek the channels of a target stream.
+
+        Parameters
+        ----------
+        stream :
+            The name of the tar stream to peek.
+        fstep :
+            The forecast step to peek. Default is 0.
+        Returns
+        -------
+        channels :
+            A list of channel names in the tar stream.
+        """
+        with ZarrIO(self.fname_zarr) as zio:
+            dummy_out = zio.get_data(list(self.get_samples())[0], stream, list(self.get_forecast_steps())[0])
+            channels = dummy_out.target.channels
+            _logger.debug(f"Peeked channels for stream {stream}: {channels}")
+
+        return channels
+    
+    def get_inference_stream_attr(self, stream_name: str, key: str, default = None):
+        """
+        Get the value of a key for a specific stream from the a model config.
+
+        Parameters:
+        ------------
+            config: dict
+                The full configuration dictionary.
+            stream_name: str
+                The name of the stream (e.g. 'ERA5').
+            key: str
+                The key to look up (e.g. 'tokenize_spacetime').
+            default: Optional
+                Value to return if not found (default: None).
+
+        Returns:
+            The parameter value if found, otherwise the default.
+        """
+        for stream in self.inference_cfg.get("streams", []):
+            if stream.get("name") == stream_name:
+                return stream.get(key, default)
+        return default
+
+

--- a/packages/evaluate/src/weathergen/evaluate/json_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/json_reader.py
@@ -1,0 +1,115 @@
+# (C) Copyright 2025 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import omegaconf as oc
+import xarray as xr
+from tqdm import tqdm
+
+from weathergen.common.io import ZarrIO
+from weathergen.evaluate.plot_utils import (
+    plot_metric_region,
+)
+from weathergen.evaluate.plotter import LinePlots, Plotter
+from weathergen.evaluate.score import VerifiedData, get_score
+from weathergen.evaluate.score_utils import RegionBoundingBox, to_list
+from weathergen.utils.config import _REPO_ROOT, load_config, load_model_config
+from weathergen.evaluate.io_reader import Reader
+
+_logger = logging.getLogger(__name__)
+_logger.setLevel(logging.INFO)
+
+class JsonReader(Reader):
+    """Specialized Reader for runs that include a Zarr output file."""
+
+    def __init__(self, eval_cfg: dict, run_id: str, private_paths: dict = None):
+        super().__init__(eval_cfg, run_id, private_paths)
+
+    def check_availability(self, 
+        stream: str, 
+        available_data: dict = None,
+        mode: str = ""
+    ):
+        """
+        Check if requested channels, forecast steps and samples are
+        i) available in the previously saved json if metric data is specified (return False otherwise)
+        ii) available in the Zarr file (return error otherwise)
+        Additionally, if channels, forecast steps or samples is None/'all', it will
+        i) set the variable to all available vars in Zarr file
+        ii) return True only if the respective variable contains the same indeces in JSON and Zarr (return False otherwise)
+
+        Parameters
+        ----------
+        stream : str
+            The stream considered.
+        available_data : dict, optional
+            The available data loaded from JSON.
+        Returns
+        -------
+        bool
+            True/False depending on the above logic (True if metrics do not need recomputing)
+        str
+            channels
+        str
+            fsteps
+        str
+            samples
+        """
+
+        # fill info for requested channels, fsteps, samples
+        channels, fsteps, samples = self._get_channels_fsteps_samples(stream, mode)
+       
+        requested = {
+            "channel": set(channels) if channels is not None else None,
+            "fstep": set(fsteps) if fsteps is not None else None,
+            "sample": set(samples) if samples is not None else None,
+        }
+        # fill info from available json file (if provided)
+        available = {
+            "channel": set(available_data["channel"].values.ravel())
+            if available_data is not None
+            else {},
+            "fstep": set(available_data["forecast_step"].values.ravel())
+            if available_data is not None
+            else {},
+            "sample": set(available_data.coords["sample"].values.ravel())
+            if available_data is not None
+            else {},
+        }
+
+        for name in ["channel", "fstep", "sample"]:
+            if requested[name] is None:
+                # Default to all in Zarr
+                requested[name] = available[name]
+
+            # Must be a subset of available_data (if provided)
+            breakpoint()
+            missing = requested[name] - available[name]
+            assert requested[name] <= available[name], f"{name.capitalize()}(s) {missing} missing in evaluation. Adjust selection."
+
+            _logger.info(
+                f"All checks passed – All channels, samples, fsteps requested for {mode} are present in json file..."
+            )
+
+        return True, (
+            sorted(list(requested["channel"])),
+            sorted(list(requested["fstep"])),
+            sorted(list(requested["sample"])),
+        )
+
+    #TODO: improve this
+    def plot_subtimesteps(self, stream: str):
+        return True
+
+

--- a/packages/evaluate/src/weathergen/evaluate/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotter.py
@@ -540,14 +540,31 @@ class Plotter:
 
 
 class LinePlots:
-    def __init__(self, cfg: dict, output_basedir: str | Path):
-        self.cfg = cfg
-        self.image_format = cfg.image_format
-        self.dpi_val = cfg.get("dpi_val")
-        self.fig_size = cfg.get("fig_size", (8, 10))
-        self.log_scale = cfg.evaluation.get("log_scale", False)
-        self.add_grid = cfg.evaluation.get("add_grid", False)
+    def __init__(self, plotter_cfg: dict, output_basedir: str | Path):
+        """
+        Initialize the LinePlots class.
+
+        Parameters
+        ----------
+        plotter_cfg:
+            Configuration dictionary containing basic information for plotting.
+            Expected keys are:
+                - image_format: Format of the saved images (e.g., 'png', 'pdf', etc.)
+                - dpi_val: DPI value for the saved images
+                - fig_size: Size of the figure (width, height) in inches
+        output_basedir:
+            Base directory under which the plots will be saved.
+            Expected scheme `<results_base_dir>/<run_id>`.
+        """
+
+        self.image_format = plotter_cfg.get("image_format")
+        self.dpi_val = plotter_cfg.get("dpi_val")
+        self.fig_size = plotter_cfg.get("fig_size")
+        self.log_scale = plotter_cfg.get("log_scale")
+        self.add_grid = plotter_cfg.get("add_grid")
+        
         self.out_plot_dir = Path(output_basedir) / "line_plots"
+
         if not os.path.exists(self.out_plot_dir):
             _logger.info(f"Creating dir {self.out_plot_dir}")
             os.makedirs(self.out_plot_dir, exist_ok=True)

--- a/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
@@ -17,14 +17,17 @@ from pathlib import Path
 from omegaconf import OmegaConf, DictConfig
 
 from weathergen.evaluate.utils import (
+    get_reader,
     calc_scores_per_stream,
-    check_availability,
     metric_list_to_json,
     plot_data,
     plot_summary,
     retrieve_metric_from_json,
 )
 from weathergen.evaluate.io_reader import Reader, WeatherGeneratorOutput
+from weathergen.evaluate.json_reader import JsonReader
+from weathergen.evaluate.zarr_reader import ZarrReader
+
 from weathergen.utils.config import _REPO_ROOT
 
 _logger = logging.getLogger(__name__)
@@ -77,8 +80,8 @@ def evaluate_from_config(cfg):
 
     for run_id, run in runs.items():
         _logger.info(f"RUN {run_id}: Getting data...")
-
-        reader = Reader(run, run_id, private_paths)
+        
+        reader = get_reader(run, run_id, private_paths)
 
         for stream in reader.streams:
             _logger.info(f"RUN {run_id}: Processing stream {stream}...")
@@ -103,8 +106,8 @@ def evaluate_from_config(cfg):
                                 region,
                                 metric,
                             )
-                            checked, (channels, fsteps, samples) = check_availability(
-                                reader, stream, metric_data, mode="evaluation"
+                            checked, (channels, fsteps, samples) = reader.check_availability(
+                                stream, metric_data, mode="evaluation"
                             )
                             if not checked:
                                 metrics_to_compute.append(metric)

--- a/packages/evaluate/src/weathergen/evaluate/utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils.py
@@ -18,195 +18,25 @@ import xarray as xr
 from tqdm import tqdm
 
 from weathergen.common.io import ZarrIO
-from weathergen.evaluate.plot_utils import (
-    plot_metric_region,
-)
+from weathergen.evaluate.plot_utils import plot_metric_region
+from weathergen.evaluate.io_reader import WeatherGeneratorOutput, Reader
 from weathergen.evaluate.plotter import LinePlots, Plotter
 from weathergen.evaluate.score import VerifiedData, get_score
-from weathergen.evaluate.score_utils import RegionBoundingBox, to_list
+from weathergen.evaluate.score_utils import  to_list
 
 _logger = logging.getLogger(__name__)
 _logger.setLevel(logging.INFO)
 
-
-@dataclass
-class WeatherGeneratorOutput:
-    target: dict
-    prediction: dict
-    points_per_sample: xr.DataArray | None
-
-
-# TODO: This function needs some careful refactoring.
-def get_data(
-    cfg: dict,
-    results_dir: Path,
-    stream: str,
-    region: str = "global",
-    samples: list[int] = None,
-    fsteps: list[str] = None,
-    channels: list[str] = None,
-    return_counts: bool = False,
-) -> WeatherGeneratorOutput:
-    """
-    Retrieve prediction and target data for a given run from the Zarr store.
-
-    Parameters
-    ----------
-    cfg :
-        Configuration dictionary containing all information for the evaluation.
-    results_dir : Path
-        Directory where the inference results are stored. Expected scheme `<results_base_dir>/<run_id>`.
-    stream :
-        Stream name to retrieve data for.
-    region :
-        Region name to retrieve data for.
-    samples :
-        List of sample indices to retrieve. If None, all samples are retrieved.
-    fsteps :
-        List of forecast steps to retrieve. If None, all forecast steps are retrieved.
-    channels :
-        List of channel names to retrieve. If None, all channels are retrieved.
-    return_counts :
-        If True, also return the number of points per sample.
-
-    Returns
-    -------
-    WeatherGeneratorOutput
-        A dataclass containing:
-        - target: Dictionary of xarray DataArrays for targets, indexed by forecast step.
-        - prediction: Dictionary of xarray DataArrays for predictions, indexed by forecast step.
-        - points_per_sample: xarray DataArray containing the number of points per sample, if `return_counts` is True.
-    """
-    run_id = results_dir.name
-    run = cfg.run_ids[run_id]
-
-    fname_zarr = results_dir.joinpath(
-        f"validation_epoch{run['epoch']:05d}_rank{run['rank']:04d}.zarr"
-    )
-
-    if not fname_zarr.exists() or not fname_zarr.is_dir():
-        _logger.error(f"Zarr file {fname_zarr} does not exist or is not a directory.")
-        raise FileNotFoundError(
-            f"Zarr file {fname_zarr} does not exist or is not a directory."
-        )
-
-    bbox = RegionBoundingBox.from_region_name(region)
-
-    with ZarrIO(fname_zarr) as zio:
-        zio_forecast_steps = zio.forecast_steps
-        stream_cfg = run.streams[stream]
-        all_channels = peek_tar_channels(zio, stream, zio_forecast_steps[0])
-        _logger.info(f"RUN {run_id}: Processing stream {stream}...")
-
-        fsteps = zio_forecast_steps if fsteps is None else fsteps
-
-        # TODO: Avoid conversion of fsteps and sample to integers (as obtained from the ZarrIO)
-        fsteps = sorted([int(fstep) for fstep in fsteps])
-        samples = sorted(
-            [int(sample) for sample in zio.samples] if samples is None else samples
-        )
-        channels = channels or stream_cfg.get("channels", all_channels)
-        channels = to_list(channels)
-
-        da_tars, da_preds = [], []
-
-        if return_counts:
-            points_per_sample = xr.DataArray(
-                np.full((len(fsteps), len(samples)), np.nan),
-                coords={"forecast_step": fsteps, "sample": samples},
-                dims=("forecast_step", "sample"),
-                name=f"points_per_sample_{stream}",
-            )
-        else:
-            points_per_sample = None
-
-        fsteps_final = []
-
-        for fstep in fsteps:
-            _logger.info(f"RUN {run_id} - {stream}: Processing fstep {fstep}...")
-            da_tars_fs, da_preds_fs = [], []
-            pps = []
-
-            for sample in tqdm(
-                samples, desc=f"Processing {run_id} - {stream} - {fstep}"
-            ):
-                out = zio.get_data(sample, stream, fstep)
-                target, pred = out.target.as_xarray(), out.prediction.as_xarray()
-
-                if region != "global":
-                    _logger.debug(
-                        f"Applying bounding box mask for region '{region}' to targets and predictions..."
-                    )
-                    target = bbox.apply_mask(target)
-                    pred = bbox.apply_mask(pred)
-
-                npoints = len(target.ipoint)
-                if npoints == 0:
-                    _logger.info(
-                        f"Skipping {stream} sample {sample} forecast step: {fstep}. Dataset is empty."
-                    )
-                    continue
-
-                da_tars_fs.append(target.squeeze())
-                da_preds_fs.append(pred.squeeze())
-                pps.append(npoints)
-
-            if len(da_tars_fs) > 0:
-                fsteps_final.append(fstep)
-
-            _logger.debug(
-                f"Concatenating targets and predictions for stream {stream}, forecast_step {fstep}..."
-            )
-
-            if da_tars_fs:
-                da_tars_fs = xr.concat(da_tars_fs, dim="ipoint")
-                da_preds_fs = xr.concat(da_preds_fs, dim="ipoint")
-
-                if set(channels) != set(all_channels):
-                    _logger.debug(
-                        f"Restricting targets and predictions to channels {channels} for stream {stream}..."
-                    )
-                    available_channels = da_tars_fs.channel.values
-                    existing_channels = [
-                        ch for ch in channels if ch in available_channels
-                    ]
-                    if len(existing_channels) < len(channels):
-                        _logger.warning(
-                            f"The following channels were not found: {list(set(channels) - set(existing_channels))}. Skipping them."
-                        )
-
-                    da_tars_fs = da_tars_fs.sel(channel=existing_channels)
-                    da_preds_fs = da_preds_fs.sel(channel=existing_channels)
-
-                da_tars.append(da_tars_fs)
-                da_preds.append(da_preds_fs)
-            if return_counts:
-                points_per_sample.loc[{"forecast_step": fstep}] = np.array(pps)
-
-        # Safer than a list
-        da_tars = {fstep: da for fstep, da in zip(fsteps_final, da_tars, strict=False)}
-        da_preds = {
-            fstep: da for fstep, da in zip(fsteps_final, da_preds, strict=False)
-        }
-
-        return WeatherGeneratorOutput(
-            target=da_tars, prediction=da_preds, points_per_sample=points_per_sample
-        )
-
-
 def calc_scores_per_stream(
-    cfg: dict, results_dir: Path, stream: str, region: str, metrics: list[str]
+    reader: Reader, stream: str, region: str, metrics: list[str]
 ) -> tuple[xr.DataArray, xr.DataArray]:
     """
     Calculate scores for a given run and stream using the specified metrics.
 
     Parameters
     ----------
-    cfg :
-        Configuration dictionary containing all information for the evaluation.
-    results_dir : Path
-        Directory where the results are stored.
-        Expected scheme `<results_base_dir>/<run_id>`.
+    reader : Reader
+        Reader object containing all info about a particular run.
     stream :
         Stream name to calculate scores for.
     region :
@@ -218,19 +48,16 @@ def calc_scores_per_stream(
     -------
     Tuple of xarray DataArray containing the scores and the number of points per sample.
     """
-    run_id = results_dir.name
 
     _logger.info(
-        f"RUN {run_id} - {stream}: Calculating scores for metrics {metrics}..."
+        f"RUN {reader.run_id} - {stream}: Calculating scores for metrics {metrics}..."
     )
 
     checked, (channels, fsteps, samples) = check_availability(
-        cfg, stream, results_dir, mode="evaluation"
+        reader, stream, mode="evaluation"
     )
 
-    output_data = get_data(
-        cfg,
-        results_dir,
+    output_data =reader.get_data( 
         stream,
         region=region,
         fsteps=fsteps,
@@ -305,7 +132,7 @@ def calc_scores_per_stream(
 
         metric_stream.loc[{"forecast_step": int(fstep)}] = combined_metrics
 
-    _logger.info(f"Scores for run {run_id} - {stream} calculated successfully.")
+    _logger.info(f"Scores for run {reader.run_id} - {stream} calculated successfully.")
 
     metric_stream = xr.concat(metric_list, dim="forecast_step")
     metric_stream = metric_stream.assign_coords({"forecast_step": fsteps})
@@ -314,42 +141,34 @@ def calc_scores_per_stream(
 
 
 def plot_data(
-    cfg: dict,
-    run_cfg: oc.DictConfig,
-    results_dir: Path,
-    plot_dir: Path,
+    reader: Reader, 
     stream: str,
+    global_plotting_opts: dict
 ) -> list[str]:
     """
     Plot the data for a given run and stream.
 
     Parameters
     ----------
-    cfg : dict
-        Configuration dictionary containing all information for the evaluation.
-    run_cfg: dict
-        Run sub-config.
-    results_dir :
-        Directory where the inference results are stored.
-        Expected scheme `<results_base_dir>/<run_id>`.
-    plot_dir :
-        Base directory where the plots will be saved.
-    stream :
+    reader: Reader
+        Reader object containing all infos about the run
+    stream: str 
         Stream name to plot data for.
-    stream_cfg:
-        Stream sub-config.
+    global_plotting_opts: dict
+        Dictionary containing all plotting options that apply globally to all run_ids
+
     Returns
     -------
     List of plot names generated during the plotting process.
     """
-    run_id = run_cfg["run_id"]
+    run_id = reader.run_id
 
     # get stream dict from evaluation config (assumed to be part of cfg at this point)
-    stream_cfg = cfg["run_ids"][run_id]["streams"][stream]
+    stream_cfg = reader.get_stream(stream)
 
     # handle plotting settings
     plot_settings = stream_cfg.get("plotting", {})
-
+   
     # return early if no plotting is requested
     if not (
         plot_settings
@@ -362,36 +181,22 @@ def plot_data(
         return
 
     plotter_cfg = {
-        "image_format": cfg.get("image_format", "png"),
-        "dpi_val": cfg.get("dpi_val", 300),
-        "fig_size": cfg.get("fig_size", (8, 10)),
-        "plot_subtimesteps": get_stream_attr(
-            run_cfg, stream, "tokenize_spacetime", False
-        ),
+        "image_format": global_plotting_opts.get("image_format", "png"),
+        "dpi_val": global_plotting_opts.get("dpi_val", 300),
+        "fig_size": global_plotting_opts.get("fig_size", (8, 10)),
+        "plot_subtimesteps": reader.get_inference_stream_attr(stream, "tokenize_spacetime", False)
     }
 
-    plotter = Plotter(plotter_cfg, plot_dir)
+    plotter = Plotter(plotter_cfg, reader.runplot_dir)
 
     check, (plot_chs, plot_fsteps, plot_samples) = check_availability(
-        cfg, stream, results_dir, mode="plotting"
+        reader, stream, mode="plotting"
     )
 
     # Check if maps should be plotted and handle configuration if provided
     plot_maps = plot_settings.get("plot_maps", False)
     if not isinstance(plot_maps, bool):
         raise TypeError("plot_maps must be a boolean.")
-
-    if isinstance(cfg.get("global_plotting_options", False), oc.dictconfig.DictConfig):
-        if isinstance(
-            cfg.global_plotting_options.get(stream), oc.dictconfig.DictConfig
-        ):
-            maps_config = cfg.global_plotting_options.get(stream)
-        else:
-            cfg["global_plotting_options"][stream] = {}
-            maps_config = cfg.global_plotting_options.get(stream)
-    else:
-        cfg["global_plotting_options"] = {stream: {}}
-        maps_config = cfg.global_plotting_options.get(stream)
 
     # Check if histograms should be plotted
     plot_histograms = plot_settings.get("plot_histograms", False)
@@ -408,9 +213,7 @@ def plot_data(
     if plot_samples == "all":
         plot_samples = None
 
-    model_output = get_data(
-        cfg,
-        results_dir,
+    model_output = reader.get_data(
         stream,
         samples=plot_samples,
         fsteps=plot_fsteps,
@@ -423,10 +226,11 @@ def plot_data(
     if not da_tars:
         _logger.info(f"Skipping Plot Data for {stream}. Targets are empty.")
         return
-
-    maps_config = common_ranges(da_tars, da_preds, plot_chs, maps_config)
-
-    plot_names = []
+    
+    #get common ranges across all run_ids
+    if not isinstance(global_plotting_opts.get(stream), oc.DictConfig):
+        global_plotting_opts[stream] = oc.DictConfig({})
+    maps_config = common_ranges(da_tars, da_preds, plot_chs, global_plotting_opts[stream])
 
     plot_names = []
 
@@ -480,13 +284,11 @@ def plot_data(
 
 
 def metric_list_to_json(
+    reader: Reader, 
     metrics_list: list[xr.DataArray],
     npoints_sample_list: list[xr.DataArray],
     streams: list[str],
     region: str,
-    metric_dir: Path,
-    run_id: str,
-    epoch: int,
 ):
     """
     Write the evaluation results collected in a list of xarray DataArrays for the metrics
@@ -494,6 +296,8 @@ def metric_list_to_json(
 
     Parameters
     ----------
+    reader: 
+        Reader object containing all info about the run_id.
     metrics_list :
         Metrics per stream.
     npoints_sample_list :
@@ -513,7 +317,7 @@ def metric_list_to_json(
         "The lengths of metrics_list, npoints_sample_list, and streams must be the same."
     )
 
-    metric_dir.mkdir(parents=True, exist_ok=True)
+    reader.metrics_dir.mkdir(parents=True, exist_ok=True)
 
     for s_idx, stream in enumerate(streams):
         metrics_stream, npoints_sample_stream = (
@@ -532,8 +336,8 @@ def metric_list_to_json(
 
             # Match the expected filename pattern
             save_path = (
-                metric_dir
-                / f"{run_id}_{stream}_{region}_{metric}_epoch{epoch:05d}.json"
+                reader.metrics_dir
+                / f"{reader.run_id}_{stream}_{region}_{metric}_epoch{reader.epoch}.json"
             )
 
             _logger.info(f"Saving results to {save_path}")
@@ -541,30 +345,26 @@ def metric_list_to_json(
                 json.dump(metric_dict, f, indent=4)
 
     _logger.info(
-        f"Saved all results of inference run {run_id} - epoch {epoch:d} successfully to {metric_dir}."
+        f"Saved all results of inference run {reader.run_id} - epoch {reader.epoch:d} successfully to {reader.metrics_dir}."
     )
 
 
 def retrieve_metric_from_json(
-    metric_dir: str, run_id: str, stream: str, region: str, metric: str, epoch: int
+    reader: Reader, stream: str, region: str, metric: str
 ):
     """
     Retrieve the score for a given run, stream, metric, epoch, and rank from a JSON file.
 
     Parameters
     ----------
-    metric_dir :
-        Directory where JSON files are stored.
-    run_id :
-        Run identifier.
+    reader :
+        Reader object containing all info for a specific run_id
     stream :
         Stream name.
     region :
         Region name.
     metric :
         Metric name.
-    epoch :
-        Epoch number.
 
     Returns
     -------
@@ -572,7 +372,7 @@ def retrieve_metric_from_json(
         The metric DataArray.
     """
     score_path = (
-        Path(metric_dir) / f"{run_id}_{stream}_{region}_{metric}_epoch{epoch:05d}.json"
+        Path(reader.metrics_dir) / f"{reader.run_id}_{stream}_{region}_{metric}_epoch{reader.epoch:05d}.json"
     )
     _logger.debug(f"Looking for: {score_path}")
 
@@ -602,8 +402,18 @@ def plot_summary(cfg: dict, scores_dict: dict, summary_dir: Path):
     metrics = cfg.evaluation.metrics
     print_summary = cfg.evaluation.get("print_summary", False)
     regions = cfg.evaluation.get("regions", ["global"])
+    plt_opt = cfg.get("global_plotting_options", {})
+    eval_opt = cfg.get("evaluation", {})
 
-    plotter = LinePlots(cfg, summary_dir)
+    plot_cfg = {
+        "image_format" : plt_opt.get("image_format", "png"), 
+        "dpi_val": plt_opt.get("dpi_val", 300), 
+        "fig_size": plt_opt.get("fig_size", (8, 10)), 
+        "log_scale": eval_opt.get("log_scale", False), 
+        "add_grid": eval_opt.get("add_grid", False), 
+    }
+
+    plotter = LinePlots(plot_cfg, summary_dir)
 
     for region in regions:
         for metric in metrics:
@@ -612,8 +422,7 @@ def plot_summary(cfg: dict, scores_dict: dict, summary_dir: Path):
             )
 
 
-############# Utility functions ############
-
+############# Utility functions ############    
 
 def common_ranges(
     data_tars: list[dict],
@@ -717,33 +526,6 @@ def calc_bounds(
     return list_bound
 
 
-def peek_tar_channels(zio: ZarrIO, stream: str, fstep: int = 0) -> list[str]:
-    """
-    Peek the channels of a target stream in a ZarrIO object.
-
-    Parameters
-    ----------
-    zio :
-        The ZarrIO object containing the tar stream.
-    stream :
-        The name of the tar stream to peek.
-    fstep :
-        The forecast step to peek. Default is 0.
-    Returns
-    -------
-    channels :
-        A list of channel names in the tar stream.
-    """
-    if not isinstance(zio, ZarrIO):
-        raise TypeError("zio must be an instance of ZarrIO")
-
-    dummy_out = zio.get_data(0, stream, fstep)
-    channels = dummy_out.target.channels
-    _logger.debug(f"Peeked channels for stream {stream}: {channels}")
-
-    return channels
-
-
 def scalar_coord_to_dim(da: xr.DataArray, name: str, axis: int = -1) -> xr.DataArray:
     """
     Convert a scalar coordinate to a dimension in an xarray DataArray.
@@ -772,9 +554,8 @@ def scalar_coord_to_dim(da: xr.DataArray, name: str, axis: int = -1) -> xr.DataA
 
 
 def check_availability(
-    cfg: dict,
-    stream: str,
-    results_dir: Path,
+    reader: Reader,
+    stream: str, 
     available_data: dict = None,
     mode: str = "",
 ):
@@ -788,12 +569,10 @@ def check_availability(
 
     Parameters
     ----------
-    cfg :dict
-        The plot config.
+    reader : Reader
+        Reader object that handles the IO and the config for the given run_id
     stream : str
         The stream considered.
-    results_dir : Path
-        The path where the Zarr should live.
     available_data : dict, optional
         The available data loaded from JSON.
     Returns
@@ -807,10 +586,9 @@ def check_availability(
     str
         samples
     """
-    run_id = results_dir.name
 
     # fill info for requested channels, fsteps, samples
-    channels, fsteps, samples = _get_channels_fsteps_samples(cfg, run_id, stream, mode)
+    channels, fsteps, samples = _get_channels_fsteps_samples(reader, stream, mode)
 
     requested = {
         "channel": set(channels) if channels is not None else None,
@@ -831,49 +609,34 @@ def check_availability(
         else {},
     }
 
-    # fill info from zarr
-    # TODO: make fname_zarr retrieval nicer
-    epoch = cfg.get("run_ids").get(run_id).get("epoch")
-    rank = cfg.get("run_ids").get(run_id).get("rank")
-
-    fname_zarr = results_dir.joinpath(
-        f"validation_epoch{epoch:05d}_rank{rank:04d}.zarr"
-    )
-
-    if not fname_zarr.exists() or not fname_zarr.is_dir():
-        _logger.error(f"Zarr file {fname_zarr} does not exist or is not a directory.")
-        raise FileNotFoundError(
-            f"Zarr file {fname_zarr} does not exist or is not a directory."
-        )
-
-    with ZarrIO(fname_zarr) as zio:
-        zio_data = {
-            "fstep": set(int(f) for f in zio.forecast_steps),
-            "sample": set(int(s) for s in zio.samples),
-            "channel": set(peek_tar_channels(zio, stream, zio.forecast_steps[0])),
-        }
+    # fill info from reader
+    reader_data = {
+        "fstep": set(int(f) for f in reader.get_forecast_steps()),
+        "sample": set(int(s) for s in reader.get_samples()),
+        "channel": set(reader.get_channels(stream)),
+    }
 
     check = True
     corrected = False
     for name in ["channel", "fstep", "sample"]:
         if requested[name] is None:
             # Default to all in Zarr
-            requested[name] = zio_data[name]
+            requested[name] = reader_data[name]
             # If JSON exists, must exactly match
-            if available_data is not None and zio_data[name] != available[name]:
+            if available_data is not None and reader_data[name] != available[name]:
                 _logger.info(
                     f"Requested all {name}s for {mode}, but previous config was a strict subset. Recomputing."
                 )
                 check = False
 
         # Must be subset of Zarr
-        if not requested[name] <= zio_data[name]:
-            missing = requested[name] - zio_data[name]
+        if not requested[name] <= reader_data[name]:
+            missing = requested[name] - reader_data[name]
             _logger.info(
                 f"Requested {name}(s) {missing} do(es) not exist in Zarr. "
                 f"Removing missing {name}(s) for {mode}."
             )
-            requested[name] = requested[name] & zio_data[name]
+            requested[name] = requested[name] & reader_data[name]
             corrected = True
 
         # Must be a subset of available_data (if provided)
@@ -896,16 +659,14 @@ def check_availability(
     )
 
 
-def _get_channels_fsteps_samples(cfg: dict, run_id: str, stream: str, mode: str):
+def _get_channels_fsteps_samples(reader: Reader, stream: str, mode: str):
     """
     Get channels, fsteps and samples for a given run and stream from the config. Replace 'all' with None.
 
     Parameters
     ----------
-    cfg: dict
+    reader: Reader
         The plot config.
-    run: str,
-        The run considered.
     stream: str
         The stream considered.
     mode: str
@@ -924,39 +685,15 @@ def _get_channels_fsteps_samples(cfg: dict, run_id: str, stream: str, mode: str)
         "get_channels_fsteps_samples:: Mode should be either 'plotting' or 'evaluation'"
     )
 
-    samples = cfg.run_ids.get(run_id).streams.get(stream)[mode].get("sample", None)
-    fsteps = (
-        cfg.run_ids.get(run_id).streams.get(stream)[mode].get("forecast_step", None)
-    )
+    stream_cfg = reader.get_stream(stream)
+    assert stream_cfg.get(mode, False), "Mode does not exist in stream config. Please add it."
 
-    channels = cfg.run_ids.get(run_id).streams.get(stream).get("channels", None)
+    samples = stream_cfg[mode].get("sample", None)
+    fsteps = stream_cfg[mode].get("forecast_step", None)
+    channels = stream_cfg.get("channels", None)
 
     channels = None if (channels == "all" or channels is None) else list(channels)
     fsteps = None if (fsteps == "all" or fsteps is None) else list(fsteps)
     samples = None if (samples == "all" or samples is None) else list(samples)
 
     return channels, fsteps, samples
-
-
-def get_stream_attr(config: oc.DictConfig, stream_name: str, key: str, default=None):
-    """
-    Get the value of a key for a specific stream from the a model config.
-
-    Parameters:
-    ------------
-        config: dict
-            The full configuration dictionary.
-        stream_name: str
-            The name of the stream (e.g. 'ERA5').
-        key: str
-            The key to look up (e.g. 'tokenize_spacetime').
-        default: Optional
-            Value to return if not found (default: None).
-
-    Returns:
-        The parameter value if found, otherwise the default.
-    """
-    for stream in config.get("streams", []):
-        if stream.get("name") == stream_name:
-            return stream.get(key, default)
-    return default

--- a/packages/evaluate/src/weathergen/evaluate/utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils.py
@@ -19,13 +19,24 @@ from tqdm import tqdm
 
 from weathergen.common.io import ZarrIO
 from weathergen.evaluate.plot_utils import plot_metric_region
-from weathergen.evaluate.io_reader import WeatherGeneratorOutput, Reader
 from weathergen.evaluate.plotter import LinePlots, Plotter
 from weathergen.evaluate.score import VerifiedData, get_score
 from weathergen.evaluate.score_utils import  to_list
+from weathergen.evaluate.io_reader import Reader, WeatherGeneratorOutput
+from weathergen.evaluate.json_reader import JsonReader
+from weathergen.evaluate.zarr_reader import ZarrReader
 
 _logger = logging.getLogger(__name__)
 _logger.setLevel(logging.INFO)
+
+def get_reader(run, run_id, private_paths):
+    run_type = run.get("run_type", "zarr_io")
+    if run_type == "zarr_io":
+            return ZarrReader(run, run_id, private_paths)
+    elif run_type == "quaver": 
+        return JsonReader(run, run_id, private_paths)
+    else:
+        return None
 
 def calc_scores_per_stream(
     reader: Reader, stream: str, region: str, metrics: list[str]
@@ -53,8 +64,8 @@ def calc_scores_per_stream(
         f"RUN {reader.run_id} - {stream}: Calculating scores for metrics {metrics}..."
     )
 
-    checked, (channels, fsteps, samples) = check_availability(
-        reader, stream, mode="evaluation"
+    checked, (channels, fsteps, samples) = reader.check_availability(
+        stream, mode="evaluation"
     )
 
     output_data =reader.get_data( 
@@ -184,13 +195,13 @@ def plot_data(
         "image_format": global_plotting_opts.get("image_format", "png"),
         "dpi_val": global_plotting_opts.get("dpi_val", 300),
         "fig_size": global_plotting_opts.get("fig_size", (8, 10)),
-        "plot_subtimesteps": reader.get_inference_stream_attr(stream, "tokenize_spacetime", False)
+        "plot_subtimesteps": reader.plot_subtimesteps(stream),
     }
 
     plotter = Plotter(plotter_cfg, reader.runplot_dir)
 
-    check, (plot_chs, plot_fsteps, plot_samples) = check_availability(
-        reader, stream, mode="plotting"
+    check, (plot_chs, plot_fsteps, plot_samples) = reader.check_availability(
+       stream, mode="plotting"
     )
 
     # Check if maps should be plotted and handle configuration if provided
@@ -551,149 +562,3 @@ def scalar_coord_to_dim(da: xr.DataArray, name: str, axis: int = -1) -> xr.DataA
         da = da.drop_vars(name)
         da = da.expand_dims({name: [val]}, axis=axis)
     return da
-
-
-def check_availability(
-    reader: Reader,
-    stream: str, 
-    available_data: dict = None,
-    mode: str = "",
-):
-    """
-    Check if requested channels, forecast steps and samples are
-    i) available in the previously saved json if metric data is specified (return False otherwise)
-    ii) available in the Zarr file (return error otherwise)
-    Additionally, if channels, forecast steps or samples is None/'all', it will
-    i) set the variable to all available vars in Zarr file
-    ii) return True only if the respective variable contains the same indeces in JSON and Zarr (return False otherwise)
-
-    Parameters
-    ----------
-    reader : Reader
-        Reader object that handles the IO and the config for the given run_id
-    stream : str
-        The stream considered.
-    available_data : dict, optional
-        The available data loaded from JSON.
-    Returns
-    -------
-    bool
-        True/False depending on the above logic (True if metrics do not need recomputing)
-    str
-        channels
-    str
-        fsteps
-    str
-        samples
-    """
-
-    # fill info for requested channels, fsteps, samples
-    channels, fsteps, samples = _get_channels_fsteps_samples(reader, stream, mode)
-
-    requested = {
-        "channel": set(channels) if channels is not None else None,
-        "fstep": set(fsteps) if fsteps is not None else None,
-        "sample": set(samples) if samples is not None else None,
-    }
-
-    # fill info from available json file (if provided)
-    available = {
-        "channel": set(available_data["channel"].values.ravel())
-        if available_data is not None
-        else {},
-        "fstep": set(available_data["forecast_step"].values.ravel())
-        if available_data is not None
-        else {},
-        "sample": set(available_data.coords["sample"].values.ravel())
-        if available_data is not None
-        else {},
-    }
-
-    # fill info from reader
-    reader_data = {
-        "fstep": set(int(f) for f in reader.get_forecast_steps()),
-        "sample": set(int(s) for s in reader.get_samples()),
-        "channel": set(reader.get_channels(stream)),
-    }
-
-    check = True
-    corrected = False
-    for name in ["channel", "fstep", "sample"]:
-        if requested[name] is None:
-            # Default to all in Zarr
-            requested[name] = reader_data[name]
-            # If JSON exists, must exactly match
-            if available_data is not None and reader_data[name] != available[name]:
-                _logger.info(
-                    f"Requested all {name}s for {mode}, but previous config was a strict subset. Recomputing."
-                )
-                check = False
-
-        # Must be subset of Zarr
-        if not requested[name] <= reader_data[name]:
-            missing = requested[name] - reader_data[name]
-            _logger.info(
-                f"Requested {name}(s) {missing} do(es) not exist in Zarr. "
-                f"Removing missing {name}(s) for {mode}."
-            )
-            requested[name] = requested[name] & reader_data[name]
-            corrected = True
-
-        # Must be a subset of available_data (if provided)
-        if available_data is not None and not requested[name] <= available[name]:
-            missing = requested[name] - available[name]
-            _logger.info(
-                f"{name.capitalize()}(s) {missing} missing in previous evaluation. Recomputing."
-            )
-            check = False
-
-    if check and not corrected:
-        scope = "metric file" if available_data is not None else "Zarr file"
-        _logger.info(
-            f"All checks passed – All channels, samples, fsteps requested for {mode} are present in {scope}..."
-        )
-    return check, (
-        sorted(list(requested["channel"])),
-        sorted(list(requested["fstep"])),
-        sorted(list(requested["sample"])),
-    )
-
-
-def _get_channels_fsteps_samples(reader: Reader, stream: str, mode: str):
-    """
-    Get channels, fsteps and samples for a given run and stream from the config. Replace 'all' with None.
-
-    Parameters
-    ----------
-    reader: Reader
-        The plot config.
-    stream: str
-        The stream considered.
-    mode: str
-        if plotting or evaluation mode
-
-    Returns
-    -------
-    list/None
-        channels
-    list/None
-        fsteps
-    list/None
-        samples
-    """
-    assert mode == "plotting" or mode == "evaluation", (
-        "get_channels_fsteps_samples:: Mode should be either 'plotting' or 'evaluation'"
-    )
-
-    stream_cfg = reader.get_stream(stream)
-    assert stream_cfg.get(mode, False), "Mode does not exist in stream config. Please add it."
-
-    samples = stream_cfg[mode].get("sample", None)
-    fsteps = stream_cfg[mode].get("forecast_step", None)
-    channels = stream_cfg.get("channels", None)
-
-    channels = None if (channels == "all" or channels is None) else list(channels)
-    fsteps = None if (fsteps == "all" or fsteps is None) else list(fsteps)
-    samples = None if (samples == "all" or samples is None) else list(samples)
-
-    return channels, fsteps, samples

--- a/packages/evaluate/src/weathergen/evaluate/zarr_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/zarr_reader.py
@@ -1,0 +1,406 @@
+# (C) Copyright 2025 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import omegaconf as oc
+import xarray as xr
+from tqdm import tqdm
+
+from weathergen.common.io import ZarrIO
+from weathergen.evaluate.plot_utils import (
+    plot_metric_region,
+)
+from weathergen.evaluate.plotter import LinePlots, Plotter
+from weathergen.evaluate.score import VerifiedData, get_score
+from weathergen.evaluate.score_utils import RegionBoundingBox, to_list
+from weathergen.utils.config import _REPO_ROOT, load_config, load_model_config
+from weathergen.evaluate.io_reader import Reader, WeatherGeneratorOutput
+
+_logger = logging.getLogger(__name__)
+_logger.setLevel(logging.INFO)
+
+class ZarrReader(Reader):
+    """Specialized Reader for runs that include a Zarr output file."""
+
+    def __init__(self, eval_cfg: dict, run_id: str, private_paths: dict = None):
+        super().__init__(eval_cfg, run_id, private_paths)
+
+        # Load model configuration and set (run-id specific) directories
+        self.inference_cfg = self._get_inference_config() 
+
+        self.results_base_dir = self.eval_cfg.get(
+                "results_base_dir", None
+            )  # base directory where results will be stored
+
+        if not self.results_base_dir:
+            self.results_base_dir = Path(self.inference_cfg["run_path"])
+            logging.info(
+                f"Results directory obtained from model config: {self.results_base_dir}"
+            )
+        else:
+            logging.info(f"Results directory parsed: {self.results_base_dir}")
+
+        # Add zarr-specific handling
+        self.fname_zarr = self.results_dir.joinpath(
+            f"validation_epoch{self.epoch:05d}_rank{self.rank:04d}.zarr"
+        )
+
+        if not self.fname_zarr.exists() or not self.fname_zarr.is_dir():
+            _logger.error(f"Zarr file {self.fname_zarr} does not exist or is not a directory.")
+            raise FileNotFoundError(
+                f"Zarr file {self.fname_zarr} does not exist or is not a directory."
+            )
+
+    def _get_inference_config(self):
+        """
+        load the config associated to the inference run (different from the eval_cfg which contains plot and evaluaiton options.)
+
+        Returns
+        -------
+        dict
+            configuration file from the inference run
+        """
+        try: 
+            if self.private_paths:
+                _logger.info(
+                    f"Loading config for run {self.run_id} from private paths: {self.private_paths}"
+                )
+                return load_config(self.private_paths, self.run_id, self.epoch)
+            else:
+                _logger.info(
+                    f"Loading config for run {self.run_id} from model directory: {self.model_base_dir}"
+                )
+                return load_model_config(self.run_id, self.epoch, self.model_base_dir)
+        except AssertionError:
+            _logger.warning("Model config not found. inference config will be empty.")
+            return {}
+
+    def get_data(self, 
+        stream: str,
+        region: str = "global",
+        samples: list[int] = None,
+        fsteps: list[str] = None,
+        channels: list[str] = None,
+        return_counts: bool = False,
+    ) -> WeatherGeneratorOutput:
+        """
+        Retrieve prediction and target data for a given run from the Zarr store.
+
+        Parameters
+        ----------
+        cfg :
+            Configuration dictionary containing all information for the evaluation.
+        results_dir : Path
+            Directory where the inference results are stored. Expected scheme `<results_base_dir>/<run_id>`.
+        stream :
+            Stream name to retrieve data for.
+        region :
+            Region name to retrieve data for.
+        samples :
+            List of sample indices to retrieve. If None, all samples are retrieved.
+        fsteps :
+            List of forecast steps to retrieve. If None, all forecast steps are retrieved.
+        channels :
+            List of channel names to retrieve. If None, all channels are retrieved.
+        return_counts :
+            If True, also return the number of points per sample.
+
+        Returns
+        -------
+        WeatherGeneratorOutput
+            A dataclass containing:
+            - target: Dictionary of xarray DataArrays for targets, indexed by forecast step.
+            - prediction: Dictionary of xarray DataArrays for predictions, indexed by forecast step.
+            - points_per_sample: xarray DataArray containing the number of points per sample, if `return_counts` is True.
+        """
+        
+        bbox = RegionBoundingBox.from_region_name(region)
+
+        with ZarrIO(self.fname_zarr) as zio:
+            stream_cfg = self.get_stream(stream)
+            all_channels = self.get_channels(stream)
+            _logger.info(f"RUN {self.run_id}: Processing stream {stream}...")
+
+            fsteps = self.get_forecast_steps() if fsteps is None else fsteps
+
+            # TODO: Avoid conversion of fsteps and sample to integers (as obtained from the ZarrIO)
+            fsteps = sorted([int(fstep) for fstep in fsteps])
+            samples = sorted(
+                [int(sample) for sample in self.get_samples()] if samples is None else samples
+            )
+            channels = channels or stream_cfg.get("channels", all_channels)
+            channels = to_list(channels)
+
+            da_tars, da_preds = [], []
+
+            if return_counts:
+                points_per_sample = xr.DataArray(
+                    np.full((len(fsteps), len(samples)), np.nan),
+                    coords={"forecast_step": fsteps, "sample": samples},
+                    dims=("forecast_step", "sample"),
+                    name=f"points_per_sample_{stream}",
+                )
+            else:
+                points_per_sample = None
+
+            fsteps_final = []
+
+            for fstep in fsteps:
+                _logger.info(f"RUN {self.run_id} - {stream}: Processing fstep {fstep}...")
+                da_tars_fs, da_preds_fs = [], []
+                pps = []
+
+                for sample in tqdm(
+                    samples, desc=f"Processing {self.run_id} - {stream} - {fstep}"
+                ):
+                    out = zio.get_data(sample, stream, fstep)
+                    target, pred = out.target.as_xarray(), out.prediction.as_xarray()
+
+                    if region != "global":
+                        _logger.debug(
+                            f"Applying bounding box mask for region '{region}' to targets and predictions..."
+                        )
+                        target = bbox.apply_mask(target)
+                        pred = bbox.apply_mask(pred)
+
+                    npoints = len(target.ipoint)
+                    if npoints == 0:
+                        _logger.info(
+                            f"Skipping {stream} sample {sample} forecast step: {fstep}. Dataset is empty."
+                        )
+                        continue
+
+                    da_tars_fs.append(target.squeeze())
+                    da_preds_fs.append(pred.squeeze())
+                    pps.append(npoints)
+
+                if len(da_tars_fs) > 0:
+                    fsteps_final.append(fstep)
+
+                _logger.debug(
+                    f"Concatenating targets and predictions for stream {stream}, forecast_step {fstep}..."
+                )
+
+                if da_tars_fs:
+                    da_tars_fs = xr.concat(da_tars_fs, dim="ipoint")
+                    da_preds_fs = xr.concat(da_preds_fs, dim="ipoint")
+
+                    if set(channels) != set(all_channels):
+                        _logger.debug(
+                            f"Restricting targets and predictions to channels {channels} for stream {stream}..."
+                        )
+                        available_channels = da_tars_fs.channel.values
+                        existing_channels = [
+                            ch for ch in channels if ch in available_channels
+                        ]
+                        if len(existing_channels) < len(channels):
+                            _logger.warning(
+                                f"The following channels were not found: {list(set(channels) - set(existing_channels))}. Skipping them."
+                            )
+
+                        da_tars_fs = da_tars_fs.sel(channel=existing_channels)
+                        da_preds_fs = da_preds_fs.sel(channel=existing_channels)
+
+                    da_tars.append(da_tars_fs)
+                    da_preds.append(da_preds_fs)
+                if return_counts:
+                    points_per_sample.loc[{"forecast_step": fstep}] = np.array(pps)
+
+            # Safer than a list
+            da_tars = {fstep: da for fstep, da in zip(fsteps_final, da_tars, strict=False)}
+            da_preds = {
+                fstep: da for fstep, da in zip(fsteps_final, da_preds, strict=False)
+            }
+
+            return WeatherGeneratorOutput(
+                target=da_tars, prediction=da_preds, points_per_sample=points_per_sample
+            )
+
+    ######## reader utils ########
+
+    def get_samples(self):
+        with ZarrIO(self.fname_zarr) as zio:
+            return set(int(s) for s in zio.samples)
+    
+    def get_forecast_steps(self):
+        with ZarrIO(self.fname_zarr) as zio:
+            return set(int(f) for f in zio.forecast_steps)
+
+    #TODO: get this from config
+    def get_channels(self, stream: str) -> list[str]:
+        """
+        Peek the channels of a target stream.
+
+        Parameters
+        ----------
+        stream :
+            The name of the tar stream to peek.
+        fstep :
+            The forecast step to peek. Default is 0.
+        Returns
+        -------
+        channels :
+            A list of channel names in the tar stream.
+        """
+        with ZarrIO(self.fname_zarr) as zio:
+            dummy_out = zio.get_data(list(self.get_samples())[0], stream, list(self.get_forecast_steps())[0])
+            channels = dummy_out.target.channels
+            _logger.debug(f"Peeked channels for stream {stream}: {channels}")
+
+        return channels
+    
+    def plot_subtimesteps(self, stream: str):
+        """
+        automatically retrieve if the run contains fixed timesteps in the window. 
+
+        Parameters:
+        ------------
+            stream: str
+                The name of the stream (e.g. 'ERA5').
+
+        Returns:
+        --------
+        bool
+            False if it should be plotted as accumulated values (e.g. NPP-ATMS)
+            True if the stream contains multiple separate timesteps (e.g. ERA5 or CERRA)
+        """
+        return self._get_inference_stream_attr(stream, "tokenize_spacetime", False)
+
+    def _get_inference_stream_attr(self, stream_name: str, key: str, default = None):
+        """
+        Get the value of a key for a specific stream from the a model config.
+
+        Parameters:
+        ------------
+            config: dict
+                The full configuration dictionary.
+            stream_name: str
+                The name of the stream (e.g. 'ERA5').
+            key: str
+                The key to look up (e.g. 'tokenize_spacetime').
+            default: Optional
+                Value to return if not found (default: None).
+
+        Returns:
+            The parameter value if found, otherwise the default.
+        """
+        for stream in self.inference_cfg.get("streams", []):
+            if stream.get("name") == stream_name:
+                return stream.get(key, default)
+        return default
+
+    def check_availability(self, 
+        stream: str, 
+        available_data: dict = None,
+        mode: str = "",
+    ):
+        """
+        Check if requested channels, forecast steps and samples are
+        i) available in the previously saved json if metric data is specified (return False otherwise)
+        ii) available in the Zarr file (return error otherwise)
+        Additionally, if channels, forecast steps or samples is None/'all', it will
+        i) set the variable to all available vars in Zarr file
+        ii) return True only if the respective variable contains the same indeces in JSON and Zarr (return False otherwise)
+
+        Parameters
+        ----------
+        stream : str
+            The stream considered.
+        available_data : dict, optional
+            The available data loaded from JSON.
+        Returns
+        -------
+        bool
+            True/False depending on the above logic (True if metrics do not need recomputing)
+        str
+            channels
+        str
+            fsteps
+        str
+            samples
+        """
+
+        # fill info for requested channels, fsteps, samples
+        channels, fsteps, samples = self._get_channels_fsteps_samples(stream, mode)
+
+        requested = {
+            "channel": set(channels) if channels is not None else None,
+            "fstep": set(fsteps) if fsteps is not None else None,
+            "sample": set(samples) if samples is not None else None,
+        }
+
+        # fill info from available json file (if provided)
+        available = {
+            "channel": set(available_data["channel"].values.ravel())
+            if available_data is not None
+            else {},
+            "fstep": set(available_data["forecast_step"].values.ravel())
+            if available_data is not None
+            else {},
+            "sample": set(available_data.coords["sample"].values.ravel())
+            if available_data is not None
+            else {},
+        }
+
+        # fill info from reader
+        reader_data = {
+            "fstep": set(int(f) for f in self.get_forecast_steps()),
+            "sample": set(int(s) for s in self.get_samples()),
+            "channel": set(self.get_channels(stream)),
+        }
+
+        check = True
+        corrected = False
+        for name in ["channel", "fstep", "sample"]:
+            if requested[name] is None:
+                # Default to all in Zarr
+                requested[name] = reader_data[name]
+                # If JSON exists, must exactly match
+                if available_data is not None and reader_data[name] != available[name]:
+                    _logger.info(
+                        f"Requested all {name}s for {mode}, but previous config was a strict subset. Recomputing."
+                    )
+                    check = False
+
+            # Must be subset of Zarr
+            if not requested[name] <= reader_data[name]:
+                missing = requested[name] - reader_data[name]
+                _logger.info(
+                    f"Requested {name}(s) {missing} do(es) not exist in Zarr. "
+                    f"Removing missing {name}(s) for {mode}."
+                )
+                requested[name] = requested[name] & reader_data[name]
+                corrected = True
+
+            # Must be a subset of available_data (if provided)
+            if available_data is not None and not requested[name] <= available[name]:
+                missing = requested[name] - available[name]
+                _logger.info(
+                    f"{name.capitalize()}(s) {missing} missing in previous evaluation. Recomputing."
+                )
+                check = False
+
+        if check and not corrected:
+            scope = "metric file" if available_data is not None else "Zarr file"
+            _logger.info(
+                f"All checks passed – All channels, samples, fsteps requested for {mode} are present in {scope}..."
+            )
+        return check, (
+            sorted(list(requested["channel"])),
+            sorted(list(requested["fstep"])),
+            sorted(list(requested["sample"])),
+        )
+
+
+


### PR DESCRIPTION
## Description
The PR creates a Reader class as a wrapper to the WG ZarrIO + config loading steps, to store all info in one object. 
Tested on ERA5 and CERRA for multiple samples, fsteps and metrics.

## Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

closes https://github.com/ecmwf/WeatherGenerator/issues/866
closes https://github.com/ecmwf/WeatherGenerator/issues/889

## Code Compatibility

-   [ ] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory

<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.
-   [ ] I have not introduced new dependencies in the inference portion of the pipeline

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes

<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->