### PR TITLE
Add levels

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotter.py
@@ -11,8 +11,8 @@ import numpy as np
 import omegaconf as oc
 import xarray as xr
 from PIL import Image
-from weathergen.common.config import _load_private_conf
 
+from weathergen.common.config import _load_private_conf
 from weathergen.evaluate.plot_utils import DefaultMarkerSize
 
 work_dir = Path(_load_private_conf(None)["path_shared_working_dir"]) / "assets/cartopy"

--- a/packages/evaluate/src/weathergen/evaluate/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotter.py
@@ -11,8 +11,8 @@ import numpy as np
 import omegaconf as oc
 import xarray as xr
 from PIL import Image
-
 from weathergen.common.config import _load_private_conf
+
 from weathergen.evaluate.plot_utils import DefaultMarkerSize
 
 work_dir = Path(_load_private_conf(None)["path_shared_working_dir"]) / "assets/cartopy"
@@ -418,6 +418,18 @@ class Plotter:
         marker = map_kwargs_save.pop("marker", "o")
         vmin = map_kwargs_save.pop("vmin", None)
         vmax = map_kwargs_save.pop("vmax", None)
+        cmap = plt.get_cmap(map_kwargs_save.pop("colormap", "coolwarm"))
+
+        if isinstance(map_kwargs_save.get("levels", False), oc.listconfig.ListConfig):
+            norm = mpl.colors.BoundaryNorm(
+                map_kwargs_save.pop("levels", None), cmap.N, extend="both"
+            )
+        else:
+            norm = mpl.colors.Normalize(
+                vmin=vmin,
+                vmax=vmax,
+                clip=False,
+            )
 
         # scale marker size
         marker_size = marker_size_base
@@ -434,19 +446,6 @@ class Plotter:
         ax.coastlines()
 
         valid_time = str(data["valid_time"][0].values.astype("datetime64[m]"))
-
-        if isinstance(map_kwargs_save.get("levels", False), oc.listconfig.ListConfig):
-            cmap = plt.get_cmap(map_kwargs_save.pop("colormap", "coolwarm"))
-            norm = mpl.colors.BoundaryNorm(
-                map_kwargs_save.pop("levels", None), cmap.N, extend="both"
-            )
-        else:
-            cmap = plt.get_cmap(map_kwargs_save.pop("colormap", "coolwarm"))
-            norm = mpl.colors.Normalize(
-                vmin=vmin,
-                vmax=vmax,
-                clip=False,
-            )
 
         scatter_plt = ax.scatter(
             data["lon"],

--- a/packages/evaluate/src/weathergen/evaluate/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotter.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import cartopy
 import cartopy.crs as ccrs
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import omegaconf as oc
@@ -434,16 +435,28 @@ class Plotter:
 
         valid_time = str(data["valid_time"][0].values.astype("datetime64[m]"))
 
+        if isinstance(map_kwargs_save.get("levels", False), oc.listconfig.ListConfig):
+            cmap = plt.get_cmap(map_kwargs_save.pop("colormap", "coolwarm"))
+            norm = mpl.colors.BoundaryNorm(
+                map_kwargs_save.pop("levels", None), cmap.N, extend="both"
+            )
+        else:
+            cmap = plt.get_cmap(map_kwargs_save.pop("colormap", "coolwarm"))
+            norm = mpl.colors.Normalize(
+                vmin=vmin,
+                vmax=vmax,
+                clip=False,
+            )
+
         scatter_plt = ax.scatter(
             data["lon"],
             data["lat"],
             c=data,
-            cmap="coolwarm",
+            norm=norm,
+            cmap=cmap,
             s=marker_size,
             marker=marker,
             transform=ccrs.PlateCarree(),
-            vmin=vmin,
-            vmax=vmax,
             linewidths=0.0,  # only markers, avoids aliasing for very small markers
             **map_kwargs_save,
         )


### PR DESCRIPTION
## Description

This PR adds the possibility of having  uneven levels instead of a value range in the colorbar. This is particularly useful for the precipitation variable.

You can try this with an IMERG evaluation. You can do so by adding this in the `plot_config_template`:

```
global_plotting_options:
  ERA5:
    marker_size: 2
    scale_marker_size: 1
    marker: "o"
    2t: 
      vmin: 220
      vmax: 400
  IMERG:
    tp_imerg_0:
      levels: [0., 0.0001, 0.0005, 0.001, 0.0015, 0.002, 0.003, 0.005, 0.007, 0.01, 0.015, 0.02, 0.05, 0.08, 0.12, 0.15, 0.175, 0.2, 0.25]
      colormap: 'ocean_r'
```

## Issue Number

Closes #665

## Checklist before asking for review

-   [X] I have performed a self-review of my code
-   [X] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [X] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [X] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
