### PR TITLE
Add more datetime formats

### DIFF
--- a/config/ifs_fesom_config.yml
+++ b/config/ifs_fesom_config.yml
@@ -6,14 +6,14 @@ ae_local_dim_embed: 1024
 ae_local_num_blocks: 4
 ae_local_num_heads: 16
 
-start_date: 20001010000
-end_date: 219912310000
-start_date_val: 220001010000
-end_date_val: 222012310000
+start_date: 2000-10-10T00:00
+end_date: 2199-12-31T00:00
+start_date_val: 2200-01-01T00:00
+end_date_val: 2220-12-31T00:00
 
 num_epochs: 111
-samples_per_epoch: 16392
-samples_per_validation: 1024
+samples_per_epoch: 64
+samples_per_validation: 16
 shuffle: True
 loader_num_workers: 4
 

--- a/src/weathergen/datasets/data_reader_base.py
+++ b/src/weathergen/datasets/data_reader_base.py
@@ -71,8 +71,24 @@ def str_to_datetime64(s: str | int | NPDT64) -> NPDT64:
     """
     if isinstance(s, datetime64):
         return s
-    format_str = "%Y%m%d%H%M%S"
-    return np.datetime64(datetime.datetime.strptime(str(s), format_str))
+    s_str = str(s)
+
+    supported_formats = [
+        "%Y%m%d%H%M%S",
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%d %H:%M",
+        "%Y-%m-%dT%H:%M:%S",
+        "%Y-%m-%dT%H:%M",
+    ]
+
+    for fmt in supported_formats:
+        try:
+            dt_obj = datetime.datetime.strptime(s_str, fmt)
+            return np.datetime64(dt_obj)
+        except ValueError:
+            pass
+
+    raise ValueError(f"Unable to parse the date string '{s}'. Original string might be invalid.")
 
 
 def str_to_timedelta(s: str | datetime.timedelta) -> pd.Timedelta:


### PR DESCRIPTION
Add new supported datetime formats. Now in the config datetimes can be provided in three ways:

- `2000-10-10T00:00`
- `2000-10-10 00:00`
- `200010100000`

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->
Closes https://github.com/ecmwf/WeatherGenerator/issues/952

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
