### PR TITLE
[datasets] move to new cerra and new era5

### DIFF
--- a/config/streams/cerra_seviri/cerra.yml
+++ b/config/streams/cerra_seviri/cerra.yml
@@ -9,7 +9,7 @@
 
 CERRA :
   type : anemoi
-  filenames : ['cerra-rr-an-oper-0001-mars-5p5km-1984-2022-6h-v3-hmsi.zarr']
+  filenames : ['cerra-rr-an-oper-se-al-ec-mars-5p5km-1985-2023-3h-v2']
   loss_weight : 1.
   masking_rate : 0.6
   masking_rate_none : 0.05

--- a/config/streams/cerra_seviri/cerra.yml
+++ b/config/streams/cerra_seviri/cerra.yml
@@ -9,7 +9,7 @@
 
 CERRA :
   type : anemoi
-  filenames : ['cerra-rr-an-oper-se-al-ec-mars-5p5km-1985-2023-3h-v2']
+  filenames : ['cerra-rr-an-oper-se-al-ec-mars-5p5km-1985-2023-3h-v2.zarr']
   loss_weight : 1.
   masking_rate : 0.6
   masking_rate_none : 0.05

--- a/config/streams/era5_1deg/era5.yml
+++ b/config/streams/era5_1deg/era5.yml
@@ -9,7 +9,7 @@
 
 ERA5 :
   type : anemoi
-  filenames : ['aifs-ea-an-oper-0001-mars-o96-1979-2022-6h-v6.zarr']
+  filenames : ['aifs-ea-an-oper-0001-mars-o96-1979-2023-6h-v8.zarr']
   source_exclude : ['w_', 'skt', 'tcw', 'cp', 'tp']
   target_exclude : ['w_', 'slor', 'sdor', 'tcw', 'cp', 'tp']
   loss_weight : 1.

--- a/config/streams/era5_nppatms_synop/era5.yml
+++ b/config/streams/era5_nppatms_synop/era5.yml
@@ -9,7 +9,7 @@
 
 ERA5 :
   type : anemoi
-  filenames : ['aifs-ea-an-oper-0001-mars-o96-1979-2022-6h-v6.zarr']
+  filenames : ['aifs-ea-an-oper-0001-mars-o96-1979-2023-6h-v8.zarr']
   loss_weight : 1.
   source_exclude : ['w_', 'skt', 'sp', 'tcw', 'cp', 'tp']
   target_exclude : ['w_', 'skt', 'sp', 'tcw', 'cp', 'tp']


### PR DESCRIPTION
## Description

Now that the new full resolution CERRA and ERA5 v8 are available at JSC and CSCS we should change the default config to always run on the new data. 

We will delete the old versions in a couple of weeks. Tested it at JSC but it seems I can't get a node on Clariden today. 
 
## Issue Number

closes https://github.com/ecmwf/WeatherGenerator/issues/935
closes https://github.com/ecmwf/WeatherGenerator/issues/936

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
