### PR TITLE
[1000] Adding MoEMLP layer to the forecasting engine

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -24,7 +24,7 @@ ae_adapter_with_residual: True
 ae_adapter_dropout_rate: 0.1
 
 ae_global_dim_embed: 2048
-ae_global_num_blocks: 8
+ae_global_num_blocks: 2
 ae_global_num_heads: 32
 ae_global_dropout_rate: 0.1
 ae_global_with_qk_lnorm: True
@@ -42,12 +42,12 @@ pred_mlp_adaln: True
 
 # number of steps offset applied to first target window; if set to zero and forecast_steps=0 then
 # one is training an auto-encoder
-forecast_offset : 0
+forecast_offset : 1
 forecast_delta_hrs: 0
-forecast_steps: 0
-forecast_policy: null
+forecast_steps: 1
+forecast_policy: "fixed"
 forecast_att_dense_rate: 1.0
-fe_num_blocks: 0
+fe_num_blocks: 2
 fe_num_heads: 16
 fe_dropout_rate: 0.1
 fe_with_qk_lnorm: True
@@ -93,7 +93,7 @@ ema_halflife_in_thousands: 1e-3
 
 # training mode: "forecast" or "masking" (masked token modeling)
 # for "masking" to train with auto-encoder mode, forecast_offset should be 0
-training_mode: "masking"
+training_mode: "forecast"
 # masking rate when training mode is "masking"; ignored in foreacast mode
 masking_rate: 0.6
 # sample the masking rate (with normal distribution centered at masking_rate)
@@ -168,8 +168,28 @@ train_log:
   
 # Forecast MLP type: "dense" (default) or "moe"
 fe_mlp_type: "dense"    # set to "moe" to enable MoE
+ae_global_mlp_type: "dense"    # set to "moe" to enable MoE
+ffn_mlp_type: "dense"  # set to "moe" to enable MoE in the feed-forward network of the decoder blocks
+decoder_mlp_type: "dense"  # set to "moe" to enable MoE in the decoder prediction MLP
+moe_lambda: 0.02  # coefficient for the MoE load balancing loss
 
 # MoE-only params (ignored when fe_mlp_type != "moe")
-fe_moe_num_experts: 8
-fe_moe_top_k: 2
+fe_moe_num_experts: 2
+fe_moe_top_k: 1
 fe_moe_hidden_factor: 0.5   # = HF_dense / 4
+
+# MoE-only params (ignored when ae_global_mlp_type != "moe")
+ae_global_moe_num_experts: 4
+ae_global_moe_top_k: 2
+ae_global_moe_hidden_factor: 0.5   # = HF_dense / 4
+
+# MoE-only params (ignored when ffn_mlp_type != "moe")
+ffn_moe_num_experts: 2
+ffn_moe_top_k: 1
+ffn_moe_hidden_factor: 0.5   # = HF_dense / 4
+
+# MoE-only params (ignored when decoder_mlp_type != "moe")
+decoder_moe_num_experts: 2
+decoder_moe_top_k: 1
+decoder_moe_hidden_factor: 0.5   # = HF_dense / 4
+tr_mlp_hidden_factor: 2

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -155,8 +155,23 @@ desc: ""
 data_loader_rng_seed: ???
 run_id: ???
 
+<<<<<<< HEAD
 # The period to log in the training loop (in number of batch steps)
 train_log_freq:
   terminal: 10
   metrics: 20
   checkpoint: 250
+=======
+# Parameters for logging/printing in the training loop
+train_log:
+  # The period to log metrics (in number of batch steps)
+  log_interval: 20
+  
+# Forecast MLP type: "dense" (default) or "moe"
+fe_mlp_type: "dense"    # set to "moe" to enable MoE
+
+# MoE-only params (ignored when fe_mlp_type != "moe")
+fe_moe_num_experts: 8
+fe_moe_top_k: 2
+fe_moe_hidden_factor: 0.5   # = HF_dense / 4
+>>>>>>> 36fea3a (Adding MoEMLP layer to the layers file, integrate the MoE layer in Forecasting engine, and set up the config file to control the use of this layer)

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -155,13 +155,12 @@ desc: ""
 data_loader_rng_seed: ???
 run_id: ???
 
-<<<<<<< HEAD
 # The period to log in the training loop (in number of batch steps)
 train_log_freq:
   terminal: 10
   metrics: 20
   checkpoint: 250
-=======
+
 # Parameters for logging/printing in the training loop
 train_log:
   # The period to log metrics (in number of batch steps)
@@ -174,4 +173,3 @@ fe_mlp_type: "dense"    # set to "moe" to enable MoE
 fe_moe_num_experts: 8
 fe_moe_top_k: 2
 fe_moe_hidden_factor: 0.5   # = HF_dense / 4
->>>>>>> 36fea3a (Adding MoEMLP layer to the layers file, integrate the MoE layer in Forecasting engine, and set up the config file to control the use of this layer)

--- a/src/weathergen/model/layers.py
+++ b/src/weathergen/model/layers.py
@@ -10,6 +10,7 @@
 
 import torch
 import torch.nn as nn
+from typing import Optional, Tuple, Dict, Any
 
 from weathergen.model.norms import AdaLayerNorm, RMSNorm
 
@@ -93,7 +94,7 @@ class MLP(torch.nn.Module):
                 x = x + x_in.repeat([*[1 for _ in x.shape[:-1]], x.shape[-1] // x_in.shape[-1]])
 
         return x
-    
+
 class _DenseBlock(nn.Module):
     """A tiny FFN that mirrors the structure of the current MLP stack."""
     def __init__(self, dim_in, dim_hidden, dim_out, num_layers=2,
@@ -108,49 +109,67 @@ class _DenseBlock(nn.Module):
     def forward(self, x):
         return self.net(x)
 
+
 class MoEMLP(nn.Module):
     """
-    Drop-in MoE MLP (memory-friendly):
-    - Same call pattern as the current MLP: forward(*args) where args=(x, ...) and optional aux at the end
-    - Supports residual add exactly like MLP
-    - Optional AdaLayerNorm when dim_aux is provided
-    - Simple top-k router; mixes experts with streaming accumulation (no big [E, ..., D] stack)
+    Memory-friendly MoE MLP.
+
+    Features
+    --------
+    - Matches MLP call pattern: forward(*args) where args=(x, ...) and optional aux at the end
+    - Optional AdaLayerNorm pre-norm when dim_aux is provided
+    - Top-k routing with softmax over selected logits
+    - Streams experts and accumulates outputs (no large [E, ..., D] stacks)
+    - Optional auxiliary outputs (gate loss, route histogram) via `return_aux`
+
+    Notes
+    -----
+    - If `return_aux=False` (default), we still *compute* the aux loss (with grads) and stash it
+      on `self.last_aux` and `self.last_aux_loss` so you can read it after forward if desired.
+    - To actively use the load-balancing loss in training, either set `return_aux=True` and add it
+      to your loss, or read `self.last_aux['gate_loss']` from the module instance.
     """
     def __init__(
         self,
-        dim_in,
-        dim_out,
-        num_layers=2,
-        hidden_factor=2,
-        pre_layer_norm=True,
-        dropout_rate=0.0,
+        dim_in: int,
+        dim_out: int,
+        num_layers: int = 2,
+        hidden_factor: float = 2.0,
+        pre_layer_norm: bool = True,
+        dropout_rate: float = 0.0,
         nonlin=nn.GELU,
-        with_residual=False,
-        norm_type="LayerNorm",
-        dim_aux=None,
-        norm_eps=1e-5,
-        name: str | None = None,
-        # MoE bits
+        with_residual: bool = False,
+        norm_type: str = "LayerNorm",
+        dim_aux: Optional[int] = None,
+        norm_eps: float = 1e-5,
+        name: Optional[str] = None,
+        # MoE
         num_experts: int = 8,
         top_k: int = 4,
-        router_noisy_std: float = 0.0,  # set >0 to add noise to router logits
-        # Memory bits
-        use_checkpoint: bool = False,    # checkpoint expert forward to save memory
+        router_noisy_std: float = 0.0,
+        # Memory
+        use_checkpoint: bool = False,
+        # API
+        return_aux: bool = False,
     ):
         super().__init__()
         if name is not None:
             self.name = name
 
-        assert num_layers >= 2
-        assert 1 <= top_k <= num_experts
+        assert num_layers >= 2, "MoEMLP requires at least 2 layers"
+        assert 1 <= top_k <= num_experts, "top_k must be in [1, num_experts]"
 
         self.with_residual = with_residual
         self.with_aux = dim_aux is not None
         self.pre_layer_norm = pre_layer_norm
         self.top_k = top_k
         self.num_experts = num_experts
+        self.router_noisy_std = router_noisy_std
         self.use_checkpoint = use_checkpoint
+        self.return_aux = return_aux
+        self.enable_gate_loss = True
 
+        self.register_buffer("usage_buf", torch.zeros(num_experts), persistent=False)
         dim_hidden = int(dim_in * hidden_factor)
 
         # Norm (match MLP behavior)
@@ -162,13 +181,15 @@ class MoEMLP(nn.Module):
                 else AdaLayerNorm(dim_in, dim_aux, norm_eps=norm_eps)
             )
         else:
-            self.norm = None  # no pre-norm
+            self.norm = None
 
         # Router
         self.router = nn.Linear(dim_in, num_experts)
-        self.router_noisy_std = router_noisy_std
+        # Recommended init: small std, zero bias
+        nn.init.normal_(self.router.weight, mean=0.0, std=1e-2)
+        nn.init.constant_(self.router.bias, 0.0)
 
-        # Experts (identical shape)
+        # Experts
         self.experts = nn.ModuleList(
             [
                 _DenseBlock(
@@ -183,107 +204,98 @@ class MoEMLP(nn.Module):
             ]
         )
 
-        # For optional aux loss (load-balancing); not used unless you read it
+        # Stashed aux for consumers that don't use return_aux
         self.register_buffer("last_aux_loss", torch.zeros((), dtype=torch.float32))
+        self.last_aux: Dict[str, torch.Tensor] = {}
 
-    def _gate(self, x_norm):
-        # x_norm: [*, D]. Router works on the last dim.
+    def _gate(self, x_norm: torch.Tensor) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        """
+        Returns:
+            weights: [..., E] if top_k == E else [..., K]
+            top_idx: None if full softmax, else [..., K] int indices
+        """
         logits = self.router(x_norm)
         if self.router_noisy_std > 0:
             logits = logits + torch.randn_like(logits) * self.router_noisy_std
 
         if self.top_k == self.num_experts:
-            # softmax over all experts
-            weights = torch.softmax(logits, dim=-1)  # [..., E]
-            top_idx = None  # not needed
+            weights = torch.softmax(logits, dim=-1)
+            top_idx = None
         else:
-            # top-k softmax
-            top_vals, top_idx = torch.topk(logits, k=self.top_k, dim=-1)  # [*, k]
-            weights = torch.softmax(top_vals, dim=-1)                      # [*, k]
+            top_vals, top_idx = torch.topk(logits, k=self.top_k, dim=-1)
+            weights = torch.softmax(top_vals, dim=-1)
         return weights, top_idx
 
-    @torch.no_grad()
-    def _compute_load_balance_aux(self, weights, top_idx, num_experts):
+    def _compute_load_balance_aux(
+        self, weights: torch.Tensor, top_idx: Optional[torch.Tensor], num_experts: int
+    ) -> torch.Tensor:
         """
-        Simple load-balancing penalty from Switch/MoE papers:
-        Encourage uniform expert probability and uniform usage.
-        Works with both full-softmax (top_idx None) and top-k.
+        Cross-entropy between observed expert usage and uniform 1/E target.
+        Works for both full-softmax and top-k.
         """
         if top_idx is None:
-            # weights over E
+            # weights over E -> average across batch/time dims
             probs = weights.mean(dim=tuple(range(weights.dim() - 1)))  # [E]
         else:
-            # Build usage over experts from top-k selection
-            # *prefix, K = weights.shape
-            # flat_w = weights.reshape(-1, K)         # [N, K]
-            # flat_i = top_idx.reshape(-1, K)         # [N, K]
+            # Aggregate usage from top-k selections
             if weights.shape != top_idx.shape:
-                raise ValueError(
-                    "Top-k weights and indices must share the same shape"
-                )
-
+                raise ValueError("Top-k weights and indices must share the same shape")
             K = weights.shape[-1]
             flat_w = weights.reshape(-1, K)  # [N, K]
             flat_i = top_idx.reshape(-1, K)  # [N, K]
-            E = num_experts
-            usage = torch.zeros(E, device=weights.device, dtype=weights.dtype)
+            usage = torch.zeros(num_experts, device=weights.device, dtype=weights.dtype)
             usage.scatter_add_(0, flat_i.reshape(-1), flat_w.reshape(-1))
-            usage = usage / usage.sum().clamp_min(1e-6)  # normalize
-            probs = usage  # proxy
-        # Target is uniform 1/E
+            probs = usage / usage.sum().clamp_min(1e-6)  # [E]
+
         E = num_experts
         target = torch.full_like(probs, 1.0 / E)
         aux = (probs * (probs.add(1e-6).log() - target.add(1e-6).log())).sum()
         return aux
 
     def forward(self, *args):
-        # Match your MLP(*args) calling convention
+        """
+        Args:
+            *args: expects x first; if AdaLN is enabled (dim_aux != None), the last arg is aux.
+
+        Returns:
+            y or (y, aux_out) depending on `self.return_aux`.
+            aux_out = {"gate_loss": ..., "route_hist": ...}
+        """
         x = args[0]
         x_in = x
-        aux = args[-1] if self.with_aux else None
+        aux_in = args[-1] if self.with_aux else None
 
-        # Optional pre-norm (possibly adaptive)
+        # Optional pre-norm
         if self.norm is not None:
-            if self.with_aux:
-                x = self.norm(x, aux)
-            else:
-                x = self.norm(x)
+            x = self.norm(x, aux_in) if self.with_aux else self.norm(x)
 
-        # Router
-        weights, top_idx = self._gate(x)  # weights: [..., E] or [..., K]
+        # Routing
+        weights, top_idx = self._gate(x)  # [..., E] or [..., K]
 
-        # Build a full weight tensor [..., E] if we are in top-k mode,
-        # so we can stream over experts without stacking their outputs.
+        # Build full weights when in top-k mode to stream experts
         if top_idx is None:
             w_full = weights  # [..., E]
         else:
-            # scatter top-k weights into a zero tensor of size E
             E = self.num_experts
-            w_full = torch.zeros(*weights.shape[:-1], E, device=weights.device, dtype=weights.dtype)  # [..., E]
+            w_full = torch.zeros(*weights.shape[:-1], E, device=weights.device, dtype=weights.dtype)
             w_full.scatter_(-1, top_idx, weights)
 
-        # Output accumulator (no expert stacking)
+        # Accumulate outputs without stacking
         out_dim = self.experts[0].net[-1].out_features  # last Linear of _DenseBlock
         y = x.new_zeros(*x.shape[:-1], out_dim)
 
-        # Optional gradient checkpoint
-        if self.use_checkpoint:
+        if self.use_checkpoint and self.training:
             from torch.utils.checkpoint import checkpoint
 
-        # Stream over experts: y += expert(x) * w_full[..., e]
         for e, expert in enumerate(self.experts):
-            # skip compute if weight mass is (nearly) zero for this expert
             w_e = w_full[..., e]  # [...]
-            if torch.allclose(w_e, torch.zeros((), device=w_e.device, dtype=w_e.dtype)):
+            # Skip experts with (near) zero mass
+            if w_e.abs().max() <= 1e-12:
                 continue
-
-            if self.use_checkpoint and self.training:
-                y_e = checkpoint(expert, x)
-            else:
-                y_e = expert(x)
+            y_e = expert(x) if not (self.use_checkpoint and self.training) else checkpoint(expert, x)
             y = y + y_e * w_e.unsqueeze(-1)
 
-        # Residual (same logic as your MLP)
+        # Residual
         if self.with_residual:
             if y.shape[-1] == x_in.shape[-1]:
                 y = x_in + y
@@ -291,14 +303,52 @@ class MoEMLP(nn.Module):
                 assert y.shape[-1] % x_in.shape[-1] == 0
                 y = y + x_in.repeat([*[1 for _ in y.shape[:-1]], y.shape[-1] // x_in.shape[-1]])
 
-        # Optional: update aux loss (not returned; read if you want)
-        with torch.no_grad():
-            self.last_aux_loss = self._compute_load_balance_aux(
-                # w_full if top_idx is not None else weights,  # use full probs if we built them
-                # None if top_idx is None else top_idx,
-                weights,
-                top_idx,                
-                self.num_experts,
-            )
+        # # Aux outputs (WITH grads so router learns; also stash for external access)
+        # aux_out: Dict[str, Any] = {}
+        # gate_loss = self._compute_load_balance_aux(weights, top_idx, self.num_experts)
+        # aux_out["gate_loss"] = gate_loss
 
-        return y
+        # # utilization histogram (for logging)
+        # if top_idx is None:
+        #     aux_out["route_hist"] = weights.mean(dim=tuple(range(weights.dim() - 1)))  # [E]
+        # else:
+        #     K = weights.shape[-1]
+        #     flat_w = weights.reshape(-1, K)
+        #     flat_i = top_idx.reshape(-1, K)
+        #     usage = torch.zeros(self.num_experts, device=weights.device, dtype=weights.dtype)
+        #     usage.scatter_add_(0, flat_i.reshape(-1), flat_w.reshape(-1))
+        #     aux_out["route_hist"] = usage / usage.sum().clamp_min(1e-6)  # [E]
+
+        # # stash for consumers that don't use return_aux
+        # self.last_aux = aux_out
+        # self.last_aux_loss = gate_loss
+
+        # return (y, aux_out) if self.return_aux else y
+        # --- Aux outputs (gate loss + route hist) ---
+        aux_out: Dict[str, Any] = {}
+        if self.enable_gate_loss:
+            gate_loss = self._compute_load_balance_aux(weights, top_idx, self.num_experts)
+            aux_out["gate_loss"] = gate_loss
+
+            # utilization histogram (for logging / debugging only)
+            if top_idx is None:
+                aux_out["route_hist"] = weights.mean(dim=tuple(range(weights.dim() - 1)))  # [E]
+            else:
+                K = weights.shape[-1]
+                flat_w = weights.reshape(-1, K)
+                flat_i = top_idx.reshape(-1, K)
+                usage = self.usage_buf
+                usage = usage.to(weights.device, dtype=weights.dtype)
+                usage.zero_()
+                usage.scatter_add_(0, flat_i.reshape(-1), flat_w.reshape(-1))
+                aux_out["route_hist"] = usage / usage.sum().clamp_min(1e-6)  # [E]
+        else:
+            # no aux computation this step
+            pass
+
+        # stash
+        self.last_aux = aux_out
+        if "gate_loss" in aux_out:
+            self.last_aux_loss = aux_out["gate_loss"]
+
+        return (y, aux_out) if self.return_aux else y

--- a/src/weathergen/model/layers.py
+++ b/src/weathergen/model/layers.py
@@ -93,3 +93,212 @@ class MLP(torch.nn.Module):
                 x = x + x_in.repeat([*[1 for _ in x.shape[:-1]], x.shape[-1] // x_in.shape[-1]])
 
         return x
+    
+class _DenseBlock(nn.Module):
+    """A tiny FFN that mirrors the structure of the current MLP stack."""
+    def __init__(self, dim_in, dim_hidden, dim_out, num_layers=2,
+                 nonlin=nn.GELU, dropout_rate=0.0):
+        super().__init__()
+        layers = [nn.Linear(dim_in, dim_hidden), nonlin(), nn.Dropout(dropout_rate)]
+        for _ in range(num_layers - 2):
+            layers += [nn.Linear(dim_hidden, dim_hidden), nonlin(), nn.Dropout(dropout_rate)]
+        layers += [nn.Linear(dim_hidden, dim_out)]
+        self.net = nn.Sequential(*layers)
+
+    def forward(self, x):
+        return self.net(x)
+
+class MoEMLP(nn.Module):
+    """
+    Drop-in MoE MLP (memory-friendly):
+    - Same call pattern as the current MLP: forward(*args) where args=(x, ...) and optional aux at the end
+    - Supports residual add exactly like MLP
+    - Optional AdaLayerNorm when dim_aux is provided
+    - Simple top-k router; mixes experts with streaming accumulation (no big [E, ..., D] stack)
+    """
+    def __init__(
+        self,
+        dim_in,
+        dim_out,
+        num_layers=2,
+        hidden_factor=2,
+        pre_layer_norm=True,
+        dropout_rate=0.0,
+        nonlin=nn.GELU,
+        with_residual=False,
+        norm_type="LayerNorm",
+        dim_aux=None,
+        norm_eps=1e-5,
+        name: str | None = None,
+        # MoE bits
+        num_experts: int = 8,
+        top_k: int = 4,
+        router_noisy_std: float = 0.0,  # set >0 to add noise to router logits
+        # Memory bits
+        use_checkpoint: bool = False,    # checkpoint expert forward to save memory
+    ):
+        super().__init__()
+        if name is not None:
+            self.name = name
+
+        assert num_layers >= 2
+        assert 1 <= top_k <= num_experts
+
+        self.with_residual = with_residual
+        self.with_aux = dim_aux is not None
+        self.pre_layer_norm = pre_layer_norm
+        self.top_k = top_k
+        self.num_experts = num_experts
+        self.use_checkpoint = use_checkpoint
+
+        dim_hidden = int(dim_in * hidden_factor)
+
+        # Norm (match MLP behavior)
+        Norm = nn.LayerNorm if norm_type == "LayerNorm" else RMSNorm
+        if pre_layer_norm:
+            self.norm = (
+                Norm(dim_in, eps=norm_eps)
+                if dim_aux is None
+                else AdaLayerNorm(dim_in, dim_aux, norm_eps=norm_eps)
+            )
+        else:
+            self.norm = None  # no pre-norm
+
+        # Router
+        self.router = nn.Linear(dim_in, num_experts)
+        self.router_noisy_std = router_noisy_std
+
+        # Experts (identical shape)
+        self.experts = nn.ModuleList(
+            [
+                _DenseBlock(
+                    dim_in=dim_in,
+                    dim_hidden=dim_hidden,
+                    dim_out=dim_out,
+                    num_layers=num_layers,
+                    nonlin=nonlin,
+                    dropout_rate=dropout_rate,
+                )
+                for _ in range(num_experts)
+            ]
+        )
+
+        # For optional aux loss (load-balancing); not used unless you read it
+        self.register_buffer("last_aux_loss", torch.zeros((), dtype=torch.float32))
+
+    def _gate(self, x_norm):
+        # x_norm: [*, D]. Router works on the last dim.
+        logits = self.router(x_norm)
+        if self.router_noisy_std > 0:
+            logits = logits + torch.randn_like(logits) * self.router_noisy_std
+
+        if self.top_k == self.num_experts:
+            # softmax over all experts
+            weights = torch.softmax(logits, dim=-1)  # [..., E]
+            top_idx = None  # not needed
+        else:
+            # top-k softmax
+            top_vals, top_idx = torch.topk(logits, k=self.top_k, dim=-1)  # [*, k]
+            weights = torch.softmax(top_vals, dim=-1)                      # [*, k]
+        return weights, top_idx
+
+    @torch.no_grad()
+    def _compute_load_balance_aux(self, weights, top_idx, num_experts):
+        """
+        Simple load-balancing penalty from Switch/MoE papers:
+        Encourage uniform expert probability and uniform usage.
+        Works with both full-softmax (top_idx None) and top-k.
+        """
+        if top_idx is None:
+            # weights over E
+            probs = weights.mean(dim=tuple(range(weights.dim() - 1)))  # [E]
+        else:
+            # Build usage over experts from top-k selection
+            # *prefix, K = weights.shape
+            # flat_w = weights.reshape(-1, K)         # [N, K]
+            # flat_i = top_idx.reshape(-1, K)         # [N, K]
+            if weights.shape != top_idx.shape:
+                raise ValueError(
+                    "Top-k weights and indices must share the same shape"
+                )
+
+            K = weights.shape[-1]
+            flat_w = weights.reshape(-1, K)  # [N, K]
+            flat_i = top_idx.reshape(-1, K)  # [N, K]
+            E = num_experts
+            usage = torch.zeros(E, device=weights.device, dtype=weights.dtype)
+            usage.scatter_add_(0, flat_i.reshape(-1), flat_w.reshape(-1))
+            usage = usage / usage.sum().clamp_min(1e-6)  # normalize
+            probs = usage  # proxy
+        # Target is uniform 1/E
+        E = num_experts
+        target = torch.full_like(probs, 1.0 / E)
+        aux = (probs * (probs.add(1e-6).log() - target.add(1e-6).log())).sum()
+        return aux
+
+    def forward(self, *args):
+        # Match your MLP(*args) calling convention
+        x = args[0]
+        x_in = x
+        aux = args[-1] if self.with_aux else None
+
+        # Optional pre-norm (possibly adaptive)
+        if self.norm is not None:
+            if self.with_aux:
+                x = self.norm(x, aux)
+            else:
+                x = self.norm(x)
+
+        # Router
+        weights, top_idx = self._gate(x)  # weights: [..., E] or [..., K]
+
+        # Build a full weight tensor [..., E] if we are in top-k mode,
+        # so we can stream over experts without stacking their outputs.
+        if top_idx is None:
+            w_full = weights  # [..., E]
+        else:
+            # scatter top-k weights into a zero tensor of size E
+            E = self.num_experts
+            w_full = torch.zeros(*weights.shape[:-1], E, device=weights.device, dtype=weights.dtype)  # [..., E]
+            w_full.scatter_(-1, top_idx, weights)
+
+        # Output accumulator (no expert stacking)
+        out_dim = self.experts[0].net[-1].out_features  # last Linear of _DenseBlock
+        y = x.new_zeros(*x.shape[:-1], out_dim)
+
+        # Optional gradient checkpoint
+        if self.use_checkpoint:
+            from torch.utils.checkpoint import checkpoint
+
+        # Stream over experts: y += expert(x) * w_full[..., e]
+        for e, expert in enumerate(self.experts):
+            # skip compute if weight mass is (nearly) zero for this expert
+            w_e = w_full[..., e]  # [...]
+            if torch.allclose(w_e, torch.zeros((), device=w_e.device, dtype=w_e.dtype)):
+                continue
+
+            if self.use_checkpoint and self.training:
+                y_e = checkpoint(expert, x)
+            else:
+                y_e = expert(x)
+            y = y + y_e * w_e.unsqueeze(-1)
+
+        # Residual (same logic as your MLP)
+        if self.with_residual:
+            if y.shape[-1] == x_in.shape[-1]:
+                y = x_in + y
+            else:
+                assert y.shape[-1] % x_in.shape[-1] == 0
+                y = y + x_in.repeat([*[1 for _ in y.shape[:-1]], y.shape[-1] // x_in.shape[-1]])
+
+        # Optional: update aux loss (not returned; read if you want)
+        with torch.no_grad():
+            self.last_aux_loss = self._compute_load_balance_aux(
+                # w_full if top_idx is not None else weights,  # use full probs if we built them
+                # None if top_idx is None else top_idx,
+                weights,
+                top_idx,                
+                self.num_experts,
+            )
+
+        return y


### PR DESCRIPTION
## Description
This draft PR introduces an experimental Mixture-of-Experts (MoE) MLP block as a drop-in replacement for the standard dense MLP in the Forecasting Engine.
The goal is to improve predictive skill and increase model capacity by encouraging expert specialization for different atmospheric regimes.

Key Changes:
Interface Preservation: The MoE block maintains the existing forward(*args) signature.
Architecture: Implements a lightweight top-k router and multiple small FFN experts (configurable num_experts, top_k).
Control: Enabled via a config flag (e.g., fe_mlp_type: "moe") for easy testing.

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number
Closes #1000 
<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

This is a draft PR.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
