### PR TITLE
Fix change rate calculation by aligning s1 with s0

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/score.py
@@ -642,9 +642,7 @@ class Scores:
         if s1 is None:
             return xr.full_like(s0, np.nan)
         else:
-            crate = np.abs(s0 - s1)
-            # Preserve all coordinates from s0 (alternative: use s1.values above)
-            crate = crate.assign_coords(s0.coords)
+            crate = np.abs(s0 - s1.values)
             return crate
 
     def calc_froct(

--- a/packages/evaluate/src/weathergen/evaluate/utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils.py
@@ -68,7 +68,7 @@ def get_next_data(fstep, da_preds, da_tars, fsteps):
         tars_next = da_tars.get(next_fstep, None)
         tars = da_tars.get(fstep, None)
         preds = da_preds.get(fstep, None)
-        
+
         # Reindex to match the current forecast step's coordinates if necessary
         preds_next = sort_by_coords(preds_next, preds)
         tars_next = sort_by_coords(tars_next, tars)


### PR DESCRIPTION
## Description

Fix change rate calculation by aligning s1 with s0


## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/994

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
