### PR TITLE
[939] run label action within context of repo

### DIFF
--- a/.github/workflows/pr_assign_labels.yml
+++ b/.github/workflows/pr_assign_labels.yml
@@ -15,9 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
+      - name: Use the token in a script
+        run: |
+          echo "Token starts with: ${MYTOKEN:0:4}"
+        env:
+          MYTOKEN: ${{ secrets.BKASIC_FOR_WEATHERGEN }}
+
       - name: Apply issue labels to PR
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.BKASIC_FOR_WEATHERGEN }}
           script: |
             const {owner, repo} = context.repo;
             const prNumber = context.payload.pull_request.number;

--- a/.github/workflows/pr_assign_labels.yml
+++ b/.github/workflows/pr_assign_labels.yml
@@ -2,12 +2,17 @@
 name: Sync issue labels to PR
 
 on:
-  pull_request:
+  # This runs the action within the context of the base branch, allowing it to access secrets.
+  # This is necessary because the action changes the labels (disallowed to external contributors).
+  # No other actions should be taken.
+  pull_request_target:
     types: [opened, edited, reopened, synchronize, ready_for_review]
 
 permissions:
+  # Make permissions as restrictive as possible.
+  # The action needs to read PR details and modify labels.
   pull-requests: write
-  contents: write
+  contents: read
   issues: write
 
 jobs:


### PR DESCRIPTION
## Description

Impact should be limited since it is only for labeling action

## Issue Number


## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
