### PR TITLE
Add Coordinate System Conversion to DataReaderFesom

### DIFF
--- a/src/weathergen/datasets/data_reader_base.py
+++ b/src/weathergen/datasets/data_reader_base.py
@@ -278,6 +278,8 @@ def check_reader_data(rdata: ReaderData, dtr: DTRange) -> None:
 class DataReaderBase(metaclass=ABCMeta):
     """
     Base class for data readers.
+
+    Coordinates must be provided in standard geographical format: latitude in degrees from -90 (South) to +90 (North), and longitude in degrees from -180 (West) to +180 (East).
     """
 
     # The fields that need to be set by the child classes

--- a/src/weathergen/datasets/data_reader_base.py
+++ b/src/weathergen/datasets/data_reader_base.py
@@ -279,7 +279,9 @@ class DataReaderBase(metaclass=ABCMeta):
     """
     Base class for data readers.
 
-    Coordinates must be provided in standard geographical format: latitude in degrees from -90 (South) to +90 (North), and longitude in degrees from -180 (West) to +180 (East).
+    Coordinates must be provided in standard geographical format:
+    latitude in degrees from -90 (South) to +90 (North),
+    and longitude in degrees from -180 (West) to +180 (East).
     """
 
     # The fields that need to be set by the child classes


### PR DESCRIPTION
## Description
This pull request makes the DataReaderFesom class robust to variations in input coordinate system formats.

Previously, the tokenizer silently assumed a latitude: [-90, 90] and longitude: [-180, 180] format. This undocumented requirement caused silent data corruption and training failures if a dataset used a different convention (e.g., colatitude [0, 180]). This information was added to docstring of `DataReaderBase`

Great thanks to @ankitpatnala for spotting this issue. 

## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/1018

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
