### PR TITLE
Ensure sample coordinate is repeated along ipoint for single sample case

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/io_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io_reader.py
@@ -467,6 +467,14 @@ class WeatherGenReader(Reader):
                 if da_tars_fs:
                     da_tars_fs = xr.concat(da_tars_fs, dim="ipoint")
                     da_preds_fs = xr.concat(da_preds_fs, dim="ipoint")
+                    if len(samples) == 1:
+                        # Ensure sample coordinate is repeated along ipoint even if only one sample
+                        da_tars_fs = da_tars_fs.assign_coords(
+                            sample=("ipoint", np.repeat(da_tars_fs.sample.values, len(da_tars_fs.ipoint)))
+                        )
+                        da_preds_fs = da_preds_fs.assign_coords(
+                            sample=("ipoint", np.repeat(da_preds_fs.sample.values, len(da_preds_fs.ipoint)))
+                        )
 
                     if set(channels) != set(all_channels):
                         _logger.debug(


### PR DESCRIPTION
## Description

Ensure sample coordinate is repeated along ipoint for single sample evaluation. Sample coord was previously lost in that case and led to error


## Issue Number
Closes https://github.com/ecmwf/WeatherGenerator/issues/885

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
