### PR TITLE
Optimize pos enc harmonic

### DIFF
--- a/src/weathergen/model/positional_encoding.py
+++ b/src/weathergen/model/positional_encoding.py
@@ -19,12 +19,14 @@ def positional_encoding_harmonic(x):
 
     dim_embed = x.shape[-1]
     dev = x.device
-    dtype = x.dtype 
+    dtype = x.dtype
 
     len_token_seq = x.shape[-2]
     pe = torch.zeros(len_token_seq, dim_embed, device=dev, dtype=dtype)
     position = torch.arange(0, len_token_seq, device=dev, dtype=dtype).unsqueeze(1)
-    div = torch.exp(torch.arange(0, dim_embed, 2, device=dev, dtype=dtype) * -(math.log(10000) / dim_embed))
+    div = torch.exp(
+        torch.arange(0, dim_embed, 2, device=dev, dtype=dtype) * -(math.log(10000) / dim_embed)
+    )
 
     pe[:, 0::2] = torch.sin(position * div[: pe[:, 0::2].shape[1]])
     pe[:, 1::2] = torch.cos(position * div[: pe[:, 1::2].shape[1]])


### PR DESCRIPTION
## Description
create tensors in `positional_encoding_harmonic` in GPU to improve GPU utilization. It can be seen in the following graphs:
<br>
_Before optimization:_

<img width="1517" height="922" alt="Screenshot from 2025-10-04 15-35-31" src="https://github.com/user-attachments/assets/dfa17f4b-3c24-45a6-872c-f4c04092ba66" />

<br>

_After optimization_

<img width="1471" height="848" alt="Screenshot from 2025-10-05 12-38-25" src="https://github.com/user-attachments/assets/75238f95-9360-4d6f-b3c2-ce305b56548b" />

<br>
<br>
<br>
**Convergence tests ()**
<br>
<br>

**Performance check** (`default_config.yml`)
<br>

<img width="1200" height="400" alt="download" src="https://github.com/user-attachments/assets/1e64c38d-6dd4-4b6b-b5f5-668cc7427c29" />


**Performance check** (`mixed.yml`)
<br>
<img width="1200" height="400" alt="download_mixed_data" src="https://github.com/user-attachments/assets/fbc13610-cd58-4629-9fb1-3cc21844105f" />

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number
Closes #1031 

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
