### PR TITLE
Fix CERRA eval breaking with coord sorting in `froct`

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/score.py
@@ -619,7 +619,10 @@ class Scores:
 
         return rmse
 
-    def sort_by_coords(self, da_to_sort, da_reference):
+    @staticmethod
+    def sort_by_coords(
+        da_to_sort: xr.DataArray, da_reference: xr.DataArray
+    ) -> xr.DataArray:
         """
         Sorts one xarray.DataArray's coordinate ordering to match a reference array using KDTree.
 
@@ -672,9 +675,10 @@ class Scores:
         unmatched_mask = ~np.isfinite(dist)
         if np.any(unmatched_mask):
             n_unmatched = np.sum(unmatched_mask)
-            raise ValueError(
-                f"Found {n_unmatched} reference coordinates with no matching coordinates in array to sort"
+            _logger.info(
+                f"Found {n_unmatched} reference coordinates with no matching coordinates in array to sort. Returning NaN DataArray."
             )
+            return xr.full_like(da_to_sort, np.nan)
 
         # Reorder da_to_sort to match reference ordering
         return da_to_sort.isel(ipoint=indices)

--- a/packages/evaluate/src/weathergen/evaluate/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/score.py
@@ -14,6 +14,7 @@ import dask.array as da
 import numpy as np
 import pandas as pd
 import xarray as xr
+from scipy.spatial import cKDTree
 
 from weathergen.evaluate.score_utils import to_list
 
@@ -618,6 +619,66 @@ class Scores:
 
         return rmse
 
+    def sort_by_coords(self, da_to_sort, da_reference):
+        """
+        Sorts one xarray.DataArray's coordinate ordering to match a reference array using KDTree.
+
+        This method finds the nearest neighbor in `da_to_sort` for every coordinate in
+        `da_reference`, effectively reordering `da_to_sort` along its indexed dimension to align
+        with the sequence of coordinates in the reference.
+
+        Parameters
+        ----------
+        da_to_sort : xr.DataArray
+            The DataArray whose coordinate ordering needs to be matched.
+            Must contain 'lat' and 'lon' coordinates and an indexed dimension (e.g., 'ipoint').
+        da_reference : xr.DataArray
+            The DataArray providing the target coordinate ordering (the template). Must contain
+            'lat' and 'lon' coordinates.
+
+        Returns
+        -------
+        xr.DataArray
+            A new DataArray with the data from `da_to_sort` reordered to match the
+            coordinate sequence of `da_reference`.
+
+        Raises
+        ------
+        ValueError
+            If any reference coordinate does not have a matching coordinate in
+            `da_to_sort` within the allowed distance tolerance (1e-5).
+
+        Notes
+        -----
+        The matching uses `scipy.spatial.cKDTree.query` with a strict distance threshold
+        (`distance_upper_bound=1e-5`) to ensure precise one-to-one alignment.
+        """
+
+        # Extract coordinates
+        ref_lats = da_reference.lat.values
+        ref_lons = da_reference.lon.values
+        sort_lats = da_to_sort.lat.values
+        sort_lons = da_to_sort.lon.values
+
+        # Build KDTree on coordinates to sort
+        sort_coords = np.column_stack((sort_lats, sort_lons))
+        tree = cKDTree(sort_coords)
+
+        # Find nearest neighbors for reference coordinates
+        ref_coords = np.column_stack((ref_lats, ref_lons))
+        dist, indices = tree.query(ref_coords, distance_upper_bound=1e-5)
+
+        # Check for unmatched coordinates
+        unmatched_mask = ~np.isfinite(dist)
+        if np.any(unmatched_mask):
+            n_unmatched = np.sum(unmatched_mask)
+            raise ValueError(
+                f"Found {n_unmatched} reference coordinates with no matching coordinates in array to sort"
+            )
+
+        # Reorder da_to_sort to match reference ordering
+        return da_to_sort.isel(ipoint=indices)
+
     def calc_change_rate(
         self,
         s0: xr.DataArray,
@@ -642,6 +703,9 @@ class Scores:
         if s1 is None:
             return xr.full_like(s0, np.nan)
         else:
+            # Sort the coordinates of subsequent time steps to match each other. Can be removed
+            # once unshuffling is solved elsewhere
+            s1 = self.sort_by_coords(da_to_sort=s1, da_reference=s0)
             crate = np.abs(s0 - s1.values)
             return crate
 

--- a/packages/evaluate/src/weathergen/evaluate/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/score.py
@@ -678,7 +678,7 @@ class Scores:
             _logger.info(
                 f"Found {n_unmatched} reference coordinates with no matching coordinates in array to sort. Returning NaN DataArray."
             )
-            return xr.full_like(da_to_sort, np.nan)
+            return xr.full_like(da_reference, np.nan)
 
         # Reorder da_to_sort to match reference ordering
         return da_to_sort.isel(ipoint=indices)

--- a/packages/evaluate/src/weathergen/evaluate/utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils.py
@@ -26,52 +26,16 @@ _logger = logging.getLogger(__name__)
 _logger.setLevel(logging.INFO)
 
 
-def sort_by_coords(da_to_sort, da_reference):
-    """Sort da_to_sort to match da_reference's coordinate ordering using KDTree."""
-
-    # Extract coordinates
-    ref_lats = da_reference.lat.values
-    ref_lons = da_reference.lon.values
-    sort_lats = da_to_sort.lat.values
-    sort_lons = da_to_sort.lon.values
-
-    # Build KDTree on coordinates to sort
-    sort_coords = np.column_stack((sort_lats, sort_lons))
-    tree = cKDTree(sort_coords)
-
-    # Find nearest neighbors for reference coordinates
-    ref_coords = np.column_stack((ref_lats, ref_lons))
-    dist, indices = tree.query(ref_coords, distance_upper_bound=1e-5)
-
-    # Check for unmatched coordinates
-    unmatched_mask = ~np.isfinite(dist)
-    if np.any(unmatched_mask):
-        n_unmatched = np.sum(unmatched_mask)
-        raise ValueError(
-            f"Found {n_unmatched} reference coordinates with no matching coordinates in array to sort"
-        )
-
-    # Reorder da_to_sort to match reference ordering
-    return da_to_sort.isel(ipoint=indices)
-
-
 def get_next_data(fstep, da_preds, da_tars, fsteps):
     """
     Get the next forecast step data for the given forecast step.
     """
-
     fstep_idx = fsteps.index(fstep)
     # Get the next forecast step
     next_fstep = fsteps[fstep_idx + 1] if fstep_idx + 1 < len(fsteps) else None
     if next_fstep is not None:
         preds_next = da_preds.get(next_fstep, None)
         tars_next = da_tars.get(next_fstep, None)
-        tars = da_tars.get(fstep, None)
-        preds = da_preds.get(fstep, None)
-
-        # Reindex to match the current forecast step's coordinates if necessary
-        preds_next = sort_by_coords(preds_next, preds)
-        tars_next = sort_by_coords(tars_next, tars)
     else:
         preds_next = None
         tars_next = None

--- a/packages/evaluate/src/weathergen/evaluate/utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils.py
@@ -14,7 +14,6 @@ from pathlib import Path
 import numpy as np
 import omegaconf as oc
 import xarray as xr
-from scipy.spatial import cKDTree
 from tqdm import tqdm
 
 from weathergen.evaluate.io_reader import Reader


### PR DESCRIPTION
## Description

Move the coordinate (lat/lon) sorting required for a clean `froct` calculation such that it is only executed when `froct` is calculated. This prevents crashes with CERRA data, which cannot be sorted by coords (see #1055).


## Issue Number

Closes #1056 

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test` -> did not run
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
