### PR TITLE
[1059][eval] Fix eval crash of inference models from other HPCs

### DIFF
--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -409,6 +409,35 @@ def get_path_output(config: Config, epoch: int) -> Path:
     return base_path / fname
 
 
+def get_shared_wg_path(local_path: str | Path) -> Path:
+    """
+    Resolves a local, relative path to an absolute path within the configured shared working
+    directory.
+
+    This utility function retrieves the base path defined for the shared WeatherGenerator (WG)
+    working directory from the private configuration and appends the provided local path segment.
+
+    Parameters
+    ----------
+    local_path : str or Path
+        The local or relative path segment (e.g., 'results', 'models', 'output') that needs
+        to be located within the shared working directory structure.
+
+    Returns
+    -------
+    Path
+        The absolute pathlib.Path object pointing to the specified location
+        within the shared working directory.
+
+    Notes
+    -----
+    The shared working directory base is retrieved from the 'path_shared_working_dir'
+    key found in the private configuration loaded by `_load_private_conf()`.
+    """
+    pcfg = _load_private_conf()
+    return Path(pcfg.get("path_shared_working_dir")) / local_path
+
+
 def validate_forecast_policy_and_steps(cf: OmegaConf):
     """
     Validates the forecast policy and steps within a configuration object.

--- a/packages/evaluate/src/weathergen/evaluate/io_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io_reader.py
@@ -16,7 +16,7 @@ import omegaconf as oc
 import xarray as xr
 from tqdm import tqdm
 
-from weathergen.common.config import _load_private_conf, load_config, load_model_config
+from weathergen.common.config import get_shared_wg_path, load_config, load_model_config
 from weathergen.common.io import ZarrIO
 from weathergen.evaluate.derived_channels import DeriveChannels
 from weathergen.evaluate.score_utils import RegionBoundingBox, to_list
@@ -67,7 +67,9 @@ class DataAvailability:
 
 
 class Reader:
-    def __init__(self, eval_cfg: dict, run_id: str, private_paths: dict | None = None):
+    def __init__(
+        self, eval_cfg: dict, run_id: str, private_paths: dict[str, str] | None = None
+    ):
         """
         Generic data reader class.
 
@@ -77,7 +79,7 @@ class Reader:
             config with plotting and evaluation options for that run id
         run_id : str
             run id of the model
-        private_paths: dict
+        private_paths: dict[srt, str]
             dictionary of private paths for the supported HPC
         """
         self.eval_cfg = eval_cfg
@@ -283,10 +285,7 @@ class WeatherGenReader(Reader):
         self.inference_cfg = self.get_inference_config()
 
         if not self.results_base_dir:
-            pcfg = _load_private_conf()
-            self.results_base_dir = (
-                Path(pcfg.get("path_shared_working_dir")) / "results"
-            )
+            self.results_base_dir = Path(get_shared_wg_path("results"))
             _logger.info(
                 f"Results directory obtained from private config: {self.results_base_dir}"
             )

--- a/packages/evaluate/src/weathergen/evaluate/io_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io_reader.py
@@ -15,6 +15,7 @@ import numpy as np
 import omegaconf as oc
 import xarray as xr
 from tqdm import tqdm
+
 from weathergen.common.config import _load_private_conf, load_config, load_model_config
 from weathergen.common.io import ZarrIO
 from weathergen.evaluate.derived_channels import DeriveChannels

--- a/packages/evaluate/src/weathergen/evaluate/io_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io_reader.py
@@ -15,8 +15,7 @@ import numpy as np
 import omegaconf as oc
 import xarray as xr
 from tqdm import tqdm
-
-from weathergen.common.config import load_config, load_model_config
+from weathergen.common.config import _load_private_conf, load_config, load_model_config
 from weathergen.common.io import ZarrIO
 from weathergen.evaluate.derived_channels import DeriveChannels
 from weathergen.evaluate.score_utils import RegionBoundingBox, to_list
@@ -77,8 +76,8 @@ class Reader:
             config with plotting and evaluation options for that run id
         run_id : str
             run id of the model
-        private_paths: lists
-            list of private paths for the supported HPC
+        private_paths: dict
+            dictionary of private paths for the supported HPC
         """
         self.eval_cfg = eval_cfg
         self.run_id = run_id
@@ -283,9 +282,12 @@ class WeatherGenReader(Reader):
         self.inference_cfg = self.get_inference_config()
 
         if not self.results_base_dir:
-            self.results_base_dir = Path(self.inference_cfg["run_path"])
+            pcfg = _load_private_conf()
+            self.results_base_dir = (
+                Path(pcfg.get("path_shared_working_dir")) / "results"
+            )
             _logger.info(
-                f"Results directory obtained from model config: {self.results_base_dir}"
+                f"Results directory obtained from private config: {self.results_base_dir}"
             )
         else:
             _logger.info(f"Results directory parsed: {self.results_base_dir}")


### PR DESCRIPTION
## Description

Instead of reading the model path from the inference config (which invalidates when the inference model has changed HPC), it is read from the private config of the current HPC.


## Issue Number

Closes #1059 

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test` -> Did not run
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
