### PR TITLE
fix channel order in evaluation

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils.py
@@ -141,11 +141,12 @@ def calc_scores_per_stream(
         assert int(combined_metrics.forecast_step) == int(fstep), (
             "Different steps in data and metrics. Please check."
         )
-
+    
         metric_stream.loc[
             {
                 "forecast_step": int(combined_metrics.forecast_step),
                 "sample": combined_metrics.sample,
+                "channel": combined_metrics.channel,
             }
         ] = combined_metrics
 


### PR DESCRIPTION
## Description

non alphabetical channel ordering in the zarr source is causing a crash when running on SEVIRI.  CERRA and ERA5 are already sorted. 

## Issue Number

closes https://github.com/ecmwf/WeatherGenerator/issues/1065

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
