### PR TITLE
[898][config] hotfix: use correct methot `create` instead of `construct`

### DIFF
--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -88,7 +88,7 @@ def load_model_config(run_id: str, epoch: int | None, model_path: str | None) ->
 
     config = OmegaConf.create(json.loads(json_str))
 
-    return _check_logging(config)
+    return _apply_fixes(config)
 
 
 def _get_model_config_file_name(run_id: str, epoch: int | None):
@@ -100,6 +100,7 @@ def _get_model_config_file_name(run_id: str, epoch: int | None):
         epoch_str = f"_epoch{epoch:05d}"
     return f"model_{run_id}{epoch_str}.json"
 
+
 def get_model_results(run_id: str, epoch: int, rank: int) -> Path:
     """
     Get the path to the model results zarr store from a given run_id and epoch.
@@ -109,6 +110,7 @@ def get_model_results(run_id: str, epoch: int, rank: int) -> Path:
     if not zarr_path.exists() or not zarr_path.is_dir():
         raise FileNotFoundError(f"Zarr file {zarr_path} does not exist or is not a directory.")
     return zarr_path
+
 
 def _apply_fixes(config: Config) -> Config:
     """
@@ -129,11 +131,12 @@ def _check_logging(config: Config) -> Config:
     """
     config = config.copy()
     if config.get("train_log_freq") is None:  # TODO remove this for next version
-        config.train_log_freq = OmegaConf.construct(
+        config.train_log_freq = OmegaConf.create(
             {"checkpoint": 250, "terminal": 10, "metrics": config.train_log.log_interval}
         )
 
     return config
+
 
 def load_config(
     private_home: Path | None,


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->
PR #905 had a typo in in the backward compatibility mechanism, producing an exception when triggered. This PR contains a hotfix for this bug.

## Issue Number

Closes #898 


## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
