### PR TITLE
Fix semicolon issue

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotter.py
@@ -265,7 +265,7 @@ class Plotter:
         )
         plt.legend(frameon=False)
 
-        valid_time = str(
+        valid_time = (
             target_data["valid_time"][0]
             .values.astype("datetime64[m]")
             .astype(datetime.datetime)
@@ -443,7 +443,7 @@ class Plotter:
         ax = fig.add_subplot(1, 1, 1, projection=ccrs.Robinson())
         ax.coastlines()
 
-        valid_time = str(
+        valid_time = (
             data["valid_time"][0]
             .values.astype("datetime64[m]")
             .astype(datetime.datetime)


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes introduced in this pull request.

In some systems (e.g. MacOS) the semicolon ":" in `valid_time` is interpreted as "/". This is a very small fix by removing ":" from the `valid_time`

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Closes https://github.com/ecmwf/WeatherGenerator/issues/1075

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [X] I have performed a self-review of my code
-   [X] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [X] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [X] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
