### PR TITLE
Fix adalayernorm conditioning in forecast engine

### DIFF
--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -799,6 +799,7 @@ class Model(torch.nn.Module):
         Args:
             model_params : Query and embedding parameters (never used)
             tokens : Input tokens to be processed by the model.
+            fstep: Current forecast step index (can be used as aux info).
         Returns:
             Processed tokens
         Raises:


### PR DESCRIPTION
## Description

The adalayernom in the forecast engine is provided with the index of the current forecast block instead of the forecast step `fstep`. This PR fixes this. 

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number

Closes #1115 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
