### PR TITLE
Add forecast and observation activity

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/score.py
@@ -268,31 +268,25 @@ class Scores:
 
         arg_names: list[str] = inspect.getfullargspec(f).args[1:]
 
-        if score_name in ["froct", "troct"]:
-            args = {
-                "p": data.prediction,
-                "gt": data.ground_truth,
-                "p_next": data.prediction_next,
-                "gt_next": data.ground_truth_next,
-            }
-        elif score_name in ["acc"]:
-            args = {
-                "p": data.prediction,
-                "gt": data.ground_truth,
-                "c": data.climatology,
-            }
-        elif score_name == "fact":
-            args = {
-                "p": data.prediction,
-                "c": data.climatology,
-            }
-        elif score_name == "tact":
-            args = {
-                "gt": data.ground_truth,
-                "c": data.climatology,
-            }
-        else:
-            args = {"p": data.prediction, "gt": data.ground_truth}
+        score_args_map = {
+            "froct": ["p", "gt", "p_next", "gt_next"],
+            "troct": ["p", "gt", "p_next", "gt_next"],
+            "acc":   ["p", "gt", "c"],
+            "fact":  ["p", "c"],
+            "tact":  ["gt", "c"],
+        }
+
+        available = {
+            "p": data.prediction,
+            "gt": data.ground_truth,
+            "p_next": data.prediction_next,
+            "gt_next": data.ground_truth_next,
+            "c": data.climatology,
+        }
+
+        #assign p and gt by default if metrics do not have specific args
+        keys = score_args_map.get(score_name, ["p", "gt"])
+        args = {k: available[k] for k in keys}
 
         # Add group_by_coord if provided
         if group_by_coord is not None:
@@ -888,10 +882,10 @@ class Scores:
         spatial_dims: list = None,
     ):
         """
-        Calculate target activity metric as standard deviation of target anomaly.
+        Calculate forecast activity metric as standard deviation of forecast anomaly.
 
         NOTE:
-        The climatlogical mean data clim_mean must fit to the target data.
+        The climatlogical mean data clim_mean must fit to the forecast data.
 
         Parameters
         ----------


### PR DESCRIPTION
## Description

Add activity as standard deviation of forecast or observation anomaly

## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/1125

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
