### PR TITLE
Give option to plot only prediction maps

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils.py
@@ -212,6 +212,10 @@ def plot_data(reader: Reader, stream: str, global_plotting_opts: dict) -> None:
     if not isinstance(plot_maps, bool):
         raise TypeError("plot_maps must be a boolean.")
 
+    plot_preds_only = plot_settings.get("plot_preds_only", False)
+    if not isinstance(plot_maps, bool):
+        raise TypeError("plot_preds_only must be a boolean.")
+
     # Check if histograms should be plotted
     plot_histograms = plot_settings.get("plot_histograms", False)
     if not isinstance(plot_histograms, bool):
@@ -255,9 +259,10 @@ def plot_data(reader: Reader, stream: str, global_plotting_opts: dict) -> None:
             }
 
             if plot_maps:
-                plotter.create_maps_per_sample(
-                    tars, plot_chs, data_selection, "targets", maps_config
-                )
+                if not plot_preds_only:
+                    plotter.create_maps_per_sample(
+                        tars, plot_chs, data_selection, "targets", maps_config
+                    )
                 for ens in available_data.ensemble:
                     preds_ens = (
                         preds.sel(ens=ens) if "ens" in preds.dims and ens != "mean" else preds
@@ -283,7 +288,8 @@ def plot_data(reader: Reader, stream: str, global_plotting_opts: dict) -> None:
         for ens in available_data.ensemble:
             preds_name = "preds" if "ens" not in preds.dims else f"preds_ens_{ens}"
             plotter.animation(plot_samples, plot_fsteps, plot_chs, data_selection, preds_name)
-        plotter.animation(plot_samples, plot_fsteps, plot_chs, data_selection, "targets")
+        if not plot_preds_only:
+            plotter.animation(plot_samples, plot_fsteps, plot_chs, data_selection, "targets")
 
     return
 

--- a/packages/evaluate/src/weathergen/evaluate/utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils.py
@@ -212,9 +212,9 @@ def plot_data(reader: Reader, stream: str, global_plotting_opts: dict) -> None:
     if not isinstance(plot_maps, bool):
         raise TypeError("plot_maps must be a boolean.")
 
-    plot_preds_only = plot_settings.get("plot_preds_only", False)
-    if not isinstance(plot_maps, bool):
-        raise TypeError("plot_preds_only must be a boolean.")
+    plot_target = plot_settings.get("plot_target", True)
+    if not isinstance(plot_target, bool):
+        raise TypeError("plot_target must be a boolean.")
 
     # Check if histograms should be plotted
     plot_histograms = plot_settings.get("plot_histograms", False)
@@ -259,7 +259,7 @@ def plot_data(reader: Reader, stream: str, global_plotting_opts: dict) -> None:
             }
 
             if plot_maps:
-                if not plot_preds_only:
+                if plot_target:
                     plotter.create_maps_per_sample(
                         tars, plot_chs, data_selection, "targets", maps_config
                     )
@@ -288,7 +288,7 @@ def plot_data(reader: Reader, stream: str, global_plotting_opts: dict) -> None:
         for ens in available_data.ensemble:
             preds_name = "preds" if "ens" not in preds.dims else f"preds_ens_{ens}"
             plotter.animation(plot_samples, plot_fsteps, plot_chs, data_selection, preds_name)
-        if not plot_preds_only:
+        if plot_target:
             plotter.animation(plot_samples, plot_fsteps, plot_chs, data_selection, "targets")
 
     return


### PR DESCRIPTION
## Description

With this PR there is an option only for prediction maps to be plotted to save some time and inodes. Example:

```
cj6p8lte:
  label: "4-steps no Gaussian Noise"
  results_base_dir : "/p/scratch/weatherai/shared_work/results/"
  model_base_dir: "/p/scratch/weatherai/shared_work/models/"
  epoch: 0
  rank: 0
  streams:
    ERA5:
      channels: ["2t","q_850", "10v", "z_500", "u_850"]
      evaluation:
        forecast_step: "1-10"
        sample: "0-3"
      plotting:
        sample: "3-5"
        forecast_step: "1-3"
        plot_maps: true
        plot_target: false <------------------
        plot_histograms: false
        plot_animations: false
```

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/1076

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

## Checklist before asking for review

-   [X] I have performed a self-review of my code
-   [X] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [X] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [X] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
