### PR TITLE
recover 'all' option

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/io_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io_reader.py
@@ -278,14 +278,14 @@ class Reader:
         if ensemble == "mean":
             ensemble = ["mean"]
 
-        if isinstance(fsteps, str):
+        if isinstance(fsteps, str) and fsteps != "all":
             assert re.match(r"^\d+-\d+$", fsteps), (
-                "String format for forecast_step in config must be 'digit-digit'"
+                "String format for forecast_step in config must be 'digit-digit' or 'all'"
             )
             fsteps = list(range(int(fsteps.split("-")[0]), int(fsteps.split("-")[1]) + 1))
-        if isinstance(samples, str):
+        if isinstance(samples, str) and samples != "all":
             assert re.match(r"^\d+-\d+$", samples), (
-                "String format for sample in config must be 'digit-digit'"
+                "String format for sample in config must be 'digit-digit' or 'all'"
             )
             samples = list(range(int(samples.split("-")[0]), int(samples.split("-")[1]) + 1))
 


### PR DESCRIPTION
## Description

Hotfix to recover "all" option for forecast steps and samples


## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/1143

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
