### PR TITLE
Make gradient checkpointing configurable in the embed transformer

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -6,6 +6,7 @@ embed_centroids_local_coords: False
 embed_size_centroids: 0
 embed_unembed_mode: "block"
 embed_dropout_rate: 0.1
+embed_gradient_checkpoint_mode: False
 
 target_cell_local_prediction: True
 

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -6,7 +6,7 @@ embed_centroids_local_coords: False
 embed_size_centroids: 0
 embed_unembed_mode: "block"
 embed_dropout_rate: 0.1
-embed_gradient_checkpoint_mode: True
+embed_gradient_checkpoint_mode: False
 
 target_cell_local_prediction: True
 

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -6,7 +6,7 @@ embed_centroids_local_coords: False
 embed_size_centroids: 0
 embed_unembed_mode: "block"
 embed_dropout_rate: 0.1
-embed_gradient_checkpoint_mode: False
+embed_gradient_checkpoint_mode: True
 
 target_cell_local_prediction: True
 

--- a/src/weathergen/model/embeddings.py
+++ b/src/weathergen/model/embeddings.py
@@ -159,7 +159,11 @@ class StreamEmbedTransformer(torch.nn.Module):
 
             # read out
             if self.unembed_mode == "full":
-                out = checkpoint(self.unembed, self.ln_final(x.flatten(-2, -1)), use_reentrant=False)
+                out = checkpoint(
+                    self.unembed,
+                    self.ln_final(x.flatten(-2, -1)),
+                    use_reentrant=False,
+                )
             elif self.unembed_mode == "block":
                 out = [
                     checkpoint(ue, ln(x[:, i]), use_reentrant=False)

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -71,6 +71,7 @@ class EmbeddingEngine:
                         norm_type=self.cf.norm_type,
                         embed_size_centroids=self.cf.embed_size_centroids,
                         unembed_mode=self.cf.embed_unembed_mode,
+                        embed_gradient_checkpoint_mode=self.cf.embed_gradient_checkpoint_mode,
                         stream_name=stream_name,
                     )
                 )


### PR DESCRIPTION
## Description
In order to save memory and improve computational efficiency, and since gradient checkpointing is used in several parts of the code, having the ability to enable or disable gradient checkpointing in specific sections can provide flexibility to maximize performance while also conserving memory.
<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number
Refs #1141 


## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel

## Comparing the baseline and current PR performance

When embed_gradient_checkpoint_mode is set to false, the performance and GPU memory peak are as follows:
#### default_config.yml:
`../WeatherGenerator-private/hpc/launch-slurm.py --time 60
`
<img width="1600" height="500" alt="embed_gradient_checkpoint_mode" src="https://github.com/user-attachments/assets/731f5e74-d701-4f8f-a8fd-50e14d133794" />


#### mixed.yml:
`../WeatherGenerator-private/hpc/launch-slurm.py --time 60 --config ./config/mixed.yml
`


<img width="1600" height="500" alt="embed_gradient_checkpoint_mode_mixed_dataset" src="https://github.com/user-attachments/assets/73bbaaa8-ef16-4cae-9e16-812eaaeeff85" />


For those GPUs with memory more than `25 GiB`, it is recommended to set `embed_gradient_checkpoint_mode` to False
