### PR TITLE
Make gradient checkpointing configurable in the ae_local_blocks

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -17,6 +17,7 @@ ae_local_with_qk_lnorm: True
 
 ae_local_num_queries: 1
 ae_local_queries_per_cell: False
+ae_local_blocks_grdient_checkpoint_mode: False
 ae_adapter_num_heads: 16
 ae_adapter_embed: 128
 ae_adapter_with_qk_lnorm: True

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -253,6 +253,7 @@ class Model(torch.nn.Module):
         self.sources_size = sources_size
         self.targets_num_channels = targets_num_channels
         self.targets_coords_size = targets_coords_size
+        self.ae_local_blocks_grdient_checkpoint_mode = self.cf.ae_local_blocks_grdient_checkpoint_mode
 
     #########################################
     def create(self) -> "Model":
@@ -743,8 +744,12 @@ class Model(torch.nn.Module):
                 tokens_global_all += [tokens_global_c]
                 continue
 
-            for block in self.ae_local_blocks:
-                tokens_c = checkpoint(block, tokens_c, cell_lens_c, use_reentrant=False)
+            if self.ae_local_blocks_grdient_checkpoint_mode: 
+                for block in self.ae_local_blocks:
+                    tokens_c = checkpoint(block, tokens_c, cell_lens_c, use_reentrant=False)
+            else:
+                for block in self.ae_local_blocks:
+                    tokens_c = block(tokens_c, cell_lens_c)
 
             if self.cf.latent_noise_kl_weight > 0.0:
                 tokens_c, posteriors_c = self.interpolate_latents.interpolate_with_noise(

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -743,7 +743,7 @@ class Model(torch.nn.Module):
                 tokens_global_all += [tokens_global_c]
                 continue
 
-            if self.cf.ae_local_blocks_grdient_checkpoint_mode: 
+            if self.cf.ae_local_blocks_grdient_checkpoint_mode:
                 for block in self.ae_local_blocks:
                     tokens_c = checkpoint(block, tokens_c, cell_lens_c, use_reentrant=False)
             else:

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -253,7 +253,6 @@ class Model(torch.nn.Module):
         self.sources_size = sources_size
         self.targets_num_channels = targets_num_channels
         self.targets_coords_size = targets_coords_size
-        self.ae_local_blocks_grdient_checkpoint_mode = self.cf.ae_local_blocks_grdient_checkpoint_mode
 
     #########################################
     def create(self) -> "Model":
@@ -744,7 +743,7 @@ class Model(torch.nn.Module):
                 tokens_global_all += [tokens_global_c]
                 continue
 
-            if self.ae_local_blocks_grdient_checkpoint_mode: 
+            if self.cf.ae_local_blocks_grdient_checkpoint_mode: 
                 for block in self.ae_local_blocks:
                     tokens_c = checkpoint(block, tokens_c, cell_lens_c, use_reentrant=False)
             else:


### PR DESCRIPTION
## Description
In order to save memory and improve computational efficiency, and since gradient checkpointing is used in several parts of the code, having the ability to enable or disable gradient checkpointing in specific sections can provide flexibility to maximize performance while also conserving memory.
<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number
Refs #1141 
<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel


## Comparing the baseline and current PR performance

When `ae_local_blocks_grdient_checkpoint_mode` is set to false, the performance and GPU memory peak are as follows:
#### default_config.yml:
`../WeatherGenerator-private/hpc/launch-slurm.py --time 60
`
<img width="1600" height="500" alt="ae_local_blocks_grdient_checkpoint_mode_false" src="https://github.com/user-attachments/assets/e39c9876-ee5f-4ea1-abb8-c8c053a91f64" />



#### mixed.yml:
`../WeatherGenerator-private/hpc/launch-slurm.py --time 60 --config ./config/mixed.yml
`

<img width="1600" height="500" alt="ae_local_blocks_grdient_checkpoint_mode_false_mixed" src="https://github.com/user-attachments/assets/5d1d4ad7-3d9c-41d5-ad27-f18aca4c94ce" />



For those GPUs with memory more than `16 GiB`, it is recommended to set `ae_local_blocks_grdient_checkpoint_mode` to False