### PR TITLE
Make gradient checkpointing configurable in the ae_adapter

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -22,6 +22,7 @@ ae_adapter_embed: 128
 ae_adapter_with_qk_lnorm: True
 ae_adapter_with_residual: True
 ae_adapter_dropout_rate: 0.1
+ae_adapter_grdient_checkpoint_mode: False
 
 ae_global_dim_embed: 2048
 ae_global_num_blocks: 8

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -754,15 +754,25 @@ class Model(torch.nn.Module):
             else:
                 tokens_c, posteriors = tokens_c, 0.0
 
-            for block in self.ae_adapter:
-                tokens_global_c = checkpoint(
-                    block,
-                    tokens_global_c,
-                    tokens_c,
-                    q_cells_lens_c,
-                    cell_lens_c,
-                    use_reentrant=False,
-                )
+            if self.cf.ae_adapter_grdient_checkpoint_mode:
+                for block in self.ae_adapter:
+                    tokens_global_c = checkpoint(
+                        block,
+                        tokens_global_c,
+                        tokens_c,
+                        q_cells_lens_c,
+                        cell_lens_c,
+                        use_reentrant=False,
+                    )
+            else:
+                for block in self.ae_adapter:
+                    tokens_global_c = block(
+                        tokens_global_c,
+                        tokens_c,
+                        q_cells_lens_c,
+                        cell_lens_c,
+                    )
+
 
             tokens_global_all += [tokens_global_c]
 

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -773,7 +773,6 @@ class Model(torch.nn.Module):
                         cell_lens_c,
                     )
 
-
             tokens_global_all += [tokens_global_c]
 
         tokens_global = torch.cat(tokens_global_all)


### PR DESCRIPTION
## Description
In order to save memory and improve computational efficiency, and since gradient checkpointing is used in several parts of the code, having the ability to enable or disable gradient checkpointing in specific sections can provide flexibility to maximize performance while also conserving memory.
<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number
Refs #1141 


## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel

## Comparing the baseline and current PR performance

When `ae_adapter_grdient_checkpoint_mode` is set to false, the performance and GPU memory peak are as follows:
#### default_config.yml:
`../WeatherGenerator-private/hpc/launch-slurm.py --time 60
`
<img width="1600" height="500" alt="ae_adapter_grdient_checkpoint_mode_false" src="https://github.com/user-attachments/assets/dd65130f-c805-4a63-b98e-159982656edd" />



#### mixed.yml:
`../WeatherGenerator-private/hpc/launch-slurm.py --time 60 --config ./config/mixed.yml
`

<img width="1600" height="500" alt="ae_adapter_grdient_checkpoint_mode_false_mixed" src="https://github.com/user-attachments/assets/bb97a605-5c15-417e-8d13-feedfc52dd0c" />



For those GPUs with memory more than `18 GiB`, it is recommended to set `ae_adapter_grdient_checkpoint_mode` to False
