### PR TITLE
Make gradient checkpointing configurable in the assimilate global

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -33,6 +33,7 @@ ae_global_with_qk_lnorm: True
 ae_global_att_dense_rate: 1.0
 ae_global_block_factor: 64
 ae_global_mlp_hidden_factor: 2
+assimilate_global_gradient_checkpoint_mode: False 
 
 decoder_type: PerceiverIOCoordConditioning # CrossAttentionAdaNormConditioning
 pred_adapter_kv: False

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -787,9 +787,13 @@ class Model(torch.nn.Module):
         """
 
         # global assimilation engine and adapter
-        for block in self.ae_global_blocks:
-            tokens = checkpoint(block, tokens, use_reentrant=False)
-
+        if self.cf.assimilate_global_gradient_checkpoint_mode:
+            for block in self.ae_global_blocks:
+                tokens = checkpoint(block, tokens, use_reentrant=False)
+        else:
+             for block in self.ae_global_blocks:
+                tokens = block(tokens)
+                   
         return tokens
 
     #########################################

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -791,9 +791,9 @@ class Model(torch.nn.Module):
             for block in self.ae_global_blocks:
                 tokens = checkpoint(block, tokens, use_reentrant=False)
         else:
-             for block in self.ae_global_blocks:
+            for block in self.ae_global_blocks:
                 tokens = block(tokens)
-                   
+
         return tokens
 
     #########################################


### PR DESCRIPTION
## Description
In order to save memory and improve computational efficiency, and since gradient checkpointing is used in several parts of the code, having the ability to enable or disable gradient checkpointing in specific sections can provide flexibility to maximize performance while also conserving memory.
<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number
Refs #1141 


## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel

## Comparing the baseline and current PR performance

When `assimilate_global_gradient_checkpoint_mode` is set to false, the performance and GPU memory peak are as follows:
#### default_config.yml:
`../WeatherGenerator-private/hpc/launch-slurm.py --time 60
`
<img width="1600" height="500" alt="assimilate_global_gradient_checkpoint_mode_false" src="https://github.com/user-attachments/assets/40cbb390-3776-4dfa-9ec4-02cd19cd4adc" />


#### mixed.yml:
`../WeatherGenerator-private/hpc/launch-slurm.py --time 60 --config ./config/mixed.yml
`


<img width="1600" height="500" alt="assimilate_global_gradient_checkpoint_mode_false_mixed" src="https://github.com/user-attachments/assets/bae8ec86-f45b-446b-b684-84a2081a0754" />


For those GPUs with memory more than `23 GiB`, it is recommended to set `assimilate_global_gradient_checkpoint_mode` to False
