### PR TITLE
Test turning all grad checkpointings off

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -33,6 +33,7 @@ ae_global_with_qk_lnorm: True
 ae_global_att_dense_rate: 1.0
 ae_global_block_factor: 64
 ae_global_mlp_hidden_factor: 2
+assimilate_global_gradient_checkpoint_mode: False 
 
 decoder_type: PerceiverIOCoordConditioning # CrossAttentionAdaNormConditioning
 pred_adapter_kv: False

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -6,6 +6,7 @@ embed_centroids_local_coords: False
 embed_size_centroids: 0
 embed_unembed_mode: "block"
 embed_dropout_rate: 0.1
+embed_gradient_checkpoint_mode: False
 
 target_cell_local_prediction: True
 

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -17,6 +17,7 @@ ae_local_with_qk_lnorm: True
 
 ae_local_num_queries: 1
 ae_local_queries_per_cell: False
+ae_local_blocks_grdient_checkpoint_mode: False
 ae_adapter_num_heads: 16
 ae_adapter_embed: 128
 ae_adapter_with_qk_lnorm: True

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -39,6 +39,7 @@ pred_adapter_kv: False
 pred_self_attention: True
 pred_dyadic_dims: False
 pred_mlp_adaln: True
+pred_gradient_checkpoint_mode: False
 
 # number of steps offset applied to first target window; if set to zero and forecast_steps=0 then
 # one is training an auto-encoder

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -22,6 +22,7 @@ ae_adapter_embed: 128
 ae_adapter_with_qk_lnorm: True
 ae_adapter_with_residual: True
 ae_adapter_dropout_rate: 0.1
+ae_adapter_grdient_checkpoint_mode: False
 
 ae_global_dim_embed: 2048
 ae_global_num_blocks: 8

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -6,7 +6,7 @@ embed_centroids_local_coords: False
 embed_size_centroids: 0
 embed_unembed_mode: "block"
 embed_dropout_rate: 0.1
-embed_gradient_checkpoint_mode: True
+embed_gradient_checkpoint_mode: False
 
 target_cell_local_prediction: True
 

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -6,7 +6,7 @@ embed_centroids_local_coords: False
 embed_size_centroids: 0
 embed_unembed_mode: "block"
 embed_dropout_rate: 0.1
-embed_gradient_checkpoint_mode: False
+embed_gradient_checkpoint_mode: True
 
 target_cell_local_prediction: True
 

--- a/src/weathergen/model/embeddings.py
+++ b/src/weathergen/model/embeddings.py
@@ -159,7 +159,11 @@ class StreamEmbedTransformer(torch.nn.Module):
 
             # read out
             if self.unembed_mode == "full":
-                out = checkpoint(self.unembed, self.ln_final(x.flatten(-2, -1)), use_reentrant=False)
+                out = checkpoint(
+                    self.unembed,
+                    self.ln_final(x.flatten(-2, -1)),
+                    use_reentrant=False,
+                )
             elif self.unembed_mode == "block":
                 out = [
                     checkpoint(ue, ln(x[:, i]), use_reentrant=False)

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -71,6 +71,7 @@ class EmbeddingEngine:
                         norm_type=self.cf.norm_type,
                         embed_size_centroids=self.cf.embed_size_centroids,
                         unembed_mode=self.cf.embed_unembed_mode,
+                        embed_gradient_checkpoint_mode=self.cf.embed_gradient_checkpoint_mode,
                         stream_name=stream_name,
                     )
                 )

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -253,6 +253,7 @@ class Model(torch.nn.Module):
         self.sources_size = sources_size
         self.targets_num_channels = targets_num_channels
         self.targets_coords_size = targets_coords_size
+        self.ae_local_blocks_grdient_checkpoint_mode = self.cf.ae_local_blocks_grdient_checkpoint_mode
 
     #########################################
     def create(self) -> "Model":
@@ -743,8 +744,12 @@ class Model(torch.nn.Module):
                 tokens_global_all += [tokens_global_c]
                 continue
 
-            for block in self.ae_local_blocks:
-                tokens_c = checkpoint(block, tokens_c, cell_lens_c, use_reentrant=False)
+            if self.ae_local_blocks_grdient_checkpoint_mode: 
+                for block in self.ae_local_blocks:
+                    tokens_c = checkpoint(block, tokens_c, cell_lens_c, use_reentrant=False)
+            else:
+                for block in self.ae_local_blocks:
+                    tokens_c = block(tokens_c, cell_lens_c)
 
             if self.cf.latent_noise_kl_weight > 0.0:
                 tokens_c, posteriors_c = self.interpolate_latents.interpolate_with_noise(

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -743,7 +743,7 @@ class Model(torch.nn.Module):
                 tokens_global_all += [tokens_global_c]
                 continue
 
-            if self.cf.ae_local_blocks_grdient_checkpoint_mode: 
+            if self.cf.ae_local_blocks_grdient_checkpoint_mode:
                 for block in self.ae_local_blocks:
                     tokens_c = checkpoint(block, tokens_c, cell_lens_c, use_reentrant=False)
             else:

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -253,7 +253,6 @@ class Model(torch.nn.Module):
         self.sources_size = sources_size
         self.targets_num_channels = targets_num_channels
         self.targets_coords_size = targets_coords_size
-        self.ae_local_blocks_grdient_checkpoint_mode = self.cf.ae_local_blocks_grdient_checkpoint_mode
 
     #########################################
     def create(self) -> "Model":
@@ -744,7 +743,7 @@ class Model(torch.nn.Module):
                 tokens_global_all += [tokens_global_c]
                 continue
 
-            if self.ae_local_blocks_grdient_checkpoint_mode: 
+            if self.cf.ae_local_blocks_grdient_checkpoint_mode: 
                 for block in self.ae_local_blocks:
                     tokens_c = checkpoint(block, tokens_c, cell_lens_c, use_reentrant=False)
             else:

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -787,9 +787,13 @@ class Model(torch.nn.Module):
         """
 
         # global assimilation engine and adapter
-        for block in self.ae_global_blocks:
-            tokens = checkpoint(block, tokens, use_reentrant=False)
-
+        if self.cf.assimilate_global_gradient_checkpoint_mode:
+            for block in self.ae_global_blocks:
+                tokens = checkpoint(block, tokens, use_reentrant=False)
+        else:
+             for block in self.ae_global_blocks:
+                tokens = block(tokens)
+                   
         return tokens
 
     #########################################

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -869,7 +869,6 @@ class Model(torch.nn.Module):
                     ]
                 )
             else:
-
                 tc_tokens = torch.cat(
                     [
                         tc_embed(

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -754,15 +754,25 @@ class Model(torch.nn.Module):
             else:
                 tokens_c, posteriors = tokens_c, 0.0
 
-            for block in self.ae_adapter:
-                tokens_global_c = checkpoint(
-                    block,
-                    tokens_global_c,
-                    tokens_c,
-                    q_cells_lens_c,
-                    cell_lens_c,
-                    use_reentrant=False,
-                )
+            if self.cf.ae_adapter_grdient_checkpoint_mode:
+                for block in self.ae_adapter:
+                    tokens_global_c = checkpoint(
+                        block,
+                        tokens_global_c,
+                        tokens_c,
+                        q_cells_lens_c,
+                        cell_lens_c,
+                        use_reentrant=False,
+                    )
+            else:
+                for block in self.ae_adapter:
+                    tokens_global_c = block(
+                        tokens_global_c,
+                        tokens_c,
+                        q_cells_lens_c,
+                        cell_lens_c,
+                    )
+
 
             tokens_global_all += [tokens_global_c]
 

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -791,9 +791,9 @@ class Model(torch.nn.Module):
             for block in self.ae_global_blocks:
                 tokens = checkpoint(block, tokens, use_reentrant=False)
         else:
-             for block in self.ae_global_blocks:
+            for block in self.ae_global_blocks:
                 tokens = block(tokens)
-                   
+
         return tokens
 
     #########################################

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -773,7 +773,6 @@ class Model(torch.nn.Module):
                         cell_lens_c,
                     )
 
-
             tokens_global_all += [tokens_global_c]
 
         tokens_global = torch.cat(tokens_global_all)

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -855,18 +855,31 @@ class Model(torch.nn.Module):
             ## embed token coords, concatenating along batch dimension
             # (which is taking care of through the varlen attention)
             # arguably we should to the mixed precision policy when creating the model in FSDP
-            tc_tokens = torch.cat(
-                [
-                    checkpoint(
-                        tc_embed,
-                        streams_data[i_b][ii].target_coords[fstep],
-                        use_reentrant=False,
-                    )
-                    if len(streams_data[i_b][ii].target_coords[fstep].shape) > 1
-                    else streams_data[i_b][ii].target_coords[fstep]
-                    for i_b in range(len(streams_data))
-                ]
-            )
+            if self.cf.pred_gradient_checkpoint_mode:
+                tc_tokens = torch.cat(
+                    [
+                        checkpoint(
+                            tc_embed,
+                            streams_data[i_b][ii].target_coords[fstep],
+                            use_reentrant=False,
+                        )
+                        if len(streams_data[i_b][ii].target_coords[fstep].shape) > 1
+                        else streams_data[i_b][ii].target_coords[fstep]
+                        for i_b in range(len(streams_data))
+                    ]
+                )
+            else:
+
+                tc_tokens = torch.cat(
+                    [
+                        tc_embed(
+                            streams_data[i_b][ii].target_coords[fstep],
+                        )
+                        if len(streams_data[i_b][ii].target_coords[fstep].shape) > 1
+                        else streams_data[i_b][ii].target_coords[fstep]
+                        for i_b in range(len(streams_data))
+                    ]
+                )
 
             # skip when coordinate embeddings yields nan (i.e. the coord embedding network diverged)
             if torch.isnan(tc_tokens).any():
@@ -906,6 +919,9 @@ class Model(torch.nn.Module):
             )
 
             # final prediction head to map back to physical space
-            preds_tokens += [checkpoint(self.pred_heads[ii], tc_tokens, use_reentrant=False)]
+            if self.cf.pred_gradient_checkpoint_mode:
+                preds_tokens += [checkpoint(self.pred_heads[ii], tc_tokens, use_reentrant=False)]
+            else:
+                preds_tokens += [self.pred_heads[ii](tc_tokens)]
 
         return preds_tokens


### PR DESCRIPTION
## Description
This is a merge branch related to the following PRs:
https://github.com/ecmwf/WeatherGenerator/pull/1151  
https://github.com/ecmwf/WeatherGenerator/pull/1152
https://github.com/ecmwf/WeatherGenerator/pull/1153
https://github.com/ecmwf/WeatherGenerator/pull/1155
https://github.com/ecmwf/WeatherGenerator/pull/1156


## Issue Number
Closes #1141 


## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel

## Comparing the baseline and current PR performance

When `pred_gradient_checkpoint_mode` is set to false, the performance and GPU memory peak are as follows:
#### default_config.yml:
`../WeatherGenerator-private/hpc/launch-slurm.py --time 60
`
<img width="1600" height="500" alt="all_checkpoint_off" src="https://github.com/user-attachments/assets/d01ee137-e9b9-491f-8551-aa5fd4ded032" />




#### mixed.yml:
`../WeatherGenerator-private/hpc/launch-slurm.py --time 60 --config ./config/mixed.yml
`

<img width="1600" height="500" alt="all_checkpoint_off_mixed" src="https://github.com/user-attachments/assets/dc0a8679-902f-4c57-8956-a29942e14a0c" />



