### PR TITLE
Remove forecast function, directly use ForecastEngine's forward

### DIFF
--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -640,7 +640,7 @@ class Model(torch.nn.Module):
                 if noise_std > 0.0:
                     tokens = tokens + torch.randn_like(tokens) * torch.norm(tokens) * noise_std
 
-            tokens = self.forecast(model_params, tokens, fstep)
+            tokens = self.forecast_engine(tokens, fstep)
 
         # prediction for final step
         preds_all += [
@@ -787,24 +787,6 @@ class Model(torch.nn.Module):
 
         # global assimilation engine and adapter
         tokens = self.ae_global_engine(tokens, use_reentrant=False)
-
-        return tokens
-
-    #########################################
-    def forecast(self, model_params: ModelParams, tokens: torch.Tensor, fstep: int) -> torch.Tensor:
-        """Advances latent space representation in time
-
-        Args:
-            model_params : Query and embedding parameters (never used)
-            tokens : Input tokens to be processed by the model.
-            fstep: Current forecast step index (can be used as aux info).
-        Returns:
-            Processed tokens
-        Raises:
-            ValueError: For unexpected arguments in checkpoint method
-        """
-
-        tokens = self.forecast_engine(tokens, fstep)
 
         return tokens
 


### PR DESCRIPTION
## Description

With the engines refactored into torch modules and forward functions, we don't need the forecast function in the model anymore.

## Issue Number

Closes #1194 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
