### PR TITLE
Improve FSDP2 Performance via Hybrid Sharded Data Parallel (HSDP)

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -59,6 +59,7 @@ with_mixed_precision: True
 with_flash_attention: True
 compile_model: False
 with_fsdp: True
+with_hsdp: True
 attention_dtype: bf16
 mlp_norm_eps: 1e-5
 norm_eps: 1e-4


### PR DESCRIPTION
## Description
This PR focuses on improving the performance of FSDP2. In this update, Hybrid Sharded Data Parallel (HSDP) has been implemented to reduce communication overhead in FSDP2.

Documentation related to this PR and the scaling factor can be found in the linked HedgeDoc document.

https://gitlab.jsc.fz-juelich.de/hedgedoc/GJaZ5H5GQ-KV64YvCdX_lg?view

In summary, the scaling factor from one node to two nodes has improved from **0.933** to **0.945**. The scaling factor for DDP was also measured and is **0.95**, which is comparable to HSDP.
<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number
Fixes #1233 
<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
