### PR TITLE
Implement error handling for MLflow score logging

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
@@ -212,13 +212,18 @@ def evaluate_from_config(cfg, mlflow_client: MlflowClient | None) -> None:
                     parent_run_id=parent_run.info.run_id,
                     nested=True,
                 ) as run:
-                    mlflow.set_tags(MlFlowUpload.run_tags(run_id, phase, from_run_id))
-                    log_scores(
-                        reordered_dict[run_id],
-                        mlflow_client,
-                        run.info.run_id,
-                        channels_set,
-                    )
+try:
+                                            mlflow.set_tags(MlFlowUpload.run_tags(run_id, phase, from_run_id))
+                        log_scores(
+                            reordered_dict[run_id],
+                            mlflow_client,
+                            run.info.run_id,
+                            channels_set,
+                        )
+                except Exception as e:
+                    _logger.error(f"Error logging scores for run {run_id}: {e}")
+                    mlflow.end_run(status="FAILED")
+                    raise
 
     # plot summary
     if scores_dict and cfg.evaluation.get("summary_plots", True):


### PR DESCRIPTION
Fix #1254: MLFlow runs not properly closed after error

Added try-except block around log_scores() call to ensure MLFlow runs are properly closed with FAILED status when metrics file doesn't exist or other errors occur during score logging. Previously, runs would remain in RUNNING state indefinitely when errors occurred.

## Description

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
