### PR TITLE
[1291] Update `io_reader.py` to use `mini_epoch`

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/io_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io_reader.py
@@ -469,7 +469,8 @@ class WeatherGenReader(Reader):
 
         super().__init__(eval_cfg, run_id, private_paths)
 
-        self.mini_epoch = eval_cfg.mini_epoch
+        # TODO: remove backwards compatibility to "epoch" in Feb. 2026
+        self.mini_epoch = getattr(eval_cfg, "mini_epoch", eval_cfg["epoch"])
         self.rank = eval_cfg.rank
 
         # Load model configuration and set (run-id specific) directories
@@ -889,7 +890,7 @@ class WeatherGenReader(Reader):
         """
         score_path = (
             Path(self.metrics_dir)
-            / f"{self.run_id}_{stream}_{region}_{metric}_epoch{self.mini_epoch:05d}.json"
+            / f"{self.run_id}_{stream}_{region}_{metric}_chkpt{self.mini_epoch:05d}.json"
         )
         _logger.debug(f"Looking for: {score_path}")
 


### PR DESCRIPTION
## Description

The WeatherGenReader still relied on `epoch` instead of using `mini-epoch`. This PR builds on @simone99n's #1292 to use `mini_epoch` instead of `epoch`.

Two minor modifications are added in this PR for (a) backward compatibility and (b) sound naming convention in accordance with #1190, i.e., replacing `epoch` by `chkpt` in the written evaluation files.


## Issue Number

Closes #1291

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
