### PR TITLE
Issue1279 noise conditioning

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -12,3 +12,29 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 http://www.apache.org/licenses/LICENSE-2.0
+
+=======================================================================
+google-deepmind/graphcast (several associated papers)
+
+This software incorporates code from the 'google-deepmind/graphcast' repository, with adaptations.
+
+Original Copyright 2024 DeepMind Technologies Limited.
+
+The source code is available at:
+https://github.com/google-deepmind/graphcast
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+=======================================================================
+facebookresearch/DiT (Scalable Diffusion Models with Transformers (DiT))
+
+This software incorporates code from the 'facebookresearch/DiT' repository, with adaptations.
+
+The source code is available at:
+https://github.com/facebookresearch/DiT
+
+The code and model weights are licensed under CC-BY-NC. 
+See https://raw.githubusercontent.com/facebookresearch/DiT/refs/heads/main/LICENSE.txt for details.

--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -225,7 +225,7 @@ def load_config(
     # use OmegaConf.unsafe_merge if too slow
     c = OmegaConf.merge(base_config, private_config, *overwrite_configs)
     assert isinstance(c, Config)
-    
+
     # Ensure the config has mini-epoch notation
     if hasattr(c, "samples_per_epoch"):
         c.samples_per_mini_epoch = c.samples_per_epoch

--- a/packages/dashboard/atmo_eval.py
+++ b/packages/dashboard/atmo_eval.py
@@ -77,7 +77,9 @@ def get_score_step_48h(score_col: str) -> pl.DataFrame:
         .sort("start_time")
         .filter(pl.col(score_col).is_not_null())
     )
-    _logger.info(f"Getting score data for {score_col} at 48h (step={step_48h}): len={len(score_data)}")
+    _logger.info(
+        f"Getting score data for {score_col} at 48h (step={step_48h}): len={len(score_data)}"
+    )
 
     # Iterate over the runs to get the metric at step 48h
     scores_dt: list[float | None] = []

--- a/src/weathergen/model/diffusion.py
+++ b/src/weathergen/model/diffusion.py
@@ -14,12 +14,17 @@
 # Original Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # ----------------------------------------------------------------------------
 
+# ----------------------------------------------------------------------------
+# Third-Party Attribution: google-deepmind/graphcast (several associated papers)
+# This file incorporates code originally from the 'google-deepmind/graphcast' repository, with adaptations.
+#
+# The original code is licensed under Apache 2.0. Original Copyright 2024 DeepMind Technologies Limited.
+# ----------------------------------------------------------------------------
+
 
 import dataclasses
 import math
-
 import torch
-
 from weathergen.model.engines import ForecastingEngine
 
 

--- a/src/weathergen/model/diffusion.py
+++ b/src/weathergen/model/diffusion.py
@@ -62,22 +62,19 @@ class DiffusionForecastEngine(torch.nn.Module):
     def __init__(
         self,
         forecast_engine: ForecastingEngine,
-        noise_channels: int, #TODO: how are the determined – dimension of latent space? batch size?
-        emb_channels: int, #NOTE: might be wise to choose as a function of noise_channels
+        frequency_embedding_dim: int, #TODO: how are the determined – dimension of latent space? batch size?
+        embedding_dim: int, #NOTE: might be wise to choose as a function of noise_channels
         sigma_min: float = 0.002,  # Adapt to GenCast?
         sigma_max: float = 80,
         sigma_data: float = 0.5,
         rho: float = 7,
         p_mean: float = -1.2,
         p_std: float = 1.2,
-        noise_encoding: str = 'positional',
     ):
         super().__init__()
         self.net = forecast_engine
         self.preconditioner = Preconditioner()
-        self.map_noise = PositionalEmbedding(num_channels=noise_channels, endpoint=True) if noise_encoding == 'positional' else FourierEmbedding(num_channels=noise_channels) #TODO: Compare with method used in GenCast
-        self.map_layer0 = torch.nn.Linear(noise_channels, emb_channels)
-        self.map_layer1 = torch.nn.Linear(emb_channels, noise_channels)
+        self.noise_embedder = NoiseEmbedder(embedding_dim=embedding_dim, frequency_embedding_dim=frequency_embedding_dim)
 
         # Parameters
         self.sigma_min = sigma_min
@@ -127,22 +124,11 @@ class DiffusionForecastEngine(torch.nn.Module):
         c_noise = sigma.log() / 4
 
         # Embed noise level
-        emb = self.embed_noise(c_noise.unsqueeze(-1))  #TODO: check dimensionality
+        emb = self.noise_embedder(c_noise)
 
         # Precondition input and feed through network
         x = self.preconditioner.precondition(x, c)
         return c_skip * x + c_out * self.net(c_in * x, emb)  # Eq. (7) in EDM paper
-
-    #TODO: May need to be updated from DiT paper code (currently taken from EDM paper code)
-    def embed_noise(self, noise: torch.Tensor) -> torch.Tensor:
-        """
-        Embed noise level using embedding network and MLPs.
-        """
-        emb = self.map_noise(noise)
-        emb = emb.reshape(emb.shape[0], 2, -1).flip(1).reshape(*emb.shape) #TODO: check why this is done in the EBM code 'swap cos/sin'
-        emb = silu(self.map_layer0(emb))
-        emb = silu(self.map_layer1(emb))
-        return emb
 
     def inference(
         self,
@@ -201,38 +187,49 @@ class Preconditioner:
         return x
 
 
-#NOTE: this is currently based on EDM, not on DiT
-class PositionalEmbedding(torch.nn.Module):
-    def __init__(self, num_channels, max_positions=10000, endpoint=False):
+#NOTE: Adapted from DiT codebase:
+class NoiseEmbedder(torch.nn.Module):
+    """
+    Embeds scalar timesteps into vector representations.
+    """
+    def __init__(self, embedding_dim, frequency_embedding_dim=256, dtype=torch.bfloat16):
         super().__init__()
-        self.num_channels = num_channels
-        self.max_positions = max_positions
-        self.endpoint = endpoint
+        self.dtype = dtype
+        self.mlp = torch.nn.Sequential(
+            torch.nn.Linear(frequency_embedding_dim, embedding_dim, bias=True),
+            torch.nn.SiLU(),
+            torch.nn.Linear(embedding_dim, embedding_dim, bias=True),
+        )
+        self.frequency_embedding_dim = frequency_embedding_dim
 
-    def forward(self, x):
-        freqs = torch.arange(start=0, end=self.num_channels//2, dtype=torch.float32, device=x.device)
-        freqs = freqs / (self.num_channels // 2 - (1 if self.endpoint else 0))
-        freqs = (1 / self.max_positions) ** freqs
-        x = x.ger(freqs.to(x.dtype))
-        x = torch.cat([x.cos(), x.sin()], dim=1)
-        return x
+    def timestep_embedding(self, t, max_period=10000):
+        """
+        Create sinusoidal timestep embeddings.
+        :param t: a 1-D Tensor of N indices, one per batch element.
+                          These may be fractional.
+        :param dim: the dimension of the output.
+        :param max_period: controls the minimum frequency of the embeddings.
+        :return: an (N, D) Tensor of positional embeddings.
+        """
+        half = self.frequency_embedding_dim // 2
+        freqs = torch.exp(
+            -torch.log(max_period) * torch.arange(start=0, end=half, dtype=self.dtype) / half
+        ).to(device=t.device)
+        args = t[:, None].float() * freqs[None]
+        embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+        if self.frequency_embedding_dim % 2:
+            embedding = torch.cat([embedding, torch.zeros_like(embedding[:, :1])], dim=-1)
+        return embedding
 
-# #NOTE: this is currently based on EDM, not on DiT
-class FourierEmbedding(torch.nn.Module):
-    def __init__(self, num_channels, scale=16):
-        super().__init__()
-        self.register_buffer('freqs', torch.randn(num_channels // 2) * scale)
+    def forward(self, t):
+        t_freq = self.timestep_embedding(t)
+        t_emb = self.mlp(t_freq)
+        return t_emb
 
-    def forward(self, x):
-        x = x.ger((2 * np.pi * self.freqs).to(x.dtype))
-        x = torch.cat([x.cos(), x.sin()], dim=1)
-        return x
-
-#TODO: Verify if need to add copyright notice.
+#TODO: Verify if need to add copyright notice to GenCast/DiT.
 #NOTE: This will be imported into attention.py.
-#NOTE: This is currently based on GenCast, not on DiT
 class LinearNormConditioning(torch.nn.Module):
-    """Module for norm conditioning, adapted from GenCast.
+    """Module for norm conditioning, adapted from GenCast with the additional gate parameter from DiT.
 
     Conditions the normalization of `inputs` by applying a linear layer to the
     `norm_conditioning` which produces the scale and offset for each channel.
@@ -244,20 +241,20 @@ class LinearNormConditioning(torch.nn.Module):
 
         self.conditional_linear_layer = torch.nn.Linear(
             in_features=feature_size,
-            out_features=2 * feature_size,
+            out_features=3 * feature_size,
         )
         # Optional: initialize weights similar to TruncatedNormal(stddev=1e-8)
         torch.nn.init.normal_(self.conditional_linear_layer.weight, std=1e-8)
         torch.nn.init.zeros_(self.conditional_linear_layer.bias)
 
-    def forward(self, inputs, norm_conditioning, dtype = None):
+    def forward(self, inputs, norm_conditioning):
         # norm_conditioning: [batch, feature_size]
         # inputs: [batch, ..., feature_size]
         conditional_scale_offset = self.conditional_linear_layer(norm_conditioning.to(self.dtype))
-        scale_minus_one, offset = torch.chunk(conditional_scale_offset, 2, dim=-1)
+        scale_minus_one, offset, gate = torch.chunk(conditional_scale_offset, 3, dim=-1)
         scale = scale_minus_one + 1.0
         # Reshape scale and offset for broadcasting if needed
         while scale.dim() < inputs.dim():
             scale = scale.unsqueeze(1)
             offset = offset.unsqueeze(1)
-        return (inputs * scale + offset).to(self.dtype) #TODO: check if to(self.dtype) needed here
+        return (inputs * scale + offset).to(self.dtype), gate  #TODO: check if to(self.dtype) needed here

--- a/src/weathergen/model/diffusion.py
+++ b/src/weathergen/model/diffusion.py
@@ -16,18 +16,11 @@
 
 
 import dataclasses
-
-import torch
-from torch.nn.functional import silu
-import weathergen.common.config as config
-import numpy as np
 import math
 
+import torch
+
 from weathergen.model.engines import ForecastingEngine
-
-
-
-
 
 
 @dataclasses.dataclass
@@ -61,8 +54,8 @@ class DiffusionForecastEngine(torch.nn.Module):
     def __init__(
         self,
         forecast_engine: ForecastingEngine,
-        frequency_embedding_dim: int = 256,  #TODO: determine suitable dimension
-        embedding_dim: int = 512,  #TODO: determine suitable dimension
+        frequency_embedding_dim: int = 256,  # TODO: determine suitable dimension
+        embedding_dim: int = 512,  # TODO: determine suitable dimension
         sigma_min: float = 0.002,  # Adapt to GenCast?
         sigma_max: float = 80,
         sigma_data: float = 0.5,
@@ -73,7 +66,9 @@ class DiffusionForecastEngine(torch.nn.Module):
         super().__init__()
         self.net = forecast_engine
         self.preconditioner = Preconditioner()
-        self.noise_embedder = NoiseEmbedder(embedding_dim=embedding_dim, frequency_embedding_dim=frequency_embedding_dim)
+        self.noise_embedder = NoiseEmbedder(
+            embedding_dim=embedding_dim, frequency_embedding_dim=frequency_embedding_dim
+        )
 
         # Parameters
         self.sigma_min = sigma_min
@@ -187,15 +182,13 @@ class Preconditioner:
         return x
 
 
-#NOTE: Adapted from DiT codebase:
+# NOTE: Adapted from DiT codebase:
 class NoiseEmbedder(torch.nn.Module):
     """
     Embeds scalar timesteps into vector representations.
     """
-    def __init__(self, 
-                 embedding_dim:int,
-                 frequency_embedding_dim:int,
-                 dtype=torch.bfloat16):
+
+    def __init__(self, embedding_dim: int, frequency_embedding_dim: int, dtype=torch.bfloat16):
         super().__init__()
         self.dtype = dtype
         self.mlp = torch.nn.Sequential(

--- a/src/weathergen/model/diffusion.py
+++ b/src/weathergen/model/diffusion.py
@@ -15,10 +15,10 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Third-Party Attribution: google-deepmind/graphcast (several associated papers)
-# This file incorporates code originally from the 'google-deepmind/graphcast' repository, with adaptations.
+# Third-Party Attribution: facebookresearch/DiT (Scalable Diffusion Models with Transformers (DiT))
+# This file incorporates code originally from the 'facebookresearch/DiT' repository, with adaptations.
 #
-# The original code is licensed under Apache 2.0. Original Copyright 2024 DeepMind Technologies Limited.
+# The original code is licensed under CC-BY-NC.
 # ----------------------------------------------------------------------------
 
 

--- a/src/weathergen/model/diffusion.py
+++ b/src/weathergen/model/diffusion.py
@@ -104,7 +104,7 @@ class DiffusionForecastEngine(torch.nn.Module):
         # noise = torch.randn(y.shape, device=y.device)  # now eta from MultiStreamDataSampler
         sigma = (eta * self.p_std + self.p_mean).exp()
         n = torch.randn_like(y) * sigma
-        return self.denoise(x=y + n, fstep=fstep, c=c, sigma=sigma)
+        return self.denoise(x=y + n, c=c, sigma=sigma, fstep=fstep)
 
         # Compute loss -- move this to a separate loss calculator
         # weight = (sigma**2 + self.sigma_data**2) / (sigma * self.sigma_data) ** 2  # Table 1
@@ -123,11 +123,11 @@ class DiffusionForecastEngine(torch.nn.Module):
         c_noise = sigma.log() / 4
 
         # Embed noise level
-        emb = self.noise_embedder(c_noise)
+        noise_emb = self.noise_embedder(c_noise)
 
         # Precondition input and feed through network
         x = self.preconditioner.precondition(x, c)
-        return c_skip * x + c_out * self.net(c_in * x, fstep=fstep, emb=emb)  # Eq. (7) in EDM paper
+        return c_skip * x + c_out * self.net(c_in * x, fstep=fstep, noise_emb=noise_emb)  # Eq. (7) in EDM paper
 
     def inference(
         self,
@@ -203,7 +203,7 @@ class NoiseEmbedder(torch.nn.Module):
         )
         self.frequency_embedding_dim = frequency_embedding_dim
 
-    def timestep_embedding(self, t, max_period=10000):
+    def timestep_embedding(self, t: float, max_period: int=10000):
         """
         Create sinusoidal timestep embeddings.
         :param t: a 1-D Tensor of N indices, one per batch element.
@@ -222,7 +222,7 @@ class NoiseEmbedder(torch.nn.Module):
             embedding = torch.cat([embedding, torch.zeros_like(embedding[:, :1])], dim=-1)
         return embedding
 
-    def forward(self, t):
+    def forward(self, t: float):
         t_freq = self.timestep_embedding(t)
         t_emb = self.mlp(t_freq)
         return t_emb

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -379,14 +379,14 @@ class ForecastingEngine(torch.nn.Module):
         for block in self.fe_blocks:
             block.apply(init_weights_final)
 
-    def forward(self, tokens, fstep, emb=None):
+    def forward(self, tokens, fstep, noise_emb=None):
         aux_info = torch.tensor([fstep], dtype=torch.float32, device="cuda")
         if self.cf.fe_diffusion_model:
-            assert emb is not None, (
-                "Noise embedding must be provided for diffusion forecasting engine"
+            assert noise_emb is not None, (
+                "Noise embedding must be provided for diffusion forecast engine"
             )
             for block in self.fe_blocks:
-                tokens = checkpoint(block, tokens, emb, aux_info, use_reentrant=False)
+                tokens = checkpoint(block, tokens, noise_emb, aux_info, use_reentrant=False)
         else:
             for block in self.fe_blocks:
                 tokens = checkpoint(block, tokens, aux_info, use_reentrant=False)

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -336,7 +336,7 @@ class ForecastingEngine(torch.nn.Module):
                             dim_aux=1,
                             norm_eps=self.cf.norm_eps,
                             attention_dtype=get_dtype(self.cf.attention_dtype),
-                            with_noise_conditioning=self.cf.fe_diffusion_model
+                            with_noise_conditioning=self.cf.fe_diffusion_model,
                         )
                     )
                 else:
@@ -353,7 +353,7 @@ class ForecastingEngine(torch.nn.Module):
                             dim_aux=1,
                             norm_eps=self.cf.norm_eps,
                             attention_dtype=get_dtype(self.cf.attention_dtype),
-                            with_noise_conditioning=self.cf.fe_diffusion_model
+                            with_noise_conditioning=self.cf.fe_diffusion_model,
                         )
                     )
                 # Add MLP block
@@ -366,7 +366,7 @@ class ForecastingEngine(torch.nn.Module):
                         norm_type=self.cf.norm_type,
                         dim_aux=1,
                         norm_eps=self.cf.mlp_norm_eps,
-                        with_noise_conditioning=self.cf.fe_diffusion_model
+                        with_noise_conditioning=self.cf.fe_diffusion_model,
                     )
                 )
 
@@ -382,7 +382,9 @@ class ForecastingEngine(torch.nn.Module):
     def forward(self, tokens, fstep, emb=None):
         aux_info = torch.tensor([fstep], dtype=torch.float32, device="cuda")
         if self.cf.fe_diffusion_model:
-            assert emb is not None, "Noise embedding must be provided for diffusion forecasting engine"
+            assert emb is not None, (
+                "Noise embedding must be provided for diffusion forecasting engine"
+            )
             for block in self.fe_blocks:
                 tokens = checkpoint(block, tokens, emb, aux_info, use_reentrant=False)
         else:

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -336,7 +336,7 @@ class ForecastingEngine(torch.nn.Module):
                             dim_aux=1,
                             norm_eps=self.cf.norm_eps,
                             attention_dtype=get_dtype(self.cf.attention_dtype),
-                            with_noise_conditioning=self.cf.fe_diffusion
+                            with_noise_conditioning=self.cf.fe_diffusion_model
                         )
                     )
                 else:
@@ -353,7 +353,7 @@ class ForecastingEngine(torch.nn.Module):
                             dim_aux=1,
                             norm_eps=self.cf.norm_eps,
                             attention_dtype=get_dtype(self.cf.attention_dtype),
-                            with_noise_conditioning=self.cf.fe_diffusion
+                            with_noise_conditioning=self.cf.fe_diffusion_model
                         )
                     )
                 # Add MLP block
@@ -366,7 +366,7 @@ class ForecastingEngine(torch.nn.Module):
                         norm_type=self.cf.norm_type,
                         dim_aux=1,
                         norm_eps=self.cf.mlp_norm_eps,
-                        with_noise_conditioning=self.cf.fe_diffusion
+                        with_noise_conditioning=self.cf.fe_diffusion_model
                     )
                 )
 
@@ -381,13 +381,13 @@ class ForecastingEngine(torch.nn.Module):
 
     def forward(self, tokens, fstep, emb=None):
         aux_info = torch.tensor([fstep], dtype=torch.float32, device="cuda")
-        if self.cf.fe_diffusion:
+        if self.cf.fe_diffusion_model:
             assert emb is not None, "Noise embedding must be provided for diffusion forecasting engine"
             for block in self.fe_blocks:
                 tokens = checkpoint(block, tokens, emb, aux_info, use_reentrant=False)
         else:
             for block in self.fe_blocks:
-                tokens = checkpoint(block, tokens, use_reentrant=False)
+                tokens = checkpoint(block, tokens, aux_info, use_reentrant=False)
 
         return tokens
 

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -336,6 +336,7 @@ class ForecastingEngine(torch.nn.Module):
                             dim_aux=1,
                             norm_eps=self.cf.norm_eps,
                             attention_dtype=get_dtype(self.cf.attention_dtype),
+                            with_noise_conditioning=self.cf.fe_diffusion
                         )
                     )
                 else:
@@ -352,6 +353,7 @@ class ForecastingEngine(torch.nn.Module):
                             dim_aux=1,
                             norm_eps=self.cf.norm_eps,
                             attention_dtype=get_dtype(self.cf.attention_dtype),
+                            with_noise_conditioning=self.cf.fe_diffusion
                         )
                     )
                 # Add MLP block
@@ -364,6 +366,7 @@ class ForecastingEngine(torch.nn.Module):
                         norm_type=self.cf.norm_type,
                         dim_aux=1,
                         norm_eps=self.cf.mlp_norm_eps,
+                        with_noise_conditioning=self.cf.fe_diffusion
                     )
                 )
 
@@ -376,10 +379,15 @@ class ForecastingEngine(torch.nn.Module):
         for block in self.fe_blocks:
             block.apply(init_weights_final)
 
-    def forward(self, tokens, fstep):
+    def forward(self, tokens, fstep, emb=None):
         aux_info = torch.tensor([fstep], dtype=torch.float32, device="cuda")
-        for block in self.fe_blocks:
-            tokens = checkpoint(block, tokens, aux_info, use_reentrant=False)
+        if self.cf.fe_diffusion:
+            assert emb is not None, "Noise embedding must be provided for diffusion forecasting engine"
+            for block in self.fe_blocks:
+                tokens = checkpoint(block, tokens, emb, aux_info, use_reentrant=False)
+        else:
+            for block in self.fe_blocks:
+                tokens = checkpoint(block, tokens, use_reentrant=False)
 
         return tokens
 

--- a/src/weathergen/model/layers.py
+++ b/src/weathergen/model/layers.py
@@ -7,6 +7,20 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+# ----------------------------------------------------------------------------
+# Third-Party Attribution: facebookresearch/DiT (Scalable Diffusion Models with Transformers (DiT))
+# This file incorporates code originally from the 'facebookresearch/DiT' repository, with adaptations.
+#
+# The original code is licensed under CC-BY-NC.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Third-Party Attribution: facebookresearch/DiT (Scalable Diffusion Models with Transformers (DiT))
+# This file incorporates code originally from the 'facebookresearch/DiT' repository, with adaptations.
+#
+# The original code is licensed under CC-BY-NC.
+# ----------------------------------------------------------------------------
+
 
 import torch
 import torch.nn as nn
@@ -111,8 +125,7 @@ class MLP(torch.nn.Module):
         return x
 
 
-# TODO: Verify if need to add copyright notice to GenCast/DiT.
-# NOTE: This will be imported into attention.py.
+# NOTE: Inspired by GenCast/DiT.
 class LinearNormConditioning(torch.nn.Module):
     """Module for norm conditioning, adapted from GenCast with additional gate parameter from DiT.
 

--- a/src/weathergen/model/layers.py
+++ b/src/weathergen/model/layers.py
@@ -108,11 +108,11 @@ class MLP(torch.nn.Module):
             aux = args[1]
         elif len(args) > 2:
             aux = args[-1]
-            emb = args[1] if self.with_noise_conditioning else None
+            noise_emb = args[1] if self.with_noise_conditioning else None
 
         for i, layer in enumerate(self.layers):
             if isinstance(layer, LinearNormConditioning):
-                x = layer(x, emb)  # noise embedding
+                x = layer(x, noise_emb)  # noise embedding
             else:
                 x = layer(x, aux) if (i == 0 and self.with_aux) else layer(x)
 
@@ -146,8 +146,8 @@ class LinearNormConditioning(torch.nn.Module):
         torch.nn.init.normal_(self.conditional_linear_layer.weight, std=1e-8)
         torch.nn.init.zeros_(self.conditional_linear_layer.bias)
 
-    def forward(self, inputs, emb):
-        conditional_scale_offset = self.conditional_linear_layer(emb.to(self.dtype))
+    def forward(self, inputs, noise_emb):
+        conditional_scale_offset = self.conditional_linear_layer(noise_emb.to(self.dtype))
         scale_minus_one, offset, gate = torch.chunk(conditional_scale_offset, 3, dim=-1)
         scale = scale_minus_one + 1.0
 

--- a/src/weathergen/model/layers.py
+++ b/src/weathergen/model/layers.py
@@ -15,11 +15,12 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Third-Party Attribution: facebookresearch/DiT (Scalable Diffusion Models with Transformers (DiT))
-# This file incorporates code originally from the 'facebookresearch/DiT' repository, with adaptations.
+# Third-Party Attribution: google-deepmind/graphcast (several associated papers)
+# This file incorporates code originally from the 'google-deepmind/graphcast' repository, with adaptations.
 #
-# The original code is licensed under CC-BY-NC.
+# The original code is licensed under Apache 2.0. Original Copyright 2024 DeepMind Technologies Limited.
 # ----------------------------------------------------------------------------
+
 
 
 import torch

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -30,7 +30,7 @@ def write_output(
     sample_idxs,
 ):
     stream_names = [stream.name for stream in cf.streams]
-    analysis_streams_output = cf.get( 'analysis_streams_output', None)
+    analysis_streams_output = cf.get("analysis_streams_output", None)
     if cf.streams_output is not None:
         output_stream_names = cf.streams_output
     elif analysis_streams_output is not None:  # --- to be removed at some point ---


### PR DESCRIPTION
## Description

Merge the noise embedding and conditioning functionality into the branch which collects all the diffusion PRs before merging into develop. Main new components are NoiseEmbedder and LinearNormConditioning. I tried to keep the changes as separate from existing code as possible, however some changes in the attention.py and engine.py were necessary to allow passing the noise embedding to the attention and MLP blocks. The implementation in large parts follows the DiT paper, but some adaptations have been made which are drawn form the EDM paper or GenCast. The code runs with the given default config, meaning that all shapes are aligned. The code has not been tested to ensure all new functionality works as intended. The code also runs when the fe_diffusion_model is set to False, but code should still be reviewed to ensure old functionality is not impacted. 

Copyright notices still to be added (can anyone point me to a resource on when it is necessary and how to do it?)

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number

Closes #1279 
Closes #1276 

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code
      **got Driver Not Loaded error on JuwelsBooster, but it worked with `uv run train`**
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
