### PR TITLE
Sb asma/develop/1361 fix zero div error

### DIFF
--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -488,7 +488,8 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
             # Check if workload is divisible by number of workers
             workload = local_end - local_start
             assert workload % worker_info.num_workers == 0, (
-                f"Workload {workload} is not divisible by number of workers {worker_info.num_workers}"
+                f"Workload {workload} is not divisible by number of workers "
+                f"{worker_info.num_workers}"
             )
             
             # split workload

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -484,8 +484,15 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                 * (self.mini_epoch + 13)
                 * 7
             )
+            
+            # Check if workload is divisible by number of workers
+            workload = local_end - local_start
+            assert workload % worker_info.num_workers == 0, (
+                f"Workload {workload} is not divisible by number of workers {worker_info.num_workers}"
+            )
+            
             # split workload
-            per_worker = (local_end - local_start) // worker_info.num_workers
+            per_worker = workload // worker_info.num_workers
             iter_start = local_start + worker_info.id * per_worker
             iter_end = iter_start + per_worker
             if worker_info.id + 1 == worker_info.num_workers:

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -292,9 +292,10 @@ class Trainer(TrainerBase):
             len_per_rank = (
                 len(self.dataset) // (self.world_size_original * cf.batch_size_per_gpu)
             ) * cf.batch_size_per_gpu
+            istep_denom = min(len_per_rank, cf.samples_per_mini_epoch) * self.world_size_original
             mini_epoch_base = int(
                 self.cf.istep
-                / (min(len_per_rank, cf.samples_per_mini_epoch) * self.world_size_original)
+                / max(istep_denom, 1)
             )
 
         # torch.autograd.set_detect_anomaly(True)


### PR DESCRIPTION
## Description

1) In `src/weathergen/datasets/multi_stream_data_sampler.py`: Added assertion to ensure workload is properly divisible by the number of workers
2) In `src/weathergen/train/trainer.p`: Safety fallback to avoid istep being divided by zero.

## Issue Number

Closes #1361 

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [X] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
