### PR TITLE
Enable single sample processing 

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -50,6 +50,7 @@ fe_num_heads: 16
 fe_dropout_rate: 0.1
 fe_with_qk_lnorm: True
 fe_diffusion_model: True
+repeat_data: True
 impute_latent_noise_std: 0.0  # 1e-4
 # Diffusion related parameters
 frequency_embedding_dim: 256
@@ -150,8 +151,8 @@ training_config:
     loss: "LatentDiffusionLoss" # placeholder
 
 num_mini_epochs: 32
-samples_per_mini_epoch: 4096
-samples_per_validation: 512
+samples_per_mini_epoch: 2
+samples_per_validation: 2
 
 shuffle: True
 

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -152,10 +152,10 @@ training_config:
     loss: "LatentDiffusionLoss" # placeholder
 
 num_mini_epochs: 32
-samples_per_mini_epoch: 10
-samples_per_validation: 10
+samples_per_mini_epoch: 4096
+samples_per_validation: 512
 
-shuffle: False
+shuffle: True
 
 lr_scaling_policy: "sqrt"
 lr_start: 1e-6

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -117,7 +117,6 @@ validation_mode_config: {
   "teacher_model": {}
 }
 # masking
-masking_strategy: "random" # obviously TODO
 # masking rate when training mode is "masking"; ignored in foreacast mode
 masking_rate: 0.6
 #
@@ -137,6 +136,8 @@ masking_strategy_config: {"strategies": ["random", "healpix", "channel"],
 
 # Student-teacher configuration (only used when training_mode == "student_teacher")
 # TODO: adapt so that the masking or forecast config entry also sits here
+masking_strategy: "forecast" # obviously TODO
+
 training_config:
   # when this is "masking", we are basically only using the model_input subconfig
   training_mode: "diffusion_forecast"  # "masking", "student_teacher", "forecast"
@@ -151,10 +152,10 @@ training_config:
     loss: "LatentDiffusionLoss" # placeholder
 
 num_mini_epochs: 32
-samples_per_mini_epoch: 2
-samples_per_validation: 2
+samples_per_mini_epoch: 10
+samples_per_validation: 10
 
-shuffle: True
+shuffle: False
 
 lr_scaling_policy: "sqrt"
 lr_start: 1e-6

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -176,9 +176,9 @@ log_grad_norms: False
 
 # start_date: 197901010000
 start_date: 201401010000
-end_date: 201401011200
+end_date: 201401011800
 start_date_val: 201401010000
-end_date_val: 201401011200
+end_date_val: 201401011800
 len_hrs: 6
 step_hrs: 6
 input_window_steps: 1

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -39,7 +39,7 @@ pred_mlp_adaln: True
 
 # number of steps offset applied to first target window; if set to zero and forecast_steps=0 then
 # one is training an auto-encoder
-forecast_offset : 1
+forecast_offset : 0
 forecast_delta_hrs: 0
 forecast_steps: 1
 forecast_policy: "fixed"
@@ -174,9 +174,9 @@ log_grad_norms: False
 
 # start_date: 197901010000
 start_date: 201401010000
-end_date: 202012310000
-start_date_val: 202101010000
-end_date_val: 202201010000
+end_date: 201401011200
+start_date_val: 201401010000
+end_date_val: 201401011200
 len_hrs: 6
 step_hrs: 6
 input_window_steps: 1

--- a/src/weathergen/datasets/data_reader_anemoi.py
+++ b/src/weathergen/datasets/data_reader_anemoi.py
@@ -75,8 +75,10 @@ class DataReaderAnemoi(DataReaderTimestep):
         ds: Dataset = anemoi_datasets.open_dataset(
             ds0, **kwargs, start=tw_handler.t_start, end=tw_handler.t_end
         )
-
-        period = np.timedelta64(ds.frequency)
+        if len(ds.dates) != 1:
+            period = np.timedelta64(ds.frequency)
+        else:
+            period = np.timedelta64(0, "s")
         data_start_time = ds.dates[0]
         data_end_time = ds.dates[-1]
         assert data_start_time is not None and data_end_time is not None, (

--- a/src/weathergen/datasets/data_reader_anemoi.py
+++ b/src/weathergen/datasets/data_reader_anemoi.py
@@ -75,10 +75,7 @@ class DataReaderAnemoi(DataReaderTimestep):
         ds: Dataset = anemoi_datasets.open_dataset(
             ds0, **kwargs, start=tw_handler.t_start, end=tw_handler.t_end
         )
-        if len(ds.dates) != 1:
-            period = np.timedelta64(ds.frequency)
-        else:
-            period = np.timedelta64(0, "s")
+        period = np.timedelta64(ds.frequency)
         data_start_time = ds.dates[0]
         data_end_time = ds.dates[-1]
         assert data_start_time is not None and data_end_time is not None, (

--- a/src/weathergen/datasets/data_reader_base.py
+++ b/src/weathergen/datasets/data_reader_base.py
@@ -146,7 +146,7 @@ class TimeWindowHandler:
         self.t_window_len: NPTDel64 = np.timedelta64(t_window_len_hours, "h")
         self.t_window_step: NPTDel64 = np.timedelta64(t_window_step_hours, "h")
 
-        assert self.t_start <= self.t_end, "end datetime has to be in the past of start datetime"
+        assert self.t_start < self.t_end, "end datetime has to be in the past of start datetime"
         assert self.t_start > _DT_ZERO, "start datetime has to be >= 1850-01-01T00:00."
 
     def get_index_range(self) -> TimeIndexRange:

--- a/src/weathergen/datasets/data_reader_base.py
+++ b/src/weathergen/datasets/data_reader_base.py
@@ -146,7 +146,7 @@ class TimeWindowHandler:
         self.t_window_len: NPTDel64 = np.timedelta64(t_window_len_hours, "h")
         self.t_window_step: NPTDel64 = np.timedelta64(t_window_step_hours, "h")
 
-        assert self.t_start < self.t_end, "end datetime has to be in the past of start datetime"
+        assert self.t_start <= self.t_end, "end datetime has to be in the past of start datetime"
         assert self.t_start > _DT_ZERO, "start datetime has to be >= 1850-01-01T00:00."
 
     def get_index_range(self) -> TimeIndexRange:

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -284,12 +284,18 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         assert idx_end > 0, "dataset size too small for forecast range"
         self.perms = np.arange(index_range.start, idx_end)
         if self.repeat_data and len(self.perms) < self.samples_per_mini_epoch:
-            assert self.samples_per_mini_epoch % len(self.perms) == 0, (
-                "Length of mini epoch is not a multiple of length of available data –- aborting."
-            )
-            self.perms = np.tile(
-                self.perms, self.samples_per_mini_epoch // len(self.perms)
-            )
+            if self.samples_per_mini_epoch % len(self.perms) == 0:
+                self.perms = np.tile(
+                    self.perms, self.samples_per_mini_epoch // len(self.perms)
+                )
+            else:
+                self.perms = np.tile(
+                    self.perms, self.samples_per_mini_epoch // len(self.perms)
+                )
+                random_filler = self.rng.choice(
+                    self.perms, size=self.samples_per_mini_epoch - len(self.perms), replace=False
+                )
+                self.perms = np.concatenate([self.perms, random_filler])
 
         if self.shuffle:
             self.perms = self.rng.permutation(self.perms)

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -276,15 +276,23 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         idx_end = index_range.end
         # native length of datasets, independent of mini_epoch length that has potentially been
         # specified
-        forecast_len = (self.len_hrs * (fsm)) // self.step_hrs  # TODO: check if it should be fsm + 1
+        forecast_len = (
+            self.len_hrs * (fsm)
+        ) // self.step_hrs  # TODO: check if it should be fsm + 1
         idx_end -= forecast_len + self.forecast_offset
 
         assert idx_end > 0, "dataset size too small for forecast range"
         self.perms = np.arange(index_range.start, idx_end)
         if self.repeat_data:
-            assert self.samples_per_mini_epoch == self.len, "Length of sampler was set different from samples_per_mini_epoch –- aborting to avoid unintended effects."
-            assert self.len % len(self.perms) == 0, "Length of permutations is not a multiple of length of available data –- aborting to avoid unintended effects."
-            self.perms = np.tile(self.perms, self.len // len(self.perms)) #TODO: maybe use samples_per_mini_epoch?
+            assert self.samples_per_mini_epoch == self.len, (
+                "Length of sampler was set different from samples_per_mini_epoch –- aborting."
+            )
+            assert self.len % len(self.perms) == 0, (
+                "Length of permutations is not a multiple of length of available data –- aborting."
+            )
+            self.perms = np.tile(
+                self.perms, self.len // len(self.perms)
+            )  # TODO: maybe use samples_per_mini_epoch?
             self.len = len(self.perms)
 
         if self.shuffle:
@@ -778,8 +786,9 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                 streams_data += [v for k, v in stream_data_source.items()]
 
         elif mode == "diffusion_forecast":
-
-            assert self.tokenizer.masker.current_strategy == "forecast", "No masking should be applied during diffusion forecasting."
+            assert self.tokenizer.masker.current_strategy == "forecast", (
+                "No masking should be applied during diffusion forecasting."
+            )
 
             streams_data: list[StreamData] = []
 

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -83,7 +83,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         start_date = str_to_datetime64(start_date_)
         end_date = str_to_datetime64(end_date_)
 
-        assert end_date >= start_date, (end_date, start_date)
+        assert end_date > start_date, (end_date, start_date)
 
         self.mask_value = 0.0
         self._stage = stage
@@ -256,8 +256,6 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         # value in worker_workset()
         self.rng = np.random.default_rng(self.data_loader_rng_seed)
 
-        print(self.forecast_steps)
-
         fsm = (
             self.forecast_steps[min(self.mini_epoch, len(self.forecast_steps) - 1)]
             if self.forecast_policy != "random"
@@ -271,19 +269,19 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         idx_end = index_range.end
         # native length of datasets, independent of mini_epoch length that has potentially been
         # specified
-        print(f'idx range end is {idx_end}')
-        print(f'len hrs is {self.len_hrs}, step hrs is {self.step_hrs}, fsm is {fsm}')
-        forecast_len = (self.len_hrs * (fsm)) // self.step_hrs #NOTE: why was it fsm +1?
-        print(f'forecast len is {forecast_len}')
+        print(f"idx range end is {idx_end}")
+        print(f"len hrs is {self.len_hrs}, step hrs is {self.step_hrs}, fsm is {fsm}")
+        forecast_len = (self.len_hrs * (fsm + 1)) // self.step_hrs  # NOTE: why is it fsm +1?
+        print(f"forecast len is {forecast_len}")
         idx_end -= forecast_len + self.forecast_offset
-        print(f'adjusted idx_end is {idx_end}')
-        
+        print(f"adjusted idx_end is {idx_end}")
+
         assert idx_end > 0, "dataset size too small for forecast range"
         self.perms = np.arange(index_range.start, idx_end)
         if self.shuffle:
             self.perms = self.rng.permutation(self.perms)
-        
-        print(f'Perms are: {self.perms}')
+
+        print(f"Perms are: {self.perms}")
 
         # forecast time steps
         len_dt_samples = len(self) // self.batch_size

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -278,7 +278,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         # specified
         forecast_len = (
             self.len_hrs * (fsm + 1)
-        ) // self.step_hrs  # TODO: check if it should be fsm + 1
+        ) // self.step_hrs
         idx_end -= forecast_len + self.forecast_offset
 
         assert idx_end > 0, "dataset size too small for forecast range"

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -283,7 +283,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
 
         assert idx_end > 0, "dataset size too small for forecast range"
         self.perms = np.arange(index_range.start, idx_end)
-        if self.repeat_data:
+        if self.repeat_data and len(self.perms) < self.len:
             assert self.samples_per_mini_epoch == self.len, (
                 "Length of sampler was set different from samples_per_mini_epoch –- aborting."
             )

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -188,6 +188,8 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
 
         index_range = self.time_window_handler.get_index_range()
         self.len = int(index_range.end - index_range.start)
+
+        # check the repeat data flag and adjust len accordingly
         if not self.repeat_data:
             self.len = min(self.len, samples_per_mini_epoch if samples_per_mini_epoch else self.len)
         else:
@@ -283,6 +285,8 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
 
         assert idx_end > 0, "dataset size too small for forecast range"
         self.perms = np.arange(index_range.start, idx_end)
+
+        # check repeat_data flag and fill up perms accordingly
         if self.repeat_data and len(self.perms) < self.samples_per_mini_epoch:
             if self.samples_per_mini_epoch % len(self.perms) == 0:
                 self.perms = np.tile(

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -83,7 +83,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         start_date = str_to_datetime64(start_date_)
         end_date = str_to_datetime64(end_date_)
 
-        assert end_date > start_date, (end_date, start_date)
+        assert end_date >= start_date, (end_date, start_date)
 
         self.mask_value = 0.0
         self._stage = stage
@@ -256,6 +256,8 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         # value in worker_workset()
         self.rng = np.random.default_rng(self.data_loader_rng_seed)
 
+        print(self.forecast_steps)
+
         fsm = (
             self.forecast_steps[min(self.mini_epoch, len(self.forecast_steps) - 1)]
             if self.forecast_policy != "random"
@@ -269,12 +271,19 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         idx_end = index_range.end
         # native length of datasets, independent of mini_epoch length that has potentially been
         # specified
-        forecast_len = (self.len_hrs * (fsm + 1)) // self.step_hrs
+        print(f'idx range end is {idx_end}')
+        print(f'len hrs is {self.len_hrs}, step hrs is {self.step_hrs}, fsm is {fsm}')
+        forecast_len = (self.len_hrs * (fsm)) // self.step_hrs #NOTE: why was it fsm +1?
+        print(f'forecast len is {forecast_len}')
         idx_end -= forecast_len + self.forecast_offset
+        print(f'adjusted idx_end is {idx_end}')
+        
         assert idx_end > 0, "dataset size too small for forecast range"
         self.perms = np.arange(index_range.start, idx_end)
         if self.shuffle:
             self.perms = self.rng.permutation(self.perms)
+        
+        print(f'Perms are: {self.perms}')
 
         # forecast time steps
         len_dt_samples = len(self) // self.batch_size

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -277,23 +277,19 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         # native length of datasets, independent of mini_epoch length that has potentially been
         # specified
         forecast_len = (
-            self.len_hrs * (fsm)
+            self.len_hrs * (fsm + 1)
         ) // self.step_hrs  # TODO: check if it should be fsm + 1
         idx_end -= forecast_len + self.forecast_offset
 
         assert idx_end > 0, "dataset size too small for forecast range"
         self.perms = np.arange(index_range.start, idx_end)
-        if self.repeat_data and len(self.perms) < self.len:
-            assert self.samples_per_mini_epoch == self.len, (
-                "Length of sampler was set different from samples_per_mini_epoch –- aborting."
-            )
-            assert self.len % len(self.perms) == 0, (
-                "Length of permutations is not a multiple of length of available data –- aborting."
+        if self.repeat_data and len(self.perms) < self.samples_per_mini_epoch:
+            assert self.samples_per_mini_epoch % len(self.perms) == 0, (
+                "Length of mini epoch is not a multiple of length of available data –- aborting."
             )
             self.perms = np.tile(
-                self.perms, self.len // len(self.perms)
-            )  # TODO: maybe use samples_per_mini_epoch?
-            self.len = len(self.perms)
+                self.perms, self.samples_per_mini_epoch // len(self.perms)
+            )
 
         if self.shuffle:
             self.perms = self.rng.permutation(self.perms)

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -598,8 +598,8 @@ class Model(torch.nn.Module):
         (streams_data, _, target_coords_idxs, metadata) = batch
 
         tokens, posteriors = self.encode(model_params=model_params, batch=batch)
-        
-        #TODO: Check here that the tokens are always the same when overfitting to a single sample
+
+        # TODO: Check here that the tokens are always the same when overfitting to a single sample
 
         if encode_only:
             return tokens, posteriors

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -598,6 +598,9 @@ class Model(torch.nn.Module):
         (streams_data, _, target_coords_idxs, metadata) = batch
 
         tokens, posteriors = self.encode(model_params=model_params, batch=batch)
+        
+        #TODO: Check here that the tokens are always the same when overfitting to a single sample
+
         if encode_only:
             return tokens, posteriors
 

--- a/src/weathergen/train/loss_modules/loss_module_latent_diffusion.py
+++ b/src/weathergen/train/loss_modules/loss_module_latent_diffusion.py
@@ -97,9 +97,7 @@ class LossLatentDiffusion(LossModuleBase):
 
         loss_fsteps = torch.tensor(0.0, device=self.device, requires_grad=True)
         ctr_fsteps = 0
-        print(
-            f"lengths are: target_tokens_all: {len(target_tokens_all)}, pred_tokens_all: {len(pred_tokens_all)}, fstep_loss_weights: {len(fstep_loss_weights)}"
-        )
+
         for target_tokens, pred_tokens, fstep_loss_weight in zip(
             target_tokens_all, pred_tokens_all, fstep_loss_weights, strict=True
         ):

--- a/src/weathergen/train/loss_modules/loss_module_latent_diffusion.py
+++ b/src/weathergen/train/loss_modules/loss_module_latent_diffusion.py
@@ -97,6 +97,7 @@ class LossLatentDiffusion(LossModuleBase):
 
         loss_fsteps = torch.tensor(0.0, device=self.device, requires_grad=True)
         ctr_fsteps = 0
+        print(f'lengths are: target_tokens_all: {len(target_tokens_all)}, pred_tokens_all: {len(pred_tokens_all)}, fstep_loss_weights: {len(fstep_loss_weights)}')
         for target_tokens, pred_tokens, fstep_loss_weight in zip(
             target_tokens_all, pred_tokens_all, fstep_loss_weights, strict=True
         ):

--- a/src/weathergen/train/loss_modules/loss_module_latent_diffusion.py
+++ b/src/weathergen/train/loss_modules/loss_module_latent_diffusion.py
@@ -97,7 +97,9 @@ class LossLatentDiffusion(LossModuleBase):
 
         loss_fsteps = torch.tensor(0.0, device=self.device, requires_grad=True)
         ctr_fsteps = 0
-        print(f'lengths are: target_tokens_all: {len(target_tokens_all)}, pred_tokens_all: {len(pred_tokens_all)}, fstep_loss_weights: {len(fstep_loss_weights)}')
+        print(
+            f"lengths are: target_tokens_all: {len(target_tokens_all)}, pred_tokens_all: {len(pred_tokens_all)}, fstep_loss_weights: {len(fstep_loss_weights)}"
+        )
         for target_tokens, pred_tokens, fstep_loss_weight in zip(
             target_tokens_all, pred_tokens_all, fstep_loss_weights, strict=True
         ):

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -820,6 +820,8 @@ class Trainer(TrainerBase):
         self.device_type = torch.accelerator.current_accelerator()
         self.device = torch.device(f"{self.device_type}:{self.cf.local_rank}")
         # forecast_steps is dropped here from the batch
+        for i, b in enumerate(batch[0]):
+            print(f'{i}th b before to_device: {b}')
         return (
             [[d.to_device(self.device) for d in db] for db in batch[0]],
             [b.to(self.device) for b in batch[1]],

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -495,6 +495,11 @@ class Trainer(TrainerBase):
 
         # training loop
         self.t_start = time.time()
+
+        #TODO: Remove after overfitting experiments
+        cur_source_sample = None
+        cur_target_sample = None
+
         for bidx, batch in enumerate(dataset_iter):
             # NOTE: we are still returning legacy batch structure and the new batch together.
 
@@ -540,6 +545,13 @@ class Trainer(TrainerBase):
                 for view in batch[-1].source_samples:
                     # TODO remove when ModelBatch and Sample get a to_device()
                     streams_data = [[view.streams_data["ERA5"]]]
+
+                    #TODO: Remove after overfitting experiments
+                    new_sample = streams_data[0][0].source_tokens_cells[0]
+                    if cur_source_sample is not None:
+                        assert torch.equal(cur_source_sample, new_sample), "Different source samples in batch, aborting."
+                    cur_source_sample = new_sample
+
                     streams_data = [[d.to_device(self.device) for d in db] for db in streams_data]
                     source_cell_lens = view.source_cell_lens
                     source_cell_lens = [b.to(self.device) for b in source_cell_lens]
@@ -566,6 +578,13 @@ class Trainer(TrainerBase):
                     # TODO remove when ModelBatch and Sample get a to_device()
                     streams_data = [[view.streams_data["ERA5"]]]
                     streams_data = [[d.to_device(self.device) for d in db] for db in streams_data]
+
+                    #TODO: Remove after overfitting experiments
+                    new_sample = streams_data[0][0].target_tokens[0]
+                    if cur_target_sample is not None:
+                        assert torch.equal(cur_target_sample, new_sample), "Different target tokens in batch, aborting."
+                    cur_target_sample = new_sample
+
                     source_cell_lens = view.source_cell_lens
                     source_cell_lens = [b.to(self.device) for b in source_cell_lens]
                     target_coords_idxs = view.target_coords_idx

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -496,7 +496,7 @@ class Trainer(TrainerBase):
         # training loop
         self.t_start = time.time()
 
-        #TODO: Remove after overfitting experiments
+        # TODO: Remove after overfitting experiments
         cur_source_sample = None
         cur_target_sample = None
 
@@ -546,10 +546,12 @@ class Trainer(TrainerBase):
                     # TODO remove when ModelBatch and Sample get a to_device()
                     streams_data = [[view.streams_data["ERA5"]]]
 
-                    #TODO: Remove after overfitting experiments
+                    # TODO: Remove after overfitting experiments
                     new_sample = streams_data[0][0].source_tokens_cells[0]
                     if cur_source_sample is not None:
-                        assert torch.equal(cur_source_sample, new_sample), "Different source samples in batch, aborting."
+                        assert torch.equal(cur_source_sample, new_sample), (
+                            "Different source samples in batch, aborting."
+                        )
                     cur_source_sample = new_sample
 
                     streams_data = [[d.to_device(self.device) for d in db] for db in streams_data]
@@ -579,10 +581,12 @@ class Trainer(TrainerBase):
                     streams_data = [[view.streams_data["ERA5"]]]
                     streams_data = [[d.to_device(self.device) for d in db] for db in streams_data]
 
-                    #TODO: Remove after overfitting experiments
+                    # TODO: Remove after overfitting experiments
                     new_sample = streams_data[0][0].target_tokens[0]
                     if cur_target_sample is not None:
-                        assert torch.equal(cur_target_sample, new_sample), "Different target tokens in batch, aborting."
+                        assert torch.equal(cur_target_sample, new_sample), (
+                            "Different target tokens in batch, aborting."
+                        )
                     cur_target_sample = new_sample
 
                     source_cell_lens = view.source_cell_lens

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -821,7 +821,7 @@ class Trainer(TrainerBase):
         self.device = torch.device(f"{self.device_type}:{self.cf.local_rank}")
         # forecast_steps is dropped here from the batch
         for i, b in enumerate(batch[0]):
-            print(f'{i}th b before to_device: {b}')
+            print(f"{i}th b before to_device: {b}")
         return (
             [[d.to_device(self.device) for d in db] for db in batch[0]],
             [b.to(self.device) for b in batch[1]],

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -820,8 +820,6 @@ class Trainer(TrainerBase):
         self.device_type = torch.accelerator.current_accelerator()
         self.device = torch.device(f"{self.device_type}:{self.cf.local_rank}")
         # forecast_steps is dropped here from the batch
-        for i, b in enumerate(batch[0]):
-            print(f"{i}th b before to_device: {b}")
         return (
             [[d.to_device(self.device) for d in db] for db in batch[0]],
             [b.to(self.device) for b in batch[1]],


### PR DESCRIPTION
## Description

Basically trying to enable the code to allow processing a single sample so we can overfit the diffusion model to a single sample.

We introduce a --repeat_data flag. When active, and the number of samples in the dataset is lower than the size of the mini epoch, then the data is tiled to fill up the mini epoch. Currently a check is introduced to ensure that in that case the number of samples evenly divides the size of the mini epoch to have a balanced mini epoch.

Some additional checks are introduced to avoid misconfigurations, see code.

Some checks may need to be removed after the overfitting experiment for the diffusion model.

Not currently addressing [#1370](https://github.com/ecmwf/WeatherGenerator/pull/1370).

<!--
Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number

Closes #1379 

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

## Checklist before asking for review

### Currently getting `ModuleNotFoundError: No module named 'flash_attn'` when running `uv run train`. Worked well before merging though...

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
