### PR TITLE
[1409] fix: missed renaming of `_agg_dims_in`

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/score.py
@@ -262,7 +262,7 @@ class Scores:
             self._agg_dims = list(data.prediction.dims)
         else:
             # Check if _agg_dims is in prediction data
-            for dim in self._agg_dims_in:
+            for dim in self._agg_dims:
                 if dim not in data.prediction.dims:
                     raise ValueError(
                         f"Average dimension '{dim}' not found in prediction data "


### PR DESCRIPTION
## Description

 `_agg_dims_in` was renamed to  `_agg_dims` in e85152b, however one occurrence was not renamed. This broke the evaluation workflow.

## Issue Number

Closes #1409

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
