### PR TITLE
Make missing fstep 0 produce a more meaningfull error

### DIFF
--- a/packages/common/src/weathergen/common/io.py
+++ b/packages/common/src/weathergen/common/io.py
@@ -186,7 +186,7 @@ class ItemKey:
         Infer forecast offset by the (non)presence of targets at fstep 0.
 
         Args:
-            datasets: Datasets found in a fstep 0 OutputItem.
+            datasets: Datasets found in a fstep 0 OutputItem (eg. ZarrIO.example_key).
         """
         # forecast offset=1 should produce no targets at fstep 0
         return 0 if "target" in datasets else 1
@@ -364,8 +364,7 @@ class ZarrIO:
             group = self.data_root.create_group(item.path)
         else:
             try:
-                group = self.data_root.get(item.path)
-                assert group is not None, f"Zarr group: {item.path} does not exist."
+                group = self.data_root[item.path]
             except KeyError as e:
                 msg = f"Zarr group: {item.path} has not been created."
                 raise FileNotFoundError(msg) from e
@@ -406,13 +405,17 @@ class ZarrIO:
 
     @functools.cached_property
     def example_key(self) -> ItemKey:
+        fstep = 0
         try:
             sample, example_sample = next(self.data_root.groups())
             stream, example_stream = next(example_sample.groups())
-            fstep = 0
         except StopIteration as e:
             msg = f"Data store at: {self._store_path} is empty."
             raise FileNotFoundError(msg) from e
+
+        assert fstep in example_stream.groups(), (
+            "fstep 0 is missisg, but should always contain at least sources."
+        )
 
         return ItemKey(sample, fstep, stream)
 


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->
#1087 changed the assumptions around fstep 0: It will now always contain the sources. This can be used to infer the forecast offset from the data: no targets present at fstep 0 => forecast offset 1 else 0.
This PR throws a more meaningful error when trying to evaluate on old (incompatible) inference results.

## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->
Closes #1282 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
