### PR TITLE
Wm/1270/cropping

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -1,5 +1,5 @@
-# streams_directory: "./config/streams/era5_1deg/"
-streams_directory: "./config/streams/era5_nppatms_synop/"
+streams_directory: "./config/streams/era5_1deg/"
+# streams_directory: "./config/streams/era5_nppatms_synop/"
 
 embed_orientation: "channels"
 embed_unembed_mode: "block"
@@ -119,28 +119,28 @@ ema_halflife_in_thousands: 1e-3
 
 # Student-teacher configuration (only used when training_mode == "student_teacher")
 # TODO: adapt so that the masking or forecast config entry also sits here
-training_config:
-  # when this is "masking", we are basically only using the model_input subconfig
-  training_mode: "masking"  # "masking", "student_teacher", "forecast"
+# training_config:
+#   # when this is "masking", we are basically only using the model_input subconfig
+#   training_mode: "masking"  # "masking", "student_teacher", "forecast"
 
-  model_input:
-    - masking_strategy: "random" # "random", "healpix". Masking strategy to use for model input for masking, and local (student) views when doing student-teacher
-      num_samples: 1  # if student-teacher, the number of local (student) views to generate
-      masking_strategy_config : { diffusion_rn : True, rate : 0.4 }
-      # masking_strategy_config: {"strategies": ["random", "healpix", "channel"], 
-      #                       "probabilities": [0.34, 0.33, 0.33],
-      #                       "hl_mask": 3, "mode": "per_cell",
-      #                       "same_strategy_per_batch": false
-      #                       }
-      # relationship: "independent" #, "subset", "disjoint". Relationship of student views to teacher view.
-      relationship: "complement"  # "independent", "subset", "disjoint". Relationship of student views to teacher view.
-      num_steps_input: 2
-      # loss : ibot
-      loss :
-        training :
-          - LossPhysical: {weight: 0.7, loss_fcts: [['mse', 0.8], ['mae', 0.2]]}
-        validation :
-          - LossPhysical: {weight: 1.0, loss_fcts: [['mse', 0.8]]}
+#   model_input:
+#     - masking_strategy: "random" # "random", "healpix". Masking strategy to use for model input for masking, and local (student) views when doing student-teacher
+#       num_samples: 1  # if student-teacher, the number of local (student) views to generate
+#       masking_strategy_config : { diffusion_rn : True, rate : 0.4 }
+#       # masking_strategy_config: {"strategies": ["random", "healpix", "channel"], 
+#       #                       "probabilities": [0.34, 0.33, 0.33],
+#       #                       "hl_mask": 3, "mode": "per_cell",
+#       #                       "same_strategy_per_batch": false
+#       #                       }
+#       # relationship: "independent" #, "subset", "disjoint". Relationship of student views to teacher view.
+#       relationship: "complement"  # "independent", "subset", "disjoint". Relationship of student views to teacher view.
+#       num_steps_input: 2
+#       # loss : ibot
+#       loss :
+#         training :
+#           - LossPhysical: {weight: 0.7, loss_fcts: [['mse', 0.8], ['mae', 0.2]]}
+#         validation :
+#           - LossPhysical: {weight: 1.0, loss_fcts: [['mse', 0.8]]}
     # - masking_strategy: "random"
     #   num_samples: 2  # if student-teacher, the number of local (student) views to generate
     #   masking_strategy_config : { diffusion_rn : True, rate : 0.4 }
@@ -187,12 +187,73 @@ training_config:
   #     num_samples: 1  # if student-teacher, the number of local (student) views to generate
   #     masking_strategy_config : { rate : 0.4 }
    
-  #   # masking_strategy: "cropping"  # Strategy for teacher (global) view: "random", "healpix"
-  #   # rate: 0.1  # Fraction of data to keep in global view (alternative: use "keep_m" for absolute count)
-  #   # num_samples: 2 # number of teacher views to generate
-  #   # hl_mask : 0 # healpix level to use for healpix masking strategy
-  #   # # keep_m: 100  # Alternative to rate: keep exactly this many parent cells
-  #   # rate_sampling: true  # randomly sample the rate per batch
+# ========================================
+# CROPPING EXAMPLES (cropping_healpix strategy)
+# ========================================
+# Spatial cropping: select and KEEP a spatially contiguous region, masking everything else
+# This is the inverse of healpix masking - perfect for SSL methods like DINO/JEPA/IBOT
+
+# Example 1: Basic spatial cropping (single global crop - 75% of sphere)
+training_config:
+  training_mode: "masking"
+  model_input:
+    - masking_strategy: "cropping_healpix"
+      num_samples: 1
+      masking_strategy_config:
+        hl_mask: 0          # HEALPix level for cropping (must be < healpix_level)
+        rate: 0.75          # Fraction of cells to KEEP (0.75 = keep 75%, mask 25%)
+        method: "geodesic_disk"  # Options: "disk", "random_walk", "geodesic_disk" (recommended)
+      relationship: "independent"
+      num_steps_input: 1
+      loss:
+        training:
+          - LossPhysical: {weight: 1.0, loss_fcts: [['mse', 1.0]]}
+
+# Example 2: DINO-style training (1 global + 3 local crops)
+# training_config:
+#   training_mode: "masking"
+#   target_input:
+#     - masking_strategy: "cropping_healpix"
+#       num_samples: 1
+#       masking_strategy_config: {hl_mask: 0, rate: 0.75, method: "geodesic_disk"}
+#   model_input:
+#     - masking_strategy: "cropping_healpix"
+#       num_samples: 3  # Creates 3 independent local crops
+#       masking_strategy_config: {hl_mask: 0, rate: 0.4, method: "geodesic_disk"}
+#       relationship: "independent"
+#       num_steps_input: 1
+#       loss:
+#         training:
+#           - LossPhysical: {weight: 1.0, loss_fcts: [['mse', 1.0]]}
+
+# Example 3: IBOT-style training (1 global teacher + 1 local student with controlled overlap)
+# training_config:
+#   training_mode: "masking"
+#   target_input:
+#     - masking_strategy: "cropping_healpix"
+#       num_samples: 1
+#       masking_strategy_config:
+#         hl_mask: 2          # HEALPix level 2 = 192 parent cells
+#         rate: 0.5           # Teacher crop: 50% of sphere
+#         method: "geodesic_disk"
+#   model_input:
+#     - masking_strategy: "cropping_healpix"
+#       num_samples: 1
+#       masking_strategy_config:
+#         hl_mask: 2          # Same level for consistent cropping
+#         rate: 0.3           # Student crop: 30% of sphere
+#         method: "geodesic_disk"
+#         overlap_ratio: 0.5  # 50% of student overlaps with teacher (15% overlap, 15% independent)
+#       relationship: "independent"
+#       num_steps_input: 1
+#       loss:
+#         training:
+#           - LossPhysical: {weight: 1.0, loss_fcts: [['mse', 1.0]]}
+#
+# Note: overlap_ratio controls what fraction of the STUDENT crop comes from the teacher:
+#   - 0.0 = completely disjoint (no overlap)
+#   - 0.5 = half of student overlaps with teacher
+#   - 1.0 = student is complete subset of teacher
 
 num_mini_epochs: 32
 samples_per_mini_epoch: 64 #4096

--- a/src/weathergen/datasets/masking.py
+++ b/src/weathergen/datasets/masking.py
@@ -158,74 +158,40 @@ class Masker:
         assert num_cells_to_select <= num_total_cells
 
         # Optimize center for controlled overlap if requested
+        # NOTE: This is the programmatic API approach. The config system uses a more
+        # deterministic approach in _generate_cell_mask (see lines 752-803).
         if overlap_with is not None and overlap_ratio is not None and center_cell is None:
             assert 0.0 <= overlap_ratio <= 1.0, "overlap_ratio must be in [0.0, 1.0]"
 
-            # Try multiple candidate centers to find best overlap
-            max_attempts = 100
-            best_center = None
-            best_overlap_diff = float('inf')
-
             overlap_set = set(overlap_with)
-            target_overlap_count = int(overlap_ratio * num_cells_to_select)
 
-            for _ in range(max_attempts):
-                candidate_center = self.rng.integers(0, num_total_cells)
-
-                # Quick preview: estimate overlap by checking if center is inside existing crop
-                # and sampling a few neighbors
-                if method == "geodesic_disk":
-                    # For geodesic_disk, we can estimate overlap more accurately
-                    # by checking the center's distance to the existing crop's center
-                    existing_center = overlap_with[len(overlap_with)//2]  # Approximate center
-
-                    center_lonlat = hp.healpix_to_lonlat(candidate_center, nside, order="nested")
-                    existing_lonlat = hp.healpix_to_lonlat(existing_center, nside, order="nested")
-
-                    # Simplified distance check (full computation is in geodesic_disk below)
-                    if candidate_center in overlap_set:
-                        # Center inside existing crop - likely high overlap
-                        estimated_overlap = max(0.3, overlap_ratio)
-                    else:
-                        # Center outside - lower overlap, depends on distance
-                        estimated_overlap = min(0.3, overlap_ratio)
-
-                    overlap_diff = abs(estimated_overlap - overlap_ratio)
+            # Use intelligent center selection based on overlap target
+            if overlap_ratio > 0.7:
+                # High overlap: select center from within existing crop
+                center_cell = self.rng.choice(list(overlap_set))
+            elif overlap_ratio < 0.3:
+                # Low overlap: select center from outside existing crop
+                non_overlap_cells = [c for c in range(num_total_cells) if c not in overlap_set]
+                if non_overlap_cells:
+                    center_cell = self.rng.choice(non_overlap_cells)
                 else:
-                    # For other methods, use simpler heuristic
-                    center_in_overlap = candidate_center in overlap_set
-                    if (overlap_ratio > 0.5 and center_in_overlap) or \
-                       (overlap_ratio <= 0.5 and not center_in_overlap):
-                        overlap_diff = 0.0
-                    else:
-                        overlap_diff = abs(overlap_ratio - 0.5)
-
-                if overlap_diff < best_overlap_diff:
-                    best_overlap_diff = overlap_diff
-                    best_center = candidate_center
-
-                    # Early exit if we found a good candidate
-                    if overlap_diff < 0.1:
-                        break
-
-            center_cell = best_center
-
-            if best_overlap_diff > 0.2:
-                _logger.debug(
-                    f"Controlled overlap: target={overlap_ratio:.1%}, "
-                    f"estimated diff={best_overlap_diff:.1%}"
-                )
+                    # Fallback if no non-overlap cells available
+                    center_cell = self.rng.integers(0, num_total_cells)
+            else:
+                # Medium overlap: random selection (boundary-agnostic)
+                center_cell = self.rng.integers(0, num_total_cells)
 
         # Random starting point if not specified
         elif center_cell is None:
             center_cell = self.rng.integers(0, num_total_cells)
 
         if method == "disk":
-            # Layer-by-layer neighbor growth
+            # Layer-by-layer neighbor growth - creates compact irregular regions
             selected = {center_cell}
             frontier = {center_cell}
 
             while len(selected) < num_cells_to_select and frontier:
+                # Expand frontier by one layer
                 next_frontier = set()
                 for cell in frontier:
                     with warnings.catch_warnings():
@@ -234,21 +200,23 @@ class Masker:
                     valid_neighbors = [n for n in neighbors if n != -1 and n not in selected]
                     next_frontier.update(valid_neighbors)
 
-                candidates = list(next_frontier)
-                if not candidates:
+                if not next_frontier:
                     break
 
+                # Randomly select from frontier to reach target count
+                candidates = list(next_frontier)
                 self.rng.shuffle(candidates)
                 num_to_add = min(len(candidates), num_cells_to_select - len(selected))
                 selected.update(candidates[:num_to_add])
                 frontier = set(candidates[:num_to_add])
 
         elif method == "random_walk":
-            # Random walk through neighbors
+            # Random walk through neighbors - creates elongated irregular regions
             selected = {center_cell}
             frontier = {center_cell}
 
             while len(selected) < num_cells_to_select:
+                # Get all neighbors of current frontier
                 neighbors = set()
                 for cell in frontier:
                     with warnings.catch_warnings():
@@ -260,22 +228,30 @@ class Masker:
                 if not neighbors:
                     break
 
+                # Randomly pick one neighbor and continue from there
                 next_cell = self.rng.choice(list(neighbors))
                 selected.add(next_cell)
                 frontier = {next_cell}
 
         elif method == "geodesic_disk":
-            # Angular distance selection - most uniform circular regions
+            # Angular distance selection - creates most uniform circular regions
+            # Best method for SSL (DINO/JEPA/IBOT) due to shape regularity
+
+            def lonlat_to_xyz(lon, lat):
+                """Convert lon/lat to 3D cartesian coordinates."""
+                return np.array([
+                    np.cos(lat) * np.cos(lon),
+                    np.cos(lat) * np.sin(lon),
+                    np.sin(lat)
+                ])
+
+            # Get center coordinates
             center_lonlat = hp.healpix_to_lonlat(center_cell, nside, order="nested")
-            center_lon = float(center_lonlat[0].value) if hasattr(center_lonlat[0], 'value') else float(center_lonlat[0])
-            center_lat = float(center_lonlat[1].value) if hasattr(center_lonlat[1], 'value') else float(center_lonlat[1])
+            center_lon = float(center_lonlat[0].value if hasattr(center_lonlat[0], 'value') else center_lonlat[0])
+            center_lat = float(center_lonlat[1].value if hasattr(center_lonlat[1], 'value') else center_lonlat[1])
+            center_xyz = lonlat_to_xyz(center_lon, center_lat)
 
-            center_xyz = np.array([
-                np.cos(center_lat) * np.cos(center_lon),
-                np.cos(center_lat) * np.sin(center_lon),
-                np.sin(center_lat)
-            ])
-
+            # Get all cell coordinates
             all_indices = np.arange(num_total_cells)
             all_lonlat = hp.healpix_to_lonlat(all_indices, nside, order="nested")
             all_lon = all_lonlat[0].value if hasattr(all_lonlat[0], 'value') else all_lonlat[0]
@@ -287,12 +263,10 @@ class Masker:
                 np.sin(all_lat)
             ], axis=1)
 
-            dot_products = np.dot(all_xyz, center_xyz)
-            dot_products = np.clip(dot_products, -1.0, 1.0)
+            # Compute angular distances and select closest cells
+            dot_products = np.clip(np.dot(all_xyz, center_xyz), -1.0, 1.0)
             angular_distances = np.arccos(dot_products)
-
-            sorted_indices = np.argsort(angular_distances)
-            selected = sorted_indices[:num_cells_to_select]
+            selected = np.argsort(angular_distances)[:num_cells_to_select]
 
         else:
             raise ValueError(f"Unknown selection method: {method}")
@@ -548,8 +522,9 @@ class Masker:
         # iterate over all target samples
         target_masks: list[np.typing.NDArray] = []
         target_metadata: list[SampleMetaData] = []
+        target_config_mapping = []  # Track which config each target mask came from
         # different strategies
-        for target_cfg in target_cfgs:
+        for i_target, target_cfg in enumerate(target_cfgs):
             # different samples/view per strategy
             for _ in range(target_cfg.get("num_samples", 1)):
                 target_mask, mask_params = self._get_mask(
@@ -560,19 +535,28 @@ class Masker:
                 )
                 target_masks += [target_mask]
                 target_metadata += [SampleMetaData(params={**target_cfg, **mask_params})]
+                target_config_mapping += [i_target]  # Track which config this mask came from
 
         # iterate over all source samples
         source_masks: list[np.typing.NDArray] = []
         source_metadata: list[SampleMetaData] = []
         source_target_mapping = []
+        source_config_mapping = []  # Track which config each source mask came from
         # different strategies
         for i_source, source_cfg in enumerate(source_cfgs):
             # samples per strategy
             for _ in range(source_cfg.get("num_samples", 1)):
+                # Prepare masking config - inject target mask if overlap_ratio is specified
+                masking_cfg = source_cfg.get("masking_strategy_config", {}).copy()
+                if "overlap_ratio" in masking_cfg and len(target_masks) > 0:
+                    # Enable overlap control by passing teacher's mask
+                    target_mask_for_overlap = target_masks[i_source % len(target_masks)]
+                    masking_cfg["overlap_with_mask"] = target_mask_for_overlap.cpu().numpy() if hasattr(target_mask_for_overlap, 'cpu') else target_mask_for_overlap
+
                 source_mask, mask_params = self._get_mask(
                     num_cells=num_cells,
                     strategy=source_cfg.get("masking_strategy"),
-                    masking_strategy_config=source_cfg.get("masking_strategy_config", {}),
+                    masking_strategy_config=masking_cfg,
                     target_mask=target_masks[i_source % len(target_masks)],
                     relationship=source_cfg.get("relationship", "independent"),
                 )
@@ -580,12 +564,15 @@ class Masker:
                 source_metadata += [SampleMetaData(params={**target_cfg, **mask_params})]
                 # TODO: proper correspondence between source and target
                 source_target_mapping += [i_source % len(target_masks)]
+                source_config_mapping += [i_source]  # Track which config this mask came from
 
         source_target_mapping = np.array(source_target_mapping, dtype=np.int32)
+        source_config_mapping = np.array(source_config_mapping, dtype=np.int32)
+        target_config_mapping = np.array(target_config_mapping, dtype=np.int32)
 
         return (
-            (target_masks, target_metadata),
-            (source_masks, source_metadata),
+            (target_masks, target_metadata, target_config_mapping),
+            (source_masks, source_metadata, source_config_mapping),
             source_target_mapping,
         )
 
@@ -734,10 +721,11 @@ class Masker:
                 # Spatial selection method
                 method = cfg.get("method", "geodesic_disk")  # Default to best method for SSL
 
-                # Controlled overlap support (for IBOT-style training)
-                # Note: overlap_with_mask should be provided by calling code for multi-crop setups
-                overlap_with_mask = cfg.get("overlap_with_mask", None)  # Previous crop mask at parent level
-                overlap_ratio = cfg.get("overlap_ratio", None)  # Target overlap [0.0-1.0]
+                # Deterministic overlap support (for IBOT-style training)
+                # overlap_with_mask: Teacher's crop mask at data level (hl=5)
+                # overlap_ratio: Target overlap as fraction of student crop [0.0-1.0]
+                overlap_with_mask = cfg.get("overlap_with_mask", None)
+                overlap_ratio = cfg.get("overlap_ratio", None)
 
                 # If overlap is requested but no mask provided, log a warning
                 if overlap_ratio is not None and overlap_with_mask is None:
@@ -747,38 +735,80 @@ class Masker:
                         "Use programmatic API for controlled overlap."
                     )
 
-                # Convert overlap mask to parent-level indices if provided
-                overlap_with_parents = None
-                if overlap_with_mask is not None:
-                    # Project data-level mask back to parent-level indices
-                    # Assume a parent is selected if any of its children are in the mask
-                    overlap_with_parents = []
-                    for parent_id in range(num_parent_cells):
-                        child_start = parent_id * num_children_per_parent
-                        child_end = child_start + num_children_per_parent
-                        if np.any(overlap_with_mask[child_start:child_end]):
-                            overlap_with_parents.append(parent_id)
-                    overlap_with_parents = np.array(overlap_with_parents) if overlap_with_parents else None
+                # NEW DETERMINISTIC APPROACH: Work at data level (hl=5) for exact overlap
+                if overlap_with_mask is not None and overlap_ratio is not None:
+                    assert 0.0 <= overlap_ratio <= 1.0, "overlap_ratio must be in [0.0, 1.0]"
 
-                # Select spatially contiguous parent cells
-                parent_ids = self._select_spatially_contiguous_cells(
-                    healpix_level=hl_mask,
-                    num_cells_to_select=num_parents_to_keep,
-                    center_cell=None,  # Auto-select random center (or optimized for overlap)
-                    method=method,
-                    overlap_with=overlap_with_parents,
-                    overlap_ratio=overlap_ratio,
-                )
+                    # Calculate total cells we want in student crop
+                    total_student_cells = num_parents_to_keep * num_children_per_parent
 
-                # Project to data level
-                child_offsets = np.arange(num_children_per_parent)
-                child_indices = (
-                    parent_ids[:, None] * num_children_per_parent + child_offsets
-                ).reshape(-1)
+                    # Get indices of teacher's cells (at data level)
+                    teacher_cell_indices = np.where(overlap_with_mask)[0]
+                    non_teacher_cell_indices = np.where(~overlap_with_mask)[0]
 
-                # Create mask: True = KEEP (the crop), False = MASK (everything else)
-                mask = np.zeros(num_cells, dtype=bool)
-                mask[child_indices] = True
+                    # Deterministically select overlap cells from teacher
+                    num_overlap_cells = int(np.round(overlap_ratio * total_student_cells))
+                    num_overlap_cells = min(num_overlap_cells, len(teacher_cell_indices))  # Can't exceed teacher size
+
+                    # Randomly select which teacher cells to use for overlap
+                    if num_overlap_cells > 0:
+                        overlap_cell_indices = self.rng.choice(
+                            teacher_cell_indices,
+                            size=num_overlap_cells,
+                            replace=False
+                        )
+                    else:
+                        overlap_cell_indices = np.array([], dtype=int)
+
+                    # Select remaining cells from outside teacher crop
+                    # Simplified: directly sample from non-teacher cells to guarantee correct count
+                    num_non_overlap_cells = total_student_cells - num_overlap_cells
+
+                    if num_non_overlap_cells > 0 and len(non_teacher_cell_indices) > 0:
+                        # Directly sample from non-teacher cells at data level
+                        # This ensures we get exactly the right number
+                        num_available = min(num_non_overlap_cells, len(non_teacher_cell_indices))
+                        non_overlap_child_indices = self.rng.choice(
+                            non_teacher_cell_indices,
+                            size=num_available,
+                            replace=False
+                        )
+                    else:
+                        non_overlap_child_indices = np.array([], dtype=int)
+
+                    # Combine overlap and non-overlap cells
+                    child_indices = np.concatenate([overlap_cell_indices, non_overlap_child_indices])
+
+                    # Create mask
+                    mask = np.zeros(num_cells, dtype=bool)
+                    mask[child_indices] = True
+
+                    _logger.info(
+                        f"Deterministic overlap: target={overlap_ratio:.1%}, "
+                        f"actual={len(overlap_cell_indices)/len(child_indices):.1%} "
+                        f"({len(overlap_cell_indices)}/{len(child_indices)} cells)"
+                    )
+
+                else:
+                    # No overlap control - use standard spatial selection
+                    parent_ids = self._select_spatially_contiguous_cells(
+                        healpix_level=hl_mask,
+                        num_cells_to_select=num_parents_to_keep,
+                        center_cell=None,
+                        method=method,
+                        overlap_with=None,
+                        overlap_ratio=None,
+                    )
+
+                    # Project to data level
+                    child_offsets = np.arange(num_children_per_parent)
+                    child_indices = (
+                        parent_ids[:, None] * num_children_per_parent + child_offsets
+                    ).reshape(-1)
+
+                    # Create mask: True = KEEP (the crop), False = MASK (everything else)
+                    mask = np.zeros(num_cells, dtype=bool)
+                    mask[child_indices] = True
 
         else:
             raise NotImplementedError(

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -652,7 +652,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
             masks[stream_info["name"]] = (
                 target_data[0],  # target_masks
                 source_data[0],  # source_masks
-                mapping,         # source_target_mapping
+                mapping,  # source_target_mapping
                 target_data[1],  # target_metadata
                 source_data[1],  # source_metadata
                 target_data[2],  # target_config_mapping


### PR DESCRIPTION
## Description
Implemented Healpix cropping as discussed with three different methods for spatial cover. The code also supports different overlaps between crops provided for the teacher and the student and corrects the bug when passing num_sample > 1. In the config, three different examples were provided on how to set up cropping; it was tested on the Juwels booster and it ran for few epochs.

## Checklist before asking for review

-   [X] I have performed a self-review of my code
-   [X] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [X] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
