### PR TITLE
[1448] --config can be empty

### DIFF
--- a/src/weathergen/utils/cli.py
+++ b/src/weathergen/utils/cli.py
@@ -90,7 +90,7 @@ def _add_general_arguments(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--config",
         type=Path,
-        nargs="+",
+        nargs="*",
         default=[],
         help="Optional experiment specfic configuration files in ascending order of precedence.",
     )


### PR DESCRIPTION
## Description
handle empty --config argument
This PR works in conjunction with [!103](https://gitlab.jsc.fz-juelich.de/esde/WeatherGenerator-private/-/merge_requests/103)


## Issue Number

closes #1448

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
