### PR TITLE
1469: Target_channels not dependent on val/train in physical loss calculator

### DIFF
--- a/src/weathergen/train/loss_modules/loss_module_physical.py
+++ b/src/weathergen/train/loss_modules/loss_module_physical.py
@@ -194,6 +194,11 @@ class LossPhysical(LossModuleBase):
         # TODO: iterate over batch dimension
         for stream_info in self.cf.streams:
             stream_name = stream_info["name"]
+            target_channels = (
+                stream_info.val_target_channels
+                if self.stage == "val"
+                else stream_info.train_target_channels
+            )
 
             losses_all[stream_name] = defaultdict(dict)
 
@@ -253,9 +258,7 @@ class LossPhysical(LossModuleBase):
                         weights_locations,
                     )
 
-                    for ch_n, v in zip(
-                        stream_info.train_target_channels, loss_lfct_chs, strict=True
-                    ):
+                    for ch_n, v in zip(target_channels, loss_lfct_chs, strict=True):
                         losses_all[stream_name][str(fstep)][loss_fct_name][ch_n] = (
                             spoof_weight * v if v != 0.0 else torch.nan
                         )


### PR DESCRIPTION
## Description

Inference throws following error:
```
  File "/users/thunter/work/WeatherGenerator/src/weathergen/run_train.py", line 75, in inference_from_args
    trainer.inference(cf, devices, args.from_run_id, args.mini_epoch)
  File "/users/thunter/work/WeatherGenerator/src/weathergen/train/trainer.py", line 160, in inference
    self.validate(mini_epoch=0)
  File "/users/thunter/work/WeatherGenerator/src/weathergen/train/trainer.py", line 472, in validate
    _ = self.loss_calculator_val.compute_loss(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/users/thunter/work/WeatherGenerator/src/weathergen/train/loss_calculator.py", line 90, in compute_loss
    loss_values = calculator.compute_loss(preds=preds, targets=targets)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/users/thunter/work/WeatherGenerator/src/weathergen/train/loss_modules/loss_module_physical.py", line 257, in compute_loss
    stream_info.train_target_channels, loss_lfct_chs, strict=True
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/users/thunter/work/WeatherGenerator/.venv/lib/python3.12/site-packages/omegaconf/dictconfig.py", line 355, in __getattr__
    self._format_and_raise(
  File "/users/thunter/work/WeatherGenerator/.venv/lib/python3.12/site-packages/omegaconf/base.py", line 231, in _format_and_raise
    format_and_raise(
  File "/users/thunter/work/WeatherGenerator/.venv/lib/python3.12/site-packages/omegaconf/_utils.py", line 899, in format_and_raise
    _raise(ex, cause)
  File "/users/thunter/work/WeatherGenerator/.venv/lib/python3.12/site-packages/omegaconf/_utils.py", line 797, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/users/thunter/work/WeatherGenerator/.venv/lib/python3.12/site-packages/omegaconf/dictconfig.py", line 351, in __getattr__
    return self._get_impl(
           ^^^^^^^^^^^^^^^
  File "/users/thunter/work/WeatherGenerator/.venv/lib/python3.12/site-packages/omegaconf/dictconfig.py", line 442, in _get_impl
    node = self._get_child(
           ^^^^^^^^^^^^^^^^
  File "/users/thunter/work/WeatherGenerator/.venv/lib/python3.12/site-packages/omegaconf/basecontainer.py", line 73, in _get_child
    child = self._get_node(
            ^^^^^^^^^^^^^^^
  File "/users/thunter/work/WeatherGenerator/.venv/lib/python3.12/site-packages/omegaconf/dictconfig.py", line 480, in _get_node
    raise ConfigKeyError(f"Missing key {key!s}")
omegaconf.errors.ConfigAttributeError: Missing key train_target_channels
    full_key: streams[0].train_target_channels
    object_type=dict. Did you mean: 'val_target_channels'?
```
<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number

Closes #1469 
<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
