### PR TITLE
[1476] Documentation on how to tag experiments for mlflow search

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -184,11 +184,19 @@ wgtags:
   # This may be autofilled in the future. Expected values are lowercase strings of 
   # the organizations codenames in https://confluence.ecmwf.int/display/MAEL/Staff+Contact+List
   # e.g. "ecmwf", "cmcc", "metnor", "jsc", "escience"
-  org: None
+  org: null
+  # The Github issue corresponding to this run (number such as 1234)
+  # Github issues are the central point when running experiment and contain 
+  # links to hedgedocs, code branches, pull requests etc.
+  # It is recommended to associate a run with a Github issue.
+  issue: null
   # The name of the experiment. This is a distinctive codename for the experiment campaign being run.
-  # This is expected to be the primary tag for comparing experiments in MLFlow.
+  # This is expected to be the primary tag for comparing experiments in MLFlow, along with the
+  # issue number.
   # Expected values are lowercase strings with no spaces, just underscores:
   # Examples: "rollout_ablation_grid"  
-  exp: None
+  exp: null
   # *** Experiment-specific tags ***
-  grid: None
+  # All extra tags (including lists, dictionaries, etc.) are treated 
+  # as strings by mlflow, so treat all extra tags as simple string key: value pairs.
+  grid: null


### PR DESCRIPTION
## Description

Not strictly necessary, but useful documentation for organizing runs.

Documentation:
https://gitlab.jsc.fz-juelich.de/esde/WeatherGenerator-private/-/wikis/home/Common-workflows#adding-tags-to-experiments-and-organizing-your-runs

## Issue Number

Closes #1476 

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
