### PR TITLE
Improve argument check readability of `run_train.py`

### DIFF
--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -183,7 +183,7 @@ def train_with_args(argl: list[str], stream_dir: str | None):
 if __name__ == "__main__":
     # Entry point for slurm script.
     # Check whether --from_run_id passed as argument.
-    if next((True for arg in sys.argv if "--from_run_id" in arg), False):
+    if any("--from_run_id" in arg for arg in sys.argv):
         train_continue()
     else:
         train()


### PR DESCRIPTION
## Description

Replaced `if next((True for arg in sys.argv if "--from_run_id" in arg), False):` with `if any("--from_run_id" in arg for arg in sys.argv):` in the main of `run_train.py`. While there’s no computational difference, this version is clearer and improves readability.

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


Fixes #1484

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
