### PR TITLE
fix for very sparse masks so we have no empty tokens_c

### DIFF
--- a/src/weathergen/model/encoder.py
+++ b/src/weathergen/model/encoder.py
@@ -179,6 +179,11 @@ class EncoderModule(torch.nn.Module):
             cell_lens_c = torch.cat([zero_pad, cell_lens[i * clen : i_end]])
             q_cells_lens_c = q_cells_lens[: cell_lens_c.shape[0]]
 
+            # if we have a very sparse input, we may have no tokens in the chunk, tokens_c
+            # skip processing of the empty chunk in this case
+            if tokens_c.shape[0] == 0:
+                continue
+
             # local assimilation model
             tokens_c = self.ae_local_engine(tokens_c, cell_lens_c, use_reentrant=False)
 


### PR DESCRIPTION
passing thru local assimilation

## Description

Bug in encoder in assimilate_local. For very sparse masks and hence tokens, sometimes the chunking logic in assimilate_local will lead to empty tokens_c since there are no tokens in the "chunk" of the tokens that we inspect.

## Issue Number

Closes #1494 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
