### PR TITLE
add quaver default template 

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/export/export_inference.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/export_inference.py
@@ -143,10 +143,20 @@ def parse_args(args: list) -> argparse.Namespace:
     )
 
     parser.add_argument(
-        "--template",
+        "--quaver-template-folder",
         type=str,
         help="Path to GRIB template file",
         required=False,
+        dest="quaver_template_folder",
+    )
+
+    parser.add_argument(
+        "--quaver-template-grid-type",
+        type=str,
+        help="Grid type to include in the output filename (i.e. 'O96/N320')",
+        required=False,
+        default="O96", 
+        dest="quaver_template_grid_type",
     )
 
     parser.add_argument(

--- a/packages/evaluate/src/weathergen/evaluate/export/parsers/quaver_parser.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/parsers/quaver_parser.py
@@ -19,8 +19,10 @@ uv run export --run-id ciga1p9c --stream ERA5
 --output-dir ./test_output1 
 --format quaver --type prediction target  
 --samples 2 --fsteps 2 
---quaver_template_folder "<path to quaver templates> --quaver_template_grid_type O96
+--quaver-template-folder "<path to quaver templates> --quaver-template-grid-type o96 
 --expver test 
+
+NOTE: check if it is o96 or O96 in the template.
 """
 
 

--- a/packages/evaluate/src/weathergen/evaluate/export/parsers/quaver_parser.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/parsers/quaver_parser.py
@@ -19,7 +19,7 @@ uv run export --run-id ciga1p9c --stream ERA5
 --output-dir ./test_output1 
 --format quaver --type prediction target  
 --samples 2 --fsteps 2 
---template "<path to quaver templates>/quaver_templates/aifs_{level_type}_o96_data.grib" 
+--quaver_template_folder "<path to quaver templates> --quaver_template_grid_type O96
 --expver test 
 """
 
@@ -36,8 +36,10 @@ class QuaverParser(CfParser):
         for k, v in kwargs.items():
             setattr(self, k, v)
 
-        if not hasattr(self, "template"):
-            raise ValueError("Template file must be provided for Quaver format.")
+        if not hasattr(self, "quaver_template_folder"):
+            raise ValueError("Template folder must be provided for Quaver format.")
+        if not hasattr(self, "quaver_template_grid_type"):
+            raise ValueError("Template grid type must be provided for Quaver format.")
         if not hasattr(self, "channels"):
             raise ValueError("Channels must be provided for Quaver format.")
         if not hasattr(self, "expver"):
@@ -46,6 +48,8 @@ class QuaverParser(CfParser):
         super().__init__(config, **kwargs)
 
         self.template_cache = []
+        
+        self.template = str(Path(self.quaver_template_folder) / f"aifs_{{level_type}}_{self.quaver_template_grid_type}_data.grib")
 
         self.pl_template = ekd.from_source("file", self.template.format(level_type="pl"))
         self.sf_template = ekd.from_source("file", self.template.format(level_type="sfc"))


### PR DESCRIPTION
## Description

The way one needs to input the quaver templates in export is a bit confusing at the moment. with this PR the user will just input the template folder and the grid type and the template format is created under the hood.  

## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/1286

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
