### PR TITLE
bug fix for fstep range in validation_io

### DIFF
--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -27,7 +27,7 @@ def write_output(cf, mini_epoch, batch_idx, dn_data, batch, model_output, target
     # collect all target / prediction-related information
     fp32 = torch.float32
     preds_all, targets_all, targets_coords_all, targets_times_all = [], [], [], []
-    for fstep in range(cf.forecast_offset, cf.forecast_steps + 2):
+    for fstep in range(cf.forecast_offset, cf.forecast_steps + 1):
         preds_all += [[]]
         targets_all += [[]]
         targets_coords_all += [[]]


### PR DESCRIPTION
## Description

Inference broken for masking and forecast due to + 2 in loop in write_output in validation_io.


## Issue Number

Closes #1499 

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
