### PR TITLE
deepcopy config so weight does not disappear for inference

### DIFF
--- a/src/weathergen/train/loss_calculator.py
+++ b/src/weathergen/train/loss_calculator.py
@@ -11,6 +11,7 @@
 
 import logging
 from collections import defaultdict
+from copy import deepcopy
 
 import torch
 from omegaconf import DictConfig
@@ -57,7 +58,9 @@ class LossCalculator:
         self.stddev_unweighted_hist = []
 
         calculator_configs = (
-            cf.training_config.losses if stage == TRAIN else cf.validation_config.losses
+            deepcopy(cf.training_config.losses)
+            if stage == TRAIN
+            else deepcopy(cf.validation_config.losses)
         )
 
         self.loss_calculators = [


### PR DESCRIPTION
## Description

"Weight" being dropped from val config due to pop. Copy the config to make sure we always have it.


## Issue Number

Closes #1501 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
