### PR TITLE
restore integration test - evaluation part

### DIFF
--- a/integration_tests/small1_test.py
+++ b/integration_tests/small1_test.py
@@ -12,6 +12,7 @@ import logging
 import os
 import shutil
 from pathlib import Path
+
 import omegaconf
 import pytest
 
@@ -134,7 +135,7 @@ def evaluate_results(run_id):
         }
     )
     # Not passing the mlflow client for tests.
-    evaluate_from_config(cfg, None, None )
+    evaluate_from_config(cfg, None, None)
 
 
 def load_metrics(run_id):
@@ -157,43 +158,39 @@ def assert_missing_metrics_file(run_id):
 
 
 def assert_train_loss_below_threshold(run_id):
-    """Test that the 'stream.ERA5.loss_mse.loss_avg' metric is below a threshold."""
+    """Test that the 'LossPhysical.ERA5.mse.avg' metric is below a threshold."""
     metrics = load_metrics(run_id)
+    loss_avg_name = "LossPhysical.ERA5.mse.avg"
     loss_metric = next(
         (
-            metric.get("loss.LossPhysical.ERA5.mse.loss_avg", None)
+            metric.get(loss_avg_name, None)
             for metric in reversed(metrics)
             if metric.get("stage") == "train"
         ),
         None,
     )
-    assert loss_metric is not None, (
-        "'loss.LossPhysical.ERA5.mse.loss_avg' metric is missing in metrics file"
-    )
+    assert loss_metric is not None, f"'{loss_avg_name}' metric is missing in metrics file"
     # Check that the loss does not explode in a single mini_epoch
     # This is meant to be a quick test, not a convergence test
     target = 0.25
     assert loss_metric < target, (
-        f"'loss.LossPhysical.ERA5.mse.loss_avg' is {loss_metric}, expected to be below {target}"
+        f"'{loss_avg_name}' is {loss_metric}, expected to be below {target}"
     )
 
 
 def assert_val_loss_below_threshold(run_id):
-    """Test that the 'stream.ERA5.loss_mse.loss_avg' metric is below a threshold."""
+    """Test that the 'LossPhysical.ERA5.mse.avg' metric is below a threshold."""
     metrics = load_metrics(run_id)
+    loss_avg_name = "LossPhysical.ERA5.mse.avg"
     loss_metric = next(
         (
-            metric.get("loss.LossPhysical.ERA5.mse.loss_avg", None)
+            metric.get(loss_avg_name, None)
             for metric in reversed(metrics)
             if metric.get("stage") == "val"
         ),
         None,
     )
-    assert loss_metric is not None, (
-        "'stream.ERA5.loss_mse.loss_avg' metric is missing in metrics file"
-    )
+    assert loss_metric is not None, f"'{loss_avg_name}' metric is missing in metrics file"
     # Check that the loss does not explode in a single mini_epoch
     # This is meant to be a quick test, not a convergence test
-    assert loss_metric < 0.25, (
-        f"'loss.LossPhysical.ERA5.mse.loss_avg' is {loss_metric}, expected to be below 0.25"
-    )
+    assert loss_metric < 0.25, f"'{loss_avg_name}' is {loss_metric}, expected to be below 0.25"

--- a/integration_tests/small_multi_stream_test.py
+++ b/integration_tests/small_multi_stream_test.py
@@ -110,7 +110,7 @@ def evaluate_multi_stream_results(run_id):
                             "evaluation": {"forecast_steps": "all", "sample": "all"},
                             "plotting": {
                                 "sample": [0, 1],
-                                "forecast_step": [0],
+                                "forecast_step": [1],
                                 "plot_maps": True,
                                 "plot_histograms": True,
                                 "plot_animations": False,
@@ -122,7 +122,7 @@ def evaluate_multi_stream_results(run_id):
                             "evaluation": {"forecast_steps": "all", "sample": "all"},
                             "plotting": {
                                 "sample": [0, 1],
-                                "forecast_step": [0],
+                                "forecast_step": [1],
                                 "plot_maps": True,
                                 "plot_histograms": True,
                                 "plot_animations": False,
@@ -134,7 +134,7 @@ def evaluate_multi_stream_results(run_id):
                             "evaluation": {"forecast_steps": "all", "sample": "all"},
                             "plotting": {
                                 "sample": [0, 1],
-                                "forecast_step": [0],
+                                "forecast_step": [1],
                                 "plot_maps": True,
                                 "plot_histograms": True,
                                 "plot_animations": False,

--- a/integration_tests/small_multi_stream_test.py
+++ b/integration_tests/small_multi_stream_test.py
@@ -9,7 +9,6 @@ uv run pytest ./integration_tests/small_multi_stream_test.py
 
 import json
 import logging
-import os
 import shutil
 from pathlib import Path
 
@@ -78,7 +77,9 @@ def infer_multi_stream(run_id):
             "--run_id",
             run_id,
             "--streams_output",
-            "ERA5", "SurfaceCombined", "NPPATMS",
+            "ERA5",
+            "SurfaceCombined",
+            "NPPATMS",
             "--config",
             f"{WEATHERGEN_HOME}/integration_tests/small_multi_stream.yaml",
         ]
@@ -173,7 +174,7 @@ def assert_metrics_file_exists(run_id):
 def assert_stream_losses_below_threshold(run_id, stage="train"):
     """
     Test that stream losses are below threshold for a given stage.
-    
+
     Args:
         run_id: The run identifier
         stage: Either "train" or "val"
@@ -200,16 +201,16 @@ def assert_stream_losses_below_threshold(run_id, stage="train"):
     for stream_name, threshold in stage_thresholds.items():
         loss = next(
             (
-                metric.get(f"loss.LossPhysical.{stream_name}.mse.loss_avg")
+                metric.get(f"LossPhysical.{stream_name}.mse.avg")
                 for metric in reversed(metrics)
                 if metric.get("stage") == stage
             ),
             None,
         )
 
-        assert loss is not None, f"'loss.LossPhysical.{stream_name}.mse.loss_avg' {stage} metric is missing"
+        assert loss is not None, f"'LossPhysical.{stream_name}.mse.avg' {stage} metric is missing"
         assert loss < threshold, (
-            f"'loss.LossPhysical.{stream_name}.mse.loss_avg' {stage} loss is {loss}, expected below {threshold}"
+            f"'LossPhysical.{stream_name}.mse.avg' {stage} loss is {loss}, expected below {threshold}"
         )
 
         losses[stream_name] = loss

--- a/packages/common/src/weathergen/common/io.py
+++ b/packages/common/src/weathergen/common/io.py
@@ -189,7 +189,7 @@ class ItemKey:
         Infer forecast offset by the (non)presence of targets at fstep 0.
 
         Args:
-            datasets: Datasets found in a fstep 0 OutputItem (eg. ZarrIO.example_key).
+            datasets: Datasets found in a fstep 0 OutputItem.
         """
         # forecast offset=1 should produce no targets at fstep 0
         return 0 if "target" in datasets else 1
@@ -367,7 +367,8 @@ class ZarrIO:
             group = self.data_root.create_group(item.path)
         else:
             try:
-                group = self.data_root[item.path]
+                group = self.data_root.get(item.path)
+                assert group is not None, f"Zarr group: {item.path} does not exist."
             except KeyError as e:
                 msg = f"Zarr group: {item.path} has not been created."
                 raise FileNotFoundError(msg) from e
@@ -408,17 +409,13 @@ class ZarrIO:
 
     @functools.cached_property
     def example_key(self) -> ItemKey:
-        fstep = 0
         try:
             sample, example_sample = next(self.data_root.groups())
             stream, example_stream = next(example_sample.groups())
+            fstep = 0
         except StopIteration as e:
             msg = f"Data store at: {self._store_path} is empty."
             raise FileNotFoundError(msg) from e
-
-        assert fstep in example_stream.groups(), (
-            "fstep 0 is missisg, but should always contain at least sources."
-        )
 
         return ItemKey(sample, fstep, stream)
 

--- a/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
@@ -309,7 +309,7 @@ class WeatherGenReader(Reader):
             Returns a Dataset where channels have been scaled if needed
         """
 
-        channels_z = [ch for ch in data.channel.values if str(ch).startswith("z_")]
+        channels_z = [ch for ch in np.atleast_1d(data.channel.values) if str(ch).startswith("z_")]
         data_scaled = data.copy()
         factor = 9.80665
 

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -202,7 +202,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                 "length of MultiStreamDataSampler,"
                 f"{n_duplicates} duplicate samples will be sampled."
                 "To avoid this increase the the length of the"
-                f"global sampling window by {n_duplicates * cf.step_hrs} hours."
+                f"global sampling window by {n_duplicates * forecast_len} hours."
             )
             logger.warning(msg)
         logger.info(f"index_range={index_range}, len={self.len}, len_chunk={len_chunk}")

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -202,7 +202,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                 "length of MultiStreamDataSampler,"
                 f"{n_duplicates} duplicate samples will be sampled."
                 "To avoid this increase the the length of the"
-                f"global sampling window by {n_duplicates * forecast_len} hours."
+                f"global sampling window by {n_duplicates * self.step_timedelta} hours."
             )
             logger.warning(msg)
         logger.info(f"index_range={index_range}, len={self.len}, len_chunk={len_chunk}")

--- a/src/weathergen/utils/train_logger.py
+++ b/src/weathergen/utils/train_logger.py
@@ -127,7 +127,7 @@ class TrainLogger:
         for key, value in stddev_all.items():
             metrics[key] = np.nanmean(value)
 
-        self.log_metrics("train", metrics)
+        self.log_metrics(stage, metrics)
 
     #######################################
     @staticmethod


### PR DESCRIPTION
## Description

Restore evaluation functions in integration test. 
I reverted PR: https://github.com/ecmwf/WeatherGenerator/pull/1444 for now. cc @grassesi 

This PR restores the integration test for evaluation. I still get an error though, related to:

```
E           AssertionError: 'loss.LossPhysical.ERA5.mse.loss_avg' train metric is missing
E           assert None is not None

integration_tests/small_multi_stream_test.py:
````

 related to these functions:

```
assert_stream_losses_below_threshold(test_run_id, stage="train")
assert_stream_losses_below_threshold(test_run_id, stage="val")
```

Can anybody take a look? 


## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/1505


## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
