### PR TITLE
using new parameter in multi_stream_data_sampler

### DIFF
--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -202,7 +202,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                 "length of MultiStreamDataSampler,"
                 f"{n_duplicates} duplicate samples will be sampled."
                 "To avoid this increase the the length of the"
-                f"global sampling window by {n_duplicates * cf.step_hrs} hours."
+                f"global sampling window by {n_duplicates * cf.time_window_step} hours."
             )
             logger.warning(msg)
         logger.info(f"index_range={index_range}, len={self.len}, len_chunk={len_chunk}")

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -202,7 +202,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                 "length of MultiStreamDataSampler,"
                 f"{n_duplicates} duplicate samples will be sampled."
                 "To avoid this increase the the length of the"
-                f"global sampling window by {n_duplicates * cf.time_window_step} hours."
+                f"global sampling window by {n_duplicates * self.step_timedelta} hours."
             )
             logger.warning(msg)
         logger.info(f"index_range={index_range}, len={self.len}, len_chunk={len_chunk}")


### PR DESCRIPTION
## Description

The code was looking for the old parameter name, this had to be changed.


## Issue Number

Closes #1493 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
