### PR TITLE
first implementation of controlled deterministic fractional overlap

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -195,10 +195,10 @@ training_config:
 #       relationship: "independent"
 #       num_steps_input: 1
 
-# Example 3: IBOT-style training (1 global teacher + 1 local student)
+# Example 3: IBOT-style training with deterministic fractional overlap
 # training_config:
 #   training_mode: "masking"
-#   losses :
+#   losses:
 #     LossPhysical: {weight: 0.7, loss_fcts: [['mse', 0.8], ['mae', 0.2]]}
 #   target_input:
 #     - masking_strategy: "cropping_healpix"
@@ -211,11 +211,20 @@ training_config:
 #     - masking_strategy: "cropping_healpix"
 #       num_samples: 1
 #       masking_strategy_config:
-#         hl_mask: 2          # Same level for consistent cropping
+#         hl_mask: 2          # Same level as teacher
 #         rate: 0.3           # Student crop: 30% of sphere
 #         method: "geodesic_disk"
-#       relationship: "independent"
+#         overlap_ratio: 0.5  # 50% of student overlaps with teacher (deterministic!)
+#       relationship: "overlap"  # Use fractional overlap relationship
 #       num_steps_input: 1
+#
+# Note on overlap_ratio:
+#   - overlap_ratio controls the fraction of STUDENT cells that come from teacher
+#   - Example with teacher=50% (6144 cells), student=30% (3686 cells), overlap_ratio=0.5:
+#     * 1843 cells (50% of student) randomly selected from teacher's 6144 cells
+#     * 1843 cells (50% of student) randomly selected from non-teacher cells
+#   - This gives deterministic overlap, unlike "independent" which is probabilistic
+#   - For edge cases: use "subset" (100% overlap) or "disjoint" (0% overlap)
 
 
 


### PR DESCRIPTION
This is the first attempt to implement the fractional overlapping of the crops between the student and the teacher.


## Description
Only one function added to the masking file to serve as a controller to the percentage of overlapping between the cells of the student and the teacher

## Checklist before asking for review

-   [X] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
   