### PR TITLE
Move the CUDA sync caused by the max operation to a higher level

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/export/export_inference.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/export_inference.py
@@ -155,7 +155,7 @@ def parse_args(args: list) -> argparse.Namespace:
         type=str,
         help="Grid type to include in the output filename (i.e. 'O96/N320')",
         required=False,
-        default="O96", 
+        default="O96",
         dest="quaver_template_grid_type",
     )
 

--- a/src/weathergen/model/attention.py
+++ b/src/weathergen/model/attention.py
@@ -68,7 +68,7 @@ class MultiSelfAttentionHeadVarlen(torch.nn.Module):
 
         assert with_flash, "Only flash attention supported at the moment"
 
-    def forward(self, x, x_lens, ada_ln_aux=None):
+    def forward(self, x, max_x_lens, x_lens, ada_ln_aux=None):
         if self.with_residual:
             x_in = x
         x = self.lnorm(x) if ada_ln_aux is None else self.lnorm(x, ada_ln_aux)
@@ -91,8 +91,8 @@ class MultiSelfAttentionHeadVarlen(torch.nn.Module):
             vs,
             cum_x_lens,
             cum_x_lens,
-            x_lens.max(),
-            x_lens.max(),
+            max_x_lens,
+            max_x_lens,
             softcap=self.softcap,
             dropout_p=dropout_rate,
         )
@@ -320,7 +320,7 @@ class MultiCrossAttentionHeadVarlen(torch.nn.Module):
         self.dtype = attention_dtype
         assert with_flash, "Only flash attention supported at the moment"
 
-    def forward(self, x_q, x_kv, x_q_lens=None, x_kv_lens=None, ada_ln_aux=None):
+    def forward(self, x_q, x_kv, max_x_q_lens, max_x_kv_lens, x_q_lens=None, x_kv_lens=None, ada_ln_aux=None):
         if self.with_residual:
             x_q_in = x_q
         x_q = self.lnorm_in_q(x_q) if ada_ln_aux is None else self.lnorm_in_q(x_q, ada_ln_aux)
@@ -346,8 +346,8 @@ class MultiCrossAttentionHeadVarlen(torch.nn.Module):
                 vs,
                 cum_x_q_lens,
                 cum_x_kv_lens,
-                x_q_lens.max(),
-                x_kv_lens.max(),
+                max_x_q_lens,
+                max_x_kv_lens,
                 softcap=self.softcap,
                 dropout_p=dropout_rate,
             )
@@ -427,7 +427,7 @@ class MultiCrossAttentionHeadVarlenSlicedQ(torch.nn.Module):
         self.dtype = attention_dtype
         assert with_flash, "Only flash attention supported at the moment"
 
-    def forward(self, x_q, x_kv, x_q_lens=None, x_kv_lens=None, ada_ln_aux=None):
+    def forward(self, x_q, x_kv, max_x_q_lens, max_x_kv_lens, x_q_lens=None, x_kv_lens=None, ada_ln_aux=None):
         if self.with_residual:
             x_q_in = x_q
         x_q = self.lnorm_in_q(x_q) if ada_ln_aux is None else self.lnorm_in_q(x_q, ada_ln_aux)
@@ -458,8 +458,8 @@ class MultiCrossAttentionHeadVarlenSlicedQ(torch.nn.Module):
                     vs,
                     cum_x_q_lens,
                     cum_x_kv_lens,
-                    x_q_lens.max(),
-                    x_kv_lens.max(),
+                    max_x_q_lens,
+                    max_x_kv_lens,
                     softcap=self.softcap,
                     dropout_p=dropout_rate,
                 )

--- a/src/weathergen/model/attention.py
+++ b/src/weathergen/model/attention.py
@@ -320,7 +320,9 @@ class MultiCrossAttentionHeadVarlen(torch.nn.Module):
         self.dtype = attention_dtype
         assert with_flash, "Only flash attention supported at the moment"
 
-    def forward(self, x_q, x_kv, max_x_q_lens, max_x_kv_lens, x_q_lens=None, x_kv_lens=None, ada_ln_aux=None):
+    def forward(
+        self, x_q, x_kv, max_x_q_lens, max_x_kv_lens, x_q_lens=None, x_kv_lens=None, ada_ln_aux=None
+    ):
         if self.with_residual:
             x_q_in = x_q
         x_q = self.lnorm_in_q(x_q) if ada_ln_aux is None else self.lnorm_in_q(x_q, ada_ln_aux)
@@ -427,7 +429,9 @@ class MultiCrossAttentionHeadVarlenSlicedQ(torch.nn.Module):
         self.dtype = attention_dtype
         assert with_flash, "Only flash attention supported at the moment"
 
-    def forward(self, x_q, x_kv, max_x_q_lens, max_x_kv_lens, x_q_lens=None, x_kv_lens=None, ada_ln_aux=None):
+    def forward(
+        self, x_q, x_kv, max_x_q_lens, max_x_kv_lens, x_q_lens=None, x_kv_lens=None, ada_ln_aux=None
+    ):
         if self.with_residual:
             x_q_in = x_q
         x_q = self.lnorm_in_q(x_q) if ada_ln_aux is None else self.lnorm_in_q(x_q, ada_ln_aux)

--- a/src/weathergen/model/blocks.py
+++ b/src/weathergen/model/blocks.py
@@ -74,10 +74,10 @@ class SelfAttentionBlock(nn.Module):
 
         self.apply(_basic_init)
 
-    def forward(self, x, x_lens, aux=None):
+    def forward(self, x, max_x_lens, x_lens, aux=None):
         # we have aux_lens as arg to be consistent with the CrossAttentionBlock
         assert self.with_adanorm ^ (aux is None), "Conditioning is not being used"
-        x = self.mhsa_block(x, aux, x_lens=x_lens)
+        x = self.mhsa_block(x, aux, max_x_lens=max_x_lens, x_lens=x_lens)
         x = self.mlp_block(x, aux)
         return x
 
@@ -131,7 +131,8 @@ class CrossAttentionBlock(nn.Module):
         else:
             self.ln_ca = nn.LayerNorm(dim_q, eps=kwargs["attention_kwargs"]["norm_eps"])
             self.cross_attn_block = (
-                lambda x, _, **kwargs: self.cross_attn(self.ln_ca(x), **kwargs) + x
+                lambda x, x_kv, max_x_q_lens, max_x_kv_lens, **kwargs: 
+                    self.cross_attn(self.ln_ca(x), x_kv, max_x_q_lens, max_x_kv_lens, **kwargs) + x
             )
 
         if self.with_mlp:
@@ -169,10 +170,10 @@ class CrossAttentionBlock(nn.Module):
 
         self.apply(_basic_init)
 
-    def forward(self, x, x_kv, aux, x_kv_lens=None, x_lens=None):
-        x = self.cross_attn_block(x, aux, x_kv=x_kv, x_lens=x_lens, x_kv_lens=x_kv_lens)
+    def forward(self, x, x_kv, aux, max_x_lens, max_x_kv_lens, x_kv_lens=None, x_lens=None):
+        x = self.cross_attn_block(x, aux, x_kv=x_kv, max_x_lens=max_x_lens, max_x_kv_lens=max_x_kv_lens, x_lens=x_lens, x_kv_lens=x_kv_lens)
         if self.with_self_attn:
-            x = self.mhsa_block(x, aux, x_lens=x_lens)
+            x = self.mhsa_block(x, aux, max_x_lens=max_x_lens, x_lens=x_lens)
         x = self.mlp_block(x, aux, x_lens=x_lens)
         return x
 
@@ -250,10 +251,10 @@ class OriginalPredictionBlock(nn.Module):
             )
         )
 
-    def forward(self, latent, output, coords, latent_lens, output_lens):
+    def forward(self, latent, output, coords, max_latent_lens, max_output_lens, latent_lens, output_lens):
         for layer in self.block:
             if isinstance(layer, MultiCrossAttentionHeadVarlen):
-                output = layer(output, latent, output_lens, latent_lens, coords)
+                output = layer(output, latent, max_output_lens, max_latent_lens,  output_lens, latent_lens, coords)
             else:
                 output = layer(output, output_lens, coords)
         return output

--- a/src/weathergen/model/blocks.py
+++ b/src/weathergen/model/blocks.py
@@ -131,8 +131,10 @@ class CrossAttentionBlock(nn.Module):
         else:
             self.ln_ca = nn.LayerNorm(dim_q, eps=kwargs["attention_kwargs"]["norm_eps"])
             self.cross_attn_block = (
-                lambda x, x_kv, max_x_q_lens, max_x_kv_lens, **kwargs: 
-                    self.cross_attn(self.ln_ca(x), x_kv, max_x_q_lens, max_x_kv_lens, **kwargs) + x
+                lambda x, x_kv, max_x_q_lens, max_x_kv_lens, **kwargs: self.cross_attn(
+                    self.ln_ca(x), x_kv, max_x_q_lens, max_x_kv_lens, **kwargs
+                )
+                + x
             )
 
         if self.with_mlp:
@@ -171,7 +173,15 @@ class CrossAttentionBlock(nn.Module):
         self.apply(_basic_init)
 
     def forward(self, x, x_kv, aux, max_x_lens, max_x_kv_lens, x_kv_lens=None, x_lens=None):
-        x = self.cross_attn_block(x, aux, x_kv=x_kv, max_x_lens=max_x_lens, max_x_kv_lens=max_x_kv_lens, x_lens=x_lens, x_kv_lens=x_kv_lens)
+        x = self.cross_attn_block(
+            x,
+            aux,
+            x_kv=x_kv,
+            max_x_lens=max_x_lens,
+            max_x_kv_lens=max_x_kv_lens,
+            x_lens=x_lens,
+            x_kv_lens=x_kv_lens,
+        )
         if self.with_self_attn:
             x = self.mhsa_block(x, aux, max_x_lens=max_x_lens, x_lens=x_lens)
         x = self.mlp_block(x, aux, x_lens=x_lens)
@@ -251,10 +261,20 @@ class OriginalPredictionBlock(nn.Module):
             )
         )
 
-    def forward(self, latent, output, coords, max_latent_lens, max_output_lens, latent_lens, output_lens):
+    def forward(
+        self, latent, output, coords, max_latent_lens, max_output_lens, latent_lens, output_lens
+    ):
         for layer in self.block:
             if isinstance(layer, MultiCrossAttentionHeadVarlen):
-                output = layer(output, latent, max_output_lens, max_latent_lens,  output_lens, latent_lens, coords)
+                output = layer(
+                    output,
+                    latent,
+                    max_output_lens,
+                    max_latent_lens,
+                    output_lens,
+                    latent_lens,
+                    coords,
+                )
             else:
                 output = layer(output, output_lens, coords)
         return output

--- a/src/weathergen/model/encoder.py
+++ b/src/weathergen/model/encoder.py
@@ -184,8 +184,10 @@ class EncoderModule(torch.nn.Module):
             if tokens_c.shape[0] == 0:
                 continue
 
+            # Calculate max_cell_lens_c
+            max_cell_lens_c = int(cell_lens_c.max())
             # local assimilation model
-            tokens_c = self.ae_local_engine(tokens_c, cell_lens_c, use_reentrant=False)
+            tokens_c = self.ae_local_engine(tokens_c, max_cell_lens_c, cell_lens_c, use_reentrant=False)
 
             if self.cf.latent_noise_kl_weight > 0.0:
                 tokens_c, posteriors_c = self.interpolate_latents.interpolate_with_noise(
@@ -201,6 +203,10 @@ class EncoderModule(torch.nn.Module):
             q_cells_lens_unmasked_c = torch.cat([zero_pad, q_cells_lens_c[1:][mask_c]])
             cell_lens_unmasked_c = torch.cat([zero_pad, cell_lens_c[1:][mask_c]])
 
+            # Calculate max
+            max_q_cells_lens_unmasked_c = int(q_cells_lens_unmasked_c.max())
+            max_cell_lens_unmasked_c = int(cell_lens_unmasked_c.max())
+
             if l0 == l1 or tokens_c.shape[0] == 0:
                 tokens_global_unmasked_all += [tokens_global_unmasked_c]
                 continue
@@ -209,6 +215,8 @@ class EncoderModule(torch.nn.Module):
             tokens_global_unmasked_c = self.ae_local_global_engine(
                 tokens_c,
                 tokens_global_unmasked_c,
+                max_q_cells_lens_unmasked_c,
+                max_cell_lens_unmasked_c,
                 q_cells_lens_unmasked_c,
                 cell_lens_unmasked_c,
                 use_reentrant=False,

--- a/src/weathergen/model/encoder.py
+++ b/src/weathergen/model/encoder.py
@@ -187,7 +187,9 @@ class EncoderModule(torch.nn.Module):
             # Calculate max_cell_lens_c
             max_cell_lens_c = int(cell_lens_c.max())
             # local assimilation model
-            tokens_c = self.ae_local_engine(tokens_c, max_cell_lens_c, cell_lens_c, use_reentrant=False)
+            tokens_c = self.ae_local_engine(
+                tokens_c, max_cell_lens_c, cell_lens_c, use_reentrant=False
+            )
 
             if self.cf.latent_noise_kl_weight > 0.0:
                 tokens_c, posteriors_c = self.interpolate_latents.interpolate_with_noise(

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -158,7 +158,9 @@ class LocalAssimilationEngine(torch.nn.Module):
 
     def forward(self, tokens_c, max_cell_lens_c, cell_lens_c, use_reentrant):
         for block in self.ae_local_blocks:
-            tokens_c = checkpoint(block, tokens_c, max_cell_lens_c, cell_lens_c, use_reentrant=use_reentrant)
+            tokens_c = checkpoint(
+                block, tokens_c, max_cell_lens_c, cell_lens_c, use_reentrant=use_reentrant
+            )
         return tokens_c
 
 
@@ -221,7 +223,16 @@ class Local2GlobalAssimilationEngine(torch.nn.Module):
                 )
             )
 
-    def forward(self, tokens_c, tokens_global_c, max_q_cells_lens_c, max_cell_lens_c, q_cells_lens_c, cell_lens_c, use_reentrant):
+    def forward(
+        self,
+        tokens_c,
+        tokens_global_c,
+        max_q_cells_lens_c,
+        max_cell_lens_c,
+        q_cells_lens_c,
+        cell_lens_c,
+        use_reentrant,
+    ):
         for block in self.ae_adapter:
             tokens_global_c = checkpoint(
                 block,
@@ -613,7 +624,16 @@ class TargetPredictionEngineClassic(nn.Module):
                 )
             )
 
-    def forward(self, latent, output, max_latent_lens, max_output_lens, latent_lens, output_lens, coordinates):
+    def forward(
+        self,
+        latent,
+        output,
+        max_latent_lens,
+        max_output_lens,
+        latent_lens,
+        output_lens,
+        coordinates,
+    ):
         tc_tokens = output
         tcs_lens = output_lens
         tokens_stream = latent
@@ -622,7 +642,9 @@ class TargetPredictionEngineClassic(nn.Module):
 
         for ib, block in enumerate(self.tte):
             if self.cf.pred_self_attention and ib % 3 == 1:
-                tc_tokens = checkpoint(block, tc_tokens, max_output_lens, tcs_lens, tcs_aux, use_reentrant=False)
+                tc_tokens = checkpoint(
+                    block, tc_tokens, max_output_lens, tcs_lens, tcs_aux, use_reentrant=False
+                )
             else:
                 tc_tokens = checkpoint(
                     block,
@@ -782,7 +804,16 @@ class TargetPredictionEngine(nn.Module):
                     f"{self.cf.decoder_type} is not implemented for prediction heads"
                 )
 
-    def forward(self, latent, output, max_latent_lens, max_output_lens, latent_lens, output_lens, coordinates):
+    def forward(
+        self,
+        latent,
+        output,
+        max_latent_lens,
+        max_output_lens,
+        latent_lens,
+        output_lens,
+        coordinates,
+    ):
         latent = (
             self.dropout(self.latent_in_norm(latent + self.pos_embed))
             if self.cf.decoder_type != "PerceiverIOCoordConditioning"

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -156,9 +156,9 @@ class LocalAssimilationEngine(torch.nn.Module):
                 )
             )
 
-    def forward(self, tokens_c, cell_lens_c, use_reentrant):
+    def forward(self, tokens_c, max_cell_lens_c, cell_lens_c, use_reentrant):
         for block in self.ae_local_blocks:
-            tokens_c = checkpoint(block, tokens_c, cell_lens_c, use_reentrant=use_reentrant)
+            tokens_c = checkpoint(block, tokens_c, max_cell_lens_c, cell_lens_c, use_reentrant=use_reentrant)
         return tokens_c
 
 
@@ -221,12 +221,14 @@ class Local2GlobalAssimilationEngine(torch.nn.Module):
                 )
             )
 
-    def forward(self, tokens_c, tokens_global_c, q_cells_lens_c, cell_lens_c, use_reentrant):
+    def forward(self, tokens_c, tokens_global_c, max_q_cells_lens_c, max_cell_lens_c, q_cells_lens_c, cell_lens_c, use_reentrant):
         for block in self.ae_adapter:
             tokens_global_c = checkpoint(
                 block,
                 tokens_global_c,
                 tokens_c,
+                max_q_cells_lens_c,
+                max_cell_lens_c,
                 q_cells_lens_c,
                 cell_lens_c,
                 use_reentrant=use_reentrant,
@@ -611,7 +613,7 @@ class TargetPredictionEngineClassic(nn.Module):
                 )
             )
 
-    def forward(self, latent, output, latent_lens, output_lens, coordinates):
+    def forward(self, latent, output, max_latent_lens, max_output_lens, latent_lens, output_lens, coordinates):
         tc_tokens = output
         tcs_lens = output_lens
         tokens_stream = latent
@@ -620,12 +622,14 @@ class TargetPredictionEngineClassic(nn.Module):
 
         for ib, block in enumerate(self.tte):
             if self.cf.pred_self_attention and ib % 3 == 1:
-                tc_tokens = checkpoint(block, tc_tokens, tcs_lens, tcs_aux, use_reentrant=False)
+                tc_tokens = checkpoint(block, tc_tokens, max_output_lens, tcs_lens, tcs_aux, use_reentrant=False)
             else:
                 tc_tokens = checkpoint(
                     block,
                     tc_tokens,
                     tokens_stream,
+                    max_output_lens,
+                    max_latent_lens,
                     tcs_lens,
                     tokens_lens,
                     tcs_aux,
@@ -778,7 +782,7 @@ class TargetPredictionEngine(nn.Module):
                     f"{self.cf.decoder_type} is not implemented for prediction heads"
                 )
 
-    def forward(self, latent, output, latent_lens, output_lens, coordinates):
+    def forward(self, latent, output, max_latent_lens, max_output_lens, latent_lens, output_lens, coordinates):
         latent = (
             self.dropout(self.latent_in_norm(latent + self.pos_embed))
             if self.cf.decoder_type != "PerceiverIOCoordConditioning"
@@ -791,6 +795,8 @@ class TargetPredictionEngine(nn.Module):
                     latent=latent.flatten(0, 1),
                     output=output,
                     coords=coordinates,
+                    max_latent_lens=max_latent_lens,
+                    max_output_lens=max_output_lens,
                     latent_lens=latent_lens,
                     output_lens=output_lens,
                     use_reentrant=False,
@@ -801,14 +807,17 @@ class TargetPredictionEngine(nn.Module):
                     x=output,
                     x_kv=latent.flatten(0, 1),
                     x_lens=output_lens,
+                    max_x_lens=max_output_lens,
                     aux=latent[:, 0],
                     x_kv_lens=latent_lens,
+                    max_x_kv_lens=max_latent_lens,
                     use_reentrant=False,
                 )
             else:
                 output = checkpoint(
                     layer,
                     x=output,
+                    max_x_lens=max_output_lens,
                     x_lens=output_lens,
                     aux=latent[:, 0],
                     use_reentrant=False,

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -618,10 +618,16 @@ class Model(torch.nn.Module):
                     ]
                 )
                 tcs_lens = torch.cat([torch.zeros(1, dtype=torch.int32, device=tcls.device), tcls])
+                
+                # calculate max 
+                max_tcs_lens = int(tcs_lens.max())
+                max_tokens_nbors_lens = int(tokens_nbors_lens.max())
 
                 tc_tokens = self.target_token_engines[stream_name](
                     latent=tokens_nbors,
                     output=tc_tokens,
+                    max_latent_lens=max_tokens_nbors_lens,
+                    max_output_lens=max_tcs_lens,
                     latent_lens=tokens_nbors_lens,
                     output_lens=tcs_lens,
                     coordinates=t_coords,

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -618,8 +618,8 @@ class Model(torch.nn.Module):
                     ]
                 )
                 tcs_lens = torch.cat([torch.zeros(1, dtype=torch.int32, device=tcls.device), tcls])
-                
-                # calculate max 
+
+                # calculate max
                 max_tcs_lens = int(tcs_lens.max())
                 max_tokens_nbors_lens = int(tokens_nbors_lens.max())
 


### PR DESCRIPTION
## Description
The max operation needed for `flash_attn_varlen_func` introduces an unnecessary CUDA synchronization. This sync can also prevent the module from being compiled. This PR moves the max operation as far up the call stack as possible to avoid the sync at the attention-module level.

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number
Closes #1531
<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
