### PR TITLE
small refactoring for EmbeddingEngine

### DIFF
--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -109,7 +109,7 @@ class EmbeddingEngine(torch.nn.Module):
                 continue
 
             scatter_idxs = torch.cat(scatter_idxs)
-            scatter_idxs = scatter_idxs.unsqueeze(1).repeat((1, self.cf.ae_local_dim_embed))
+            scatter_idxs = scatter_idxs.unsqueeze(1).expand((1, self.cf.ae_local_dim_embed))
             pe_idxs = torch.cat(pe_idxs)
 
             # embedding from physical space to per patch latent representation


### PR DESCRIPTION
## Description

- Replaced repeat with expand to create the full scatter index with broadcasting in the `[EmbeddingEngine](https://github.com/ecmwf/WeatherGenerator/blob/develop/src/weathergen/model/engines.py#L110)` for efficiency.
- This PR is a new version of #1467 

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number

Fixes #1466 

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
