### PR TITLE
Remove implicit loss function conversion in LossPhysical

### DIFF
--- a/src/weathergen/train/loss_modules/loss_functions.py
+++ b/src/weathergen/train/loss_modules/loss_functions.py
@@ -62,10 +62,6 @@ def stats_normalized_erf(target, ens, mu, stddev):
     return torch.mean(d * d)  # + torch.mean( torch.sqrt( stddev) )
 
 
-def mse(target, ens, mu, *kwargs):
-    return torch.nn.functional.mse_loss(target, mu)
-
-
 def mse_ens(target, ens, mu, stddev):
     mse_loss = torch.nn.functional.mse_loss
     return torch.stack([mse_loss(target, mem) for mem in ens], 0).mean()
@@ -127,7 +123,7 @@ def kernel_crps(
     return torch.mean(kcrps_chs), kcrps_chs
 
 
-def mse_channel_location_weighted(
+def mse(
     target: torch.Tensor,
     pred: torch.Tensor,
     weights_channels: torch.Tensor | None,
@@ -159,20 +155,20 @@ def mse_channel_location_weighted(
     where wp = weights_points and wc = weights_channels and "x" denotes row/col-wise multiplication.
 
     The computations are:
-    1. weight the rows of (target - pred) by wp = weights_points
+    1. weight the rows of (target - pred) by wp = weights_points (if given)
     2. take the mean over the row
-    3. weight the collapsed cols by wc = weights_channels
+    3. weight the collapsed cols by wc = weights_channels (if given)
     4. take the mean over the channel-weighted cols
 
     Params:
         target : shape ( num_data_points , num_channels )
         target : shape ( ens_dim , num_data_points , num_channels)
-        weights_channels : shape = (num_channels,)
-        weights_points : shape = (num_data_points)
+        weights_channels (optional): shape = (num_channels,)
+        weights_points (optional): shape = (num_data_points)
 
     Return:
-        loss : weight loss for gradient computation
-        loss_chs : losses per channel with location weighting but no channel weighting
+        loss : (weighted) loss for gradient computation
+        loss_chs : losses per channel (if given with location weighting but no channel weighting)
     """
 
     mask_nan = ~torch.isnan(target)

--- a/src/weathergen/train/loss_modules/loss_module_physical.py
+++ b/src/weathergen/train/loss_modules/loss_module_physical.py
@@ -49,7 +49,7 @@ class LossPhysical(LossModuleBase):
 
         # Dynamically load loss functions based on configuration and stage
         self.loss_fcts = [
-            [getattr(loss_fns, name if name != "mse" else "mse_channel_location_weighted"), w, name]
+            [getattr(loss_fns, name), w, name]
             for name, w in loss_fcts
         ]
 


### PR DESCRIPTION
## Description

Originally we converted `mse` loss to `mse_channel_location_weighted` in `LossPhysical`. 
As `mse_channel_location_weighted` calculates the non-weighted mse if no weights are given, this PR renames `mse_channel_location_weighted` to `mse` and removes the old `mse` function. 


## Issue Number

Closes #1536 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
