### PR TITLE
truncate filename in plotting tool 

### DIFF
--- a/packages/common/src/weathergen/common/io.py
+++ b/packages/common/src/weathergen/common/io.py
@@ -189,7 +189,7 @@ class ItemKey:
         Infer forecast offset by the (non)presence of targets at fstep 0.
 
         Args:
-            datasets: Datasets found in a fstep 0 OutputItem (eg. ZarrIO.example_key).
+            datasets: Datasets found in a fstep 0 OutputItem.
         """
         # forecast offset=1 should produce no targets at fstep 0
         return 0 if "target" in datasets else 1
@@ -367,7 +367,8 @@ class ZarrIO:
             group = self.data_root.create_group(item.path)
         else:
             try:
-                group = self.data_root[item.path]
+                group = self.data_root.get(item.path)
+                assert group is not None, f"Zarr group: {item.path} does not exist."
             except KeyError as e:
                 msg = f"Zarr group: {item.path} has not been created."
                 raise FileNotFoundError(msg) from e
@@ -408,17 +409,13 @@ class ZarrIO:
 
     @functools.cached_property
     def example_key(self) -> ItemKey:
-        fstep = 0
         try:
             sample, example_sample = next(self.data_root.groups())
             stream, example_stream = next(example_sample.groups())
+            fstep = 0
         except StopIteration as e:
             msg = f"Data store at: {self._store_path} is empty."
             raise FileNotFoundError(msg) from e
-
-        assert fstep in example_stream.groups(), (
-            "fstep 0 is missisg, but should always contain at least sources."
-        )
 
         return ItemKey(sample, fstep, stream)
 

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_utils.py
@@ -10,6 +10,8 @@
 import logging
 
 import numpy as np
+from typing import Iterable, Sequence
+from pathlib import Path
 
 _logger = logging.getLogger(__name__)
 
@@ -104,7 +106,11 @@ def plot_metric_region(
 
             if selected_data:
                 _logger.info(f"Creating plot for {metric} - {region} - {stream} - {ch}.")
-                name = "_".join([metric, region] + sorted(set(run_ids)) + [stream, ch])
+                name = create_filename(
+                    prefix=[metric, region],
+                    middle=sorted(set(run_ids)),
+                    suffix=[stream, ch]
+                )
                 plotter.plot(
                     selected_data,
                     labels,
@@ -160,7 +166,12 @@ def ratio_plot_metric_region(
 
         if len(selected_data) > 0:
             _logger.info(f"Creating Ratio plot for {metric} - {stream}")
-            name = "_".join([metric] + sorted(set(run_ids)) + [stream])
+           
+            name = create_filename(
+                prefix=[metric, region],
+                middle=sorted(set(run_ids)),
+                suffix=[stream]
+            )
             plotter.ratio_plot(
                 selected_data,
                 run_ids,
@@ -216,7 +227,11 @@ def heat_maps_metric_region(
 
         if len(selected_data) > 0:
             _logger.info(f"Creating Heat maps for {metric} - {stream}")
-            name = "_".join(sorted(set(run_ids)) + [stream])
+            name = create_filename(
+                prefix=[metric, region],
+                middle=sorted(set(run_ids)),
+                suffix=[stream]
+            )
             plotter.heat_map(
                 selected_data,
                 labels,
@@ -358,3 +373,51 @@ class DefaultMarkerSize:
             List of stream names.
         """
         return list(cls._marker_size_stream.keys())
+
+
+def create_filename(
+    *, 
+    prefix: Sequence[str] = (),
+    middle: Iterable[str] = (),
+    suffix: Sequence[str] = (),
+    sep: str = "_",
+    max_len: int = 255,
+):
+    """
+    Join strings as: prefix + middle + suffix, truncating only `middle`
+    to ensure the final string does not exceed max_len.
+
+    Parameters
+    ----------
+    prefix : Sequence[str]
+        Parts that must appear before the truncated section.
+    middle : Iterable[str]
+        Parts that may be truncated (order preserved).
+    suffix : Sequence[str]
+        Parts that must appear after the truncated section.
+    sep : str
+        Separator used for joining.
+    max_len : int
+        Maximum total length of the joined string.
+
+    Returns
+    -------
+    str
+        The joined string, with only `middle` truncated if necessary.
+    """
+
+    pref, mid, suf = map(lambda x: list(map(str, x)), (prefix, middle, suffix))
+    fixed = sep.join(pref + suf)
+    avail = max_len - len(fixed)
+
+    if mid and pref: avail -= len(sep)
+    if mid and suf: avail -= len(sep)
+    
+    truncated_middle, used = [], 0
+
+    for x in mid:
+        d = len(x) + (len(sep) if truncated_middle else 0)
+        if used + d > avail: break
+        truncated_middle.append(x); used += d
+
+    return sep.join(prefix + truncated_middle + suffix)

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_utils.py
@@ -417,4 +417,10 @@ def create_filename(
         truncated_middle.append(x)
         used += d
 
+    if len(truncated_middle) < len(mid):
+        _logger.warning(
+            f"Filename truncated: only {len(truncated_middle)} of {len(mid)} middle parts used "
+            f"to keep length <= {max_len}."
+        )
+
     return sep.join(prefix + truncated_middle + suffix)

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_utils.py
@@ -8,10 +8,9 @@
 # nor does it submit to any jurisdiction.
 
 import logging
+from collections.abc import Iterable, Sequence
 
 import numpy as np
-from typing import Iterable, Sequence
-from pathlib import Path
 
 _logger = logging.getLogger(__name__)
 
@@ -107,9 +106,7 @@ def plot_metric_region(
             if selected_data:
                 _logger.info(f"Creating plot for {metric} - {region} - {stream} - {ch}.")
                 name = create_filename(
-                    prefix=[metric, region],
-                    middle=sorted(set(run_ids)),
-                    suffix=[stream, ch]
+                    prefix=[metric, region], middle=sorted(set(run_ids)), suffix=[stream, ch]
                 )
                 plotter.plot(
                     selected_data,
@@ -166,11 +163,9 @@ def ratio_plot_metric_region(
 
         if len(selected_data) > 0:
             _logger.info(f"Creating Ratio plot for {metric} - {stream}")
-           
+
             name = create_filename(
-                prefix=[metric, region],
-                middle=sorted(set(run_ids)),
-                suffix=[stream]
+                prefix=[metric, region], middle=sorted(set(run_ids)), suffix=[stream]
             )
             plotter.ratio_plot(
                 selected_data,
@@ -228,9 +223,7 @@ def heat_maps_metric_region(
         if len(selected_data) > 0:
             _logger.info(f"Creating Heat maps for {metric} - {stream}")
             name = create_filename(
-                prefix=[metric, region],
-                middle=sorted(set(run_ids)),
-                suffix=[stream]
+                prefix=[metric, region], middle=sorted(set(run_ids)), suffix=[stream]
             )
             plotter.heat_map(
                 selected_data,
@@ -376,7 +369,7 @@ class DefaultMarkerSize:
 
 
 def create_filename(
-    *, 
+    *,
     prefix: Sequence[str] = (),
     middle: Iterable[str] = (),
     suffix: Sequence[str] = (),
@@ -410,14 +403,18 @@ def create_filename(
     fixed = sep.join(pref + suf)
     avail = max_len - len(fixed)
 
-    if mid and pref: avail -= len(sep)
-    if mid and suf: avail -= len(sep)
-    
+    if mid and pref:
+        avail -= len(sep)
+    if mid and suf:
+        avail -= len(sep)
+
     truncated_middle, used = [], 0
 
     for x in mid:
         d = len(x) + (len(sep) if truncated_middle else 0)
-        if used + d > avail: break
-        truncated_middle.append(x); used += d
+        if used + d > avail:
+            break
+        truncated_middle.append(x)
+        used += d
 
     return sep.join(prefix + truncated_middle + suffix)


### PR DESCRIPTION
## Description

truncate the number of `run_ids` if filename is too long.  


## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/1555

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
