### PR TITLE
Introduce configuration flags for gradient checkpointing

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -4,6 +4,9 @@ streams_directory: "./config/streams/era5_1deg/"
 embed_orientation: "channels"
 embed_unembed_mode: "block"
 embed_dropout_rate: 0.1
+embed_gradient_checkpoint_enabled: True
+
+stream_embed_gradient_checkpoint_enabled: True
 
 target_cell_local_prediction: True
 
@@ -15,11 +18,13 @@ ae_local_with_qk_lnorm: True
 
 ae_local_num_queries: 1
 ae_local_queries_per_cell: False
+ae_local_blocks_grdient_checkpoint_enabled: True
 ae_adapter_num_heads: 16
 ae_adapter_embed: 128
 ae_adapter_with_qk_lnorm: True
 ae_adapter_with_residual: True
 ae_adapter_dropout_rate: 0.1
+ae_adapter_grdient_checkpoint_enabled: True
 
 ae_global_dim_embed: 2048
 ae_global_num_blocks: 8
@@ -32,6 +37,7 @@ ae_global_att_dense_rate: 1.0
 ae_global_block_factor: 64
 ae_global_mlp_hidden_factor: 2
 ae_global_trailing_layer_norm: False
+ae_global_gradient_checkpoint_enabled: True
 
 ae_aggregation_num_blocks: 2
 ae_aggregation_num_heads: 32
@@ -40,12 +46,17 @@ ae_aggregation_with_qk_lnorm: True
 ae_aggregation_att_dense_rate: 1.0
 ae_aggregation_block_factor: 64
 ae_aggregation_mlp_hidden_factor: 2
+ae_aggregation_gradient_checkpoint_enabled: True
 
 decoder_type: PerceiverIOCoordConditioning # CrossAttentionAdaNormConditioning
+target_pred_engine_gradient_checkpoint_enabled: True
+target_pred_engine_classic_gradient_checkpoint_enabled: True
+
 pred_adapter_kv: False
 pred_self_attention: True
 pred_dyadic_dims: False
 pred_mlp_adaln: True
+pred_head_gradient_checkpoint_enabled: True
 
 # number of steps offset applied to first target window; if set to zero and forecast_steps=0 then
 # one is training an auto-encoder
@@ -62,6 +73,7 @@ fe_dropout_rate: 0.1
 fe_with_qk_lnorm: True
 fe_layer_norm_after_blocks: []  # Index starts at 0. Thus, [3] adds a LayerNorm after the fourth layer
 fe_impute_latent_noise_std: 0.0  # 1e-4
+fe_gradient_checkpoint_enabled: True
 
 healpix_level: 5
 

--- a/src/weathergen/model/embeddings.py
+++ b/src/weathergen/model/embeddings.py
@@ -7,6 +7,8 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+from functools import partial
+
 import numpy as np
 import torch
 
@@ -18,7 +20,6 @@ from weathergen.model.norms import RMSNorm
 from weathergen.model.positional_encoding import positional_encoding_harmonic
 from weathergen.model.utils import cond_checkpoint
 
-from functools import partial
 
 class StreamEmbedTransformer(torch.nn.Module):
     def __init__(
@@ -176,7 +177,9 @@ class StreamEmbedTransformer(torch.nn.Module):
 
     def forward_columns(self, x_in):
         # embed provided input data
-        x = positional_encoding_harmonic(checkpoint(self.embed, x_in, use_reentrant=False))
+        x = positional_encoding_harmonic(
+            self.checkpoint_stream_embed(self.embed, x_in, use_reentrant=False)
+        )
 
         for layer in self.layers:
             x = self.checkpoint_stream_embed(layer, x, use_reentrant=False)

--- a/src/weathergen/model/embeddings.py
+++ b/src/weathergen/model/embeddings.py
@@ -9,7 +9,6 @@
 
 import numpy as np
 import torch
-from torch.utils.checkpoint import checkpoint
 
 from weathergen.model.attention import MultiSelfAttentionHead
 from weathergen.model.layers import MLP
@@ -17,11 +16,14 @@ from weathergen.model.layers import MLP
 # from weathergen.model.mlp import MLP
 from weathergen.model.norms import RMSNorm
 from weathergen.model.positional_encoding import positional_encoding_harmonic
+from weathergen.model.utils import cond_checkpoint
 
+from functools import partial
 
 class StreamEmbedTransformer(torch.nn.Module):
     def __init__(
         self,
+        cf,
         mode,
         num_tokens,
         token_size,
@@ -57,6 +59,7 @@ class StreamEmbedTransformer(torch.nn.Module):
         self.num_blocks = num_blocks
         self.num_heads = num_heads
         self.unembed_mode = unembed_mode
+        self.cf = cf
 
         norm = torch.nn.LayerNorm if norm_type == "LayerNorm" else RMSNorm
 
@@ -135,21 +138,29 @@ class StreamEmbedTransformer(torch.nn.Module):
 
         self.dropout_final = torch.nn.Dropout(0.1)
 
+        self.checkpoint_stream_embed = partial(
+            cond_checkpoint, self.cf.get("stream_embed_gradient_checkpoint_enabled", True)
+        )
+
     def forward_channels(self, x_in):
         peh = positional_encoding_harmonic
 
         # embed provided input data
-        x = peh(checkpoint(self.embed, x_in.transpose(-2, -1), use_reentrant=False))
+        x = peh(
+            self.checkpoint_stream_embed(self.embed, x_in.transpose(-2, -1), use_reentrant=False)
+        )
 
         for layer in self.layers:
-            x = checkpoint(layer, x, use_reentrant=False)
+            x = self.checkpoint_stream_embed(layer, x, use_reentrant=False)
 
         # read out
         if self.unembed_mode == "full":
-            out = checkpoint(self.unembed, self.ln_final(x.flatten(-2, -1)), use_reentrant=False)
+            out = self.checkpoint_stream_embed(
+                self.unembed, self.ln_final(x.flatten(-2, -1)), use_reentrant=False
+            )
         elif self.unembed_mode == "block":
             out = [
-                checkpoint(ue, ln(x[:, i]), use_reentrant=False)
+                self.checkpoint_stream_embed(ue, ln(x[:, i]), use_reentrant=False)
                 for i, (ue, ln) in enumerate(zip(self.unembed, self.ln_final, strict=True))
             ]
             out = torch.stack(out, dim=1).flatten(-2, -1)
@@ -168,11 +179,13 @@ class StreamEmbedTransformer(torch.nn.Module):
         x = positional_encoding_harmonic(checkpoint(self.embed, x_in, use_reentrant=False))
 
         for layer in self.layers:
-            x = checkpoint(layer, x, use_reentrant=False)
+            x = self.checkpoint_stream_embed(layer, x, use_reentrant=False)
 
-        out = checkpoint(self.unembed1, x, use_reentrant=False)
+        out = self.checkpoint_stream_embed(self.unembed1, x, use_reentrant=False)
         out = self.unembed_nonlin(out)
-        out = checkpoint(self.unembed2, out.transpose(-2, -1), use_reentrant=False)
+        out = self.checkpoint_stream_embed(
+            self.unembed2, out.transpose(-2, -1), use_reentrant=False
+        )
         out = out.flatten(-2, -1).unsqueeze(1)
 
         # final normalize and dropout

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -7,9 +7,10 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+from functools import partial
+
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 
 from weathergen.common.config import Config
 from weathergen.model.attention import (
@@ -25,7 +26,7 @@ from weathergen.model.embeddings import (
     StreamEmbedTransformer,
 )
 from weathergen.model.layers import MLP
-from weathergen.model.utils import ActivationFactory
+from weathergen.model.utils import ActivationFactory, cond_checkpoint
 from weathergen.utils.utils import get_dtype
 
 
@@ -70,6 +71,7 @@ class EmbeddingEngine(torch.nn.Module):
                     norm_type=self.cf.norm_type,
                     unembed_mode=self.cf.embed_unembed_mode,
                     stream_name=stream_name,
+                    cf=self.cf
                 )
             elif si["embed"]["net"] == "linear":
                 self.embeds[stream_name] = StreamEmbedLinear(
@@ -156,9 +158,15 @@ class LocalAssimilationEngine(torch.nn.Module):
                 )
             )
 
+        self.checkpoint_ae_local_blocks = partial(
+            cond_checkpoint, self.cf.get("ae_local_blocks_grdient_checkpoint_enabled", True)
+        )
+
     def forward(self, tokens_c, cell_lens_c, use_reentrant):
         for block in self.ae_local_blocks:
-            tokens_c = checkpoint(block, tokens_c, cell_lens_c, use_reentrant=use_reentrant)
+            tokens_c = self.checkpoint_ae_local_blocks(
+                block, tokens_c, cell_lens_c, use_reentrant=use_reentrant
+            )
         return tokens_c
 
 
@@ -221,9 +229,13 @@ class Local2GlobalAssimilationEngine(torch.nn.Module):
                 )
             )
 
+        self.checkpoint_ae_adapter = partial(
+            cond_checkpoint, self.cf.get("ae_adapter_grdient_checkpoint_enabled", True)
+        )
+
     def forward(self, tokens_c, tokens_global_c, q_cells_lens_c, cell_lens_c, use_reentrant):
         for block in self.ae_adapter:
-            tokens_global_c = checkpoint(
+            tokens_global_c = self.checkpoint_ae_adapter(
                 block,
                 tokens_global_c,
                 tokens_c,
@@ -299,9 +311,13 @@ class QueryAggregationEngine(torch.nn.Module):
                 )
             )
 
+        self.checkpoint_ae_aggregation = partial(
+            cond_checkpoint, self.cf.get("ae_aggregation_gradient_checkpoint_enabled", True)
+        )
+
     def forward(self, tokens, use_reentrant):
         for block in self.ae_aggregation_blocks:
-            tokens = checkpoint(block, tokens, use_reentrant=use_reentrant)
+            tokens = self.checkpoint_ae_aggregation(block, tokens, use_reentrant=use_reentrant)
         return tokens
 
 
@@ -375,9 +391,13 @@ class GlobalAssimilationEngine(torch.nn.Module):
             torch.nn.LayerNorm(self.cf.ae_global_dim_embed, elementwise_affine=False)
         )
 
+        self.checkpoint_ae_global = partial(
+            cond_checkpoint, self.cf.get("ae_global_gradient_checkpoint_enabled", True)
+        )
+
     def forward(self, tokens, use_reentrant):
         for block in self.ae_global_blocks:
-            tokens = checkpoint(block, tokens, use_reentrant=use_reentrant)
+            tokens = self.checkpoint_ae_global(block, tokens, use_reentrant=use_reentrant)
         return tokens
 
 
@@ -461,13 +481,15 @@ class ForecastingEngine(torch.nn.Module):
         for block in self.fe_blocks:
             block.apply(init_weights_final)
 
+        self.checkpoint_fe = partial(cond_checkpoint, self.cf.get("fe_gradient_checkpoint_enabled", True))
+
     def forward(self, tokens, fstep):
         aux_info = None
         for _b_idx, block in enumerate(self.fe_blocks):
             if isinstance(block, torch.nn.modules.normalization.LayerNorm):
                 tokens = block(tokens)
             else:
-                tokens = checkpoint(block, tokens, aux_info, use_reentrant=False)
+                tokens = self.checkpoint_fe(block, tokens, aux_info, use_reentrant=False)
         return tokens
 
 
@@ -611,6 +633,10 @@ class TargetPredictionEngineClassic(nn.Module):
                 )
             )
 
+        self.checkpoint_pred = partial(
+            cond_checkpoint, self.cf.get("target_pred_engine_classic_gradient_checkpoint_enabled", True)
+        )
+
     def forward(self, latent, output, latent_lens, output_lens, coordinates):
         tc_tokens = output
         tcs_lens = output_lens
@@ -620,9 +646,11 @@ class TargetPredictionEngineClassic(nn.Module):
 
         for ib, block in enumerate(self.tte):
             if self.cf.pred_self_attention and ib % 3 == 1:
-                tc_tokens = checkpoint(block, tc_tokens, tcs_lens, tcs_aux, use_reentrant=False)
+                tc_tokens = self.checkpoint_pred(
+                    block, tc_tokens, tcs_lens, tcs_aux, use_reentrant=False
+                )
             else:
-                tc_tokens = checkpoint(
+                tc_tokens = self.checkpoint_pred(
                     block,
                     tc_tokens,
                     tokens_stream,
@@ -778,6 +806,10 @@ class TargetPredictionEngine(nn.Module):
                     f"{self.cf.decoder_type} is not implemented for prediction heads"
                 )
 
+        self.checkpoint_target = partial(
+            cond_checkpoint, self.cf.get("target_pred_engine_gradient_checkpoint_enabled", True)
+        )
+
     def forward(self, latent, output, latent_lens, output_lens, coordinates):
         latent = (
             self.dropout(self.latent_in_norm(latent + self.pos_embed))
@@ -786,7 +818,7 @@ class TargetPredictionEngine(nn.Module):
         )
         for layer in self.tte:
             if isinstance(layer, OriginalPredictionBlock):
-                output = checkpoint(
+                output = self.checkpoint_target(
                     layer,
                     latent=latent.flatten(0, 1),
                     output=output,
@@ -796,7 +828,7 @@ class TargetPredictionEngine(nn.Module):
                     use_reentrant=False,
                 )
             elif isinstance(layer, CrossAttentionBlock):
-                output = checkpoint(
+                output = self.checkpoint_target(
                     layer,
                     x=output,
                     x_kv=latent.flatten(0, 1),
@@ -806,7 +838,7 @@ class TargetPredictionEngine(nn.Module):
                     use_reentrant=False,
                 )
             else:
-                output = checkpoint(
+                output = self.checkpoint_target(
                     layer,
                     x=output,
                     x_lens=output_lens,

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -71,7 +71,7 @@ class EmbeddingEngine(torch.nn.Module):
                     norm_type=self.cf.norm_type,
                     unembed_mode=self.cf.embed_unembed_mode,
                     stream_name=stream_name,
-                    cf=self.cf
+                    cf=self.cf,
                 )
             elif si["embed"]["net"] == "linear":
                 self.embeds[stream_name] = StreamEmbedLinear(
@@ -481,7 +481,9 @@ class ForecastingEngine(torch.nn.Module):
         for block in self.fe_blocks:
             block.apply(init_weights_final)
 
-        self.checkpoint_fe = partial(cond_checkpoint, self.cf.get("fe_gradient_checkpoint_enabled", True))
+        self.checkpoint_fe = partial(
+            cond_checkpoint, self.cf.get("fe_gradient_checkpoint_enabled", True)
+        )
 
     def forward(self, tokens, fstep):
         aux_info = None
@@ -634,7 +636,8 @@ class TargetPredictionEngineClassic(nn.Module):
             )
 
         self.checkpoint_pred = partial(
-            cond_checkpoint, self.cf.get("target_pred_engine_classic_gradient_checkpoint_enabled", True)
+            cond_checkpoint,
+            self.cf.get("target_pred_engine_classic_gradient_checkpoint_enabled", True),
         )
 
     def forward(self, latent, output, latent_lens, output_lens, coordinates):

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -7,8 +7,8 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-from functools import partial
 import dataclasses
+from functools import partial
 
 import torch
 import torch.nn as nn

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -12,13 +12,13 @@
 import logging
 import math
 import warnings
+from functools import partial
 
 import astropy_healpix as hp
 import astropy_healpix.healpy
 import numpy as np
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 
 from weathergen.common.config import Config
 from weathergen.datasets.batch import ModelBatch
@@ -31,7 +31,7 @@ from weathergen.model.engines import (
     TargetPredictionEngineClassic,
 )
 from weathergen.model.layers import MLP, NamedLinear
-from weathergen.model.utils import get_num_parameters
+from weathergen.model.utils import cond_checkpoint, get_num_parameters
 from weathergen.utils.distributed import is_root
 from weathergen.utils.utils import get_dtype
 
@@ -283,6 +283,14 @@ class Model(torch.nn.Module):
 
         assert cf.forecast_att_dense_rate == 1.0, "Local attention not adapted for register tokens"
         self.num_register_tokens = cf.num_register_tokens
+
+        self.checkpoint_fn_embed = partial(
+            cond_checkpoint, self.cf.get("embed_gradient_checkpoint_enabled", True)
+        )
+
+        self.checkpoint_fn_pred = partial(
+            cond_checkpoint, self.cf.get("pred_head_gradient_checkpoint_enabled", True)
+        )
 
     #########################################
     def create(self) -> "Model":
@@ -593,7 +601,7 @@ class Model(torch.nn.Module):
             )
             # embed token coords
             tc_embed = self.embed_target_coords[stream_name]
-            tc_tokens = checkpoint(tc_embed, t_coords, use_reentrant=False)
+            tc_tokens = self.checkpoint_fn_embed(tc_embed, t_coords, use_reentrant=False)
 
             # skip when coordinate embeddings yields nan (i.e. the coord embedding network diverged)
             if torch.isnan(tc_tokens).any():
@@ -628,7 +636,9 @@ class Model(torch.nn.Module):
                 )
 
                 # final prediction head to map back to physical space
-                pred = checkpoint(self.pred_heads[stream_name], tc_tokens, use_reentrant=False)
+                pred = self.checkpoint_fn_pred(
+                    self.pred_heads[stream_name], tc_tokens, use_reentrant=False
+                )
 
             output.add_physical_prediction(fstep, stream_name, pred)
 

--- a/src/weathergen/model/utils.py
+++ b/src/weathergen/model/utils.py
@@ -7,10 +7,12 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+from collections.abc import Callable
+
 import torch
 import torch.nn as nn
-from typing import Callable, Optional
 from torch.utils.checkpoint import checkpoint
+
 
 #########################################
 def get_num_parameters(block):
@@ -26,17 +28,18 @@ def freeze_weights(block):
 
 ########################################
 def cond_checkpoint(
-        enable_checkpoint: bool,
-        function: Callable,
-        *args,
-        use_reentrant: Optional[bool] = None,
-        **kwargs
+    enable_checkpoint: bool,
+    function: Callable,
+    *args,
+    use_reentrant: bool | None = None,
+    **kwargs,
 ):
     if enable_checkpoint:
-        checkpoint_kwargs = {'use_reentrant': use_reentrant} if use_reentrant is not None else {}
+        checkpoint_kwargs = {"use_reentrant": use_reentrant} if use_reentrant is not None else {}
         return checkpoint(function, *args, **checkpoint_kwargs, **kwargs)
     else:
         return function(*args, **kwargs)
+
 
 #########################################
 class ActivationFactory:

--- a/src/weathergen/model/utils.py
+++ b/src/weathergen/model/utils.py
@@ -9,7 +9,8 @@
 
 import torch
 import torch.nn as nn
-
+from typing import Callable, Optional
+from torch.utils.checkpoint import checkpoint
 
 #########################################
 def get_num_parameters(block):
@@ -22,6 +23,20 @@ def freeze_weights(block):
     for p in block.parameters():
         p.requires_grad = False
 
+
+########################################
+def cond_checkpoint(
+        enable_checkpoint: bool,
+        function: Callable,
+        *args,
+        use_reentrant: Optional[bool] = None,
+        **kwargs
+):
+    if enable_checkpoint:
+        checkpoint_kwargs = {'use_reentrant': use_reentrant} if use_reentrant is not None else {}
+        return checkpoint(function, *args, **checkpoint_kwargs, **kwargs)
+    else:
+        return function(*args, **kwargs)
 
 #########################################
 class ActivationFactory:


### PR DESCRIPTION
## Description
Replaces #1168 . I opened a fresh PR because resolving conflicts in the original became messy. The change set is the same intent; this PR is the clean continuation.

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number
Closes #1141 
<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel

## Performance gain

Regarding the performance gain: when we disable all gradient checkpointing on a single node using the default config, we see about a **20% improvement** with no CUDA out-of-memory (OOM) issues, compared to the develop branch (commit df59a9a9). Here’s how I ran the code on both the develop branch and this branch:

`../WeatherGenerator-private/hpc/launch-slurm.py --time 180 --nodes=1
`
The experiments have been uploaded:
`Develop` branch test ID: `cka04xbw`
`javad/dev/cond_checkpoint_all-1141-ver1` branch test ID: `s8p7iec0`

If a different configuration runs into CUDA OOM, you can set some of the flags (not all of them) with the `checkpoint_enabled` option to True. This enables gradient checkpointing so activations are recomputed during the backward pass, which helps avoid CUDA OOM errors.