### PR TITLE
added num_samples: 1

### DIFF
--- a/integration_tests/small_multi_stream.yaml
+++ b/integration_tests/small_multi_stream.yaml
@@ -54,7 +54,7 @@ training_config:
   training_mode: ["masking"]
 
   num_mini_epochs: 1
-  samples_per_mini_epoch: 512 #128 #256
+  samples_per_mini_epoch: 120 #128 #256
   shuffle: True
 
   start_date: 2012-01-01T00:00
@@ -97,6 +97,7 @@ training_config:
   model_input: {
     "forecasting" : {
       masking_strategy: "forecast",
+      num_samples: 1,
     }
   }
 


### PR DESCRIPTION
## Description

add `num_samples` to the integration test config to avoid appending from default config.

```
  model_input: {
    "forecasting" : {
      masking_strategy: "forecast",
      num_samples: 1,
    }
  }
```


## Issue Number

No issue

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
