### PR TITLE
Bilinear decoder: adapt code for batchsize > 1

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -45,7 +45,7 @@ ae_aggregation_att_dense_rate: 1.0
 ae_aggregation_block_factor: 64
 ae_aggregation_mlp_hidden_factor: 2
 
-decoder_type: PerceiverIOCoordConditioning # Linear
+decoder_type: PerceiverIOCoordConditioning #  Main options PerceiverIOCoordConditioning or Linear
 pred_adapter_kv: False
 pred_self_attention: True
 pred_dyadic_dims: False

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -863,13 +863,12 @@ class BilinearDecoder(nn.Module):
         self.latent_dim = latent_dim
         self.bilin = nn.Bilinear(coord_dim, latent_dim, out_dim, bias=False)
 
-    def forward(self, coords_bmd, latent_bnd, tcs_lens_bn1):
+    def forward(self, coords_md, latent_nd, tcs_lens_n1):
         """
         Using Noam Shazeer notation
-        B = Batchsize
-        N = Number of latent tokens (N1 means N+1)
+        N = Number of latent tokens*batch_size (N1 means N+1)
         M = Number of coordinates to decode
         D = Hidden dimension
         """
-        latent_bmd = torch.repeat_interleave(latent_bnd, tcs_lens_bn1[1:], 1)
-        return self.bilin(coords_bmd, latent_bmd)
+        latent_md = torch.repeat_interleave(latent_nd, tcs_lens_n1[1:], 0)
+        return self.bilin(coords_md, latent_md)

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -697,11 +697,11 @@ class Model(torch.nn.Module):
                 if self.cf.decoder_type == "Linear":
                     pred = checkpoint(
                         self.target_token_engines[stream_name],
-                        tc_tokens.unsqueeze(0),  # adding the batch dimension
-                        tokens,
+                        tc_tokens,  
+                        tokens.reshape(-1, s[-1]), # collapse the batch and token dimensions
                         tcs_lens,
                         use_reentrant=False,
-                    )
+                    ).unsqueeze(0) # because the expected shape is [1, preds_per_coord, channels]
                 else:
                     tc_tokens = self.target_token_engines[stream_name](
                         latent=tokens_nbors,
@@ -716,7 +716,6 @@ class Model(torch.nn.Module):
 
             # recover batch dimension (ragged, so as list)
             pred = torch.split(pred, t_coords_lens, dim=1)
-
             output.add_physical_prediction(fstep, stream_name, pred)
 
         return output

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -697,11 +697,11 @@ class Model(torch.nn.Module):
                 if self.cf.decoder_type == "Linear":
                     pred = checkpoint(
                         self.target_token_engines[stream_name],
-                        tc_tokens,  
-                        tokens.reshape(-1, s[-1]), # collapse the batch and token dimensions
+                        tc_tokens,
+                        tokens.reshape(-1, s[-1]),  # collapse the batch and token dimensions
                         tcs_lens,
                         use_reentrant=False,
-                    ).unsqueeze(0) # because the expected shape is [1, preds_per_coord, channels]
+                    ).unsqueeze(0)  # add ensemble dim: shape is then [1, preds_per_coord, channels]
                 else:
                     tc_tokens = self.target_token_engines[stream_name](
                         latent=tokens_nbors,


### PR DESCRIPTION
## Description

Update bilinear decoder for batch size > 1


## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
