### PR TITLE
Set output dataset metadata in creation of zarr group to avoid increm…

### DIFF
--- a/packages/common/src/weathergen/common/io.py
+++ b/packages/common/src/weathergen/common/io.py
@@ -272,6 +272,14 @@ class OutputDataset:
             "coords": self.coords,
             "geoinfo": self.geoinfo,
         }
+    
+    @property
+    def metadata(self) -> dict[str, typing.Any]:
+        return {
+            "channels": dataset.channels,
+            "geoinfo_channels": dataset.geoinfo_channels,
+            "source_interval": dataset.source_interval.as_dict()
+        }
 
     @functools.cached_property
     def datapoints(self) -> NDArray[np.int_]:
@@ -436,14 +444,9 @@ class ZarrIO:
         return group
 
     def _write_dataset(self, item_group: zarr.Group, dataset: OutputDataset):
-        dataset_group = item_group.require_group(dataset.name)
-        self._write_metadata(dataset_group, dataset)
+        assert dataset.name not in list(item_group.keys), "No duplication allowed"
+        dataset_group = item_group.create_group(dataset.name, attrs=dataset.metadata)
         self._write_arrays(dataset_group, dataset)
-
-    def _write_metadata(self, dataset_group: zarr.Group, dataset: OutputDataset):
-        dataset_group.attrs["channels"] = dataset.channels
-        dataset_group.attrs["geoinfo_channels"] = dataset.geoinfo_channels
-        dataset_group.attrs["source_interval"] = dataset.source_interval.as_dict()
 
     def _write_arrays(self, dataset_group: zarr.Group, dataset: OutputDataset):
         for array_name, array in dataset.arrays.items():  # suffix is eg. data or coords


### PR DESCRIPTION
…ental metadata writes.

## Description

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
