### PR TITLE
[1601] Remove hardcoded optimizer variable eps

### DIFF
--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -275,7 +275,7 @@ class Trainer(TrainerBase):
         beta1 = max(0.5, 1.0 - kappa * (1.0 - self.training_cfg.optimizer.adamw.beta1))
         # aiming for beta2 = 0.95 at one node, ie B=4
         beta2 = 1.0 - kappa * (1.0 - self.training_cfg.optimizer.adamw.beta2)
-        eps = self.training_cfg.optimizer.adamw.eps / np.sqrt(kappa)
+        eps = self.training_cfg.optimizer.adamw.get("eps", 2e-08) / np.sqrt(kappa)
 
         self.optimizer = torch.optim.AdamW(
             self.model.parameters(),

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -275,7 +275,7 @@ class Trainer(TrainerBase):
         beta1 = max(0.5, 1.0 - kappa * (1.0 - self.training_cfg.optimizer.adamw.beta1))
         # aiming for beta2 = 0.95 at one node, ie B=4
         beta2 = 1.0 - kappa * (1.0 - self.training_cfg.optimizer.adamw.beta2)
-        eps = 2e-08 / np.sqrt(kappa)
+        eps = self.training_cfg.optimizer.adamw.eps / np.sqrt(kappa)
 
         self.optimizer = torch.optim.AdamW(
             self.model.parameters(),


### PR DESCRIPTION
## Description

Variable `eps` in adamw optimizer is hardcoded here:
https://github.com/ecmwf/WeatherGenerator/blob/0d502ed7b536c77c4116f5fd158755e0842aa71b/src/weathergen/train/trainer.py#L278
despite being a parameter in the config:
https://github.com/ecmwf/WeatherGenerator/blob/0d502ed7b536c77c4116f5fd158755e0842aa71b/config/default_config.yml#L167

This PR uses parameter `eps` from the config.


## Issue Number

Closes #1601 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
