### PR TITLE
Change parameter types from duration to timedelta

### DIFF
--- a/CONFIG_DOCUMENTATION.md
+++ b/CONFIG_DOCUMENTATION.md
@@ -160,8 +160,8 @@ Located under `training_config:` in YAML files.
 | `shuffle` | bool | `True` | Shuffle training data |
 | `start_date` | datetime | `1979-01-01T00:00` | Training data start date |
 | `end_date` | datetime | `2022-12-31T00:00` | Training data end date |
-| `time_window_step` | duration | `06:00:00` | Time step between windows |
-| `time_window_len` | duration | `06:00:00` | Length of each time window |
+| `time_window_step` | timedelta | `06:00:00` | Time step between windows |
+| `time_window_len` | timedelta | `06:00:00` | Length of each time window |
 | `window_offset_prediction` | int | `1` | Steps offset for prediction target |
 
 **Available `training_mode` options:**
@@ -213,7 +213,7 @@ Located under `training_config.forecast:`:
 
 | Parameter | Type | Default | Options | Description |
 |-----------|------|---------|---------|-------------|
-| `time_step` | duration | `06:00:00` | | Time step between forecast steps |
+| `time_step` | timedelta | `06:00:00` | | Time step between forecast steps |
 | `num_steps` | int | `2` | | Number of autoregressive forecast steps |
 | `policy` | string | `"fixed"` | `fixed`, `null` | Forecast policy |
 


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
