### PR TITLE
Enable multiple student views for one target for JEPA

### DIFF
--- a/src/weathergen/train/loss_modules/loss_module_ssl.py
+++ b/src/weathergen/train/loss_modules/loss_module_ssl.py
@@ -221,6 +221,7 @@ class LossLatentSSLStudentTeacher(LossModuleBase):
 
 def jepa_loss(student_patches_masked, student_masks, teacher_patches_masked, teacher_masks):
     # TODO remove as we deal with batch dimension
+    assert teacher_masks.shape[0] == 1 or teacher_masks.shape[0] == student_masks.shape[0]
     student_masks = student_masks.squeeze(dim=1)
     teacher_masks = teacher_masks.squeeze(dim=1)
     masks_weight = (
@@ -233,7 +234,13 @@ def jepa_loss(student_patches_masked, student_masks, teacher_patches_masked, tea
     if mask.sum() == 0:
         logger.warning("jepa_loss mask is all true, likely incorrect masking config.")
 
-    loss = F.l1_loss(student_patches_masked[mask], teacher_patches_masked[mask])
+    assert mask.shape[0] == student_patches_masked.shape[0], (
+        "mask.shape[0], batch dimension, has to match batch dimension for student_patches_masked."
+    )
+    # expand/repeat teacher_masks to match number of student samples
+    teacher_patches_masked = teacher_patches_masked.expand((mask.shape[0], -1, -1))[mask]
+    # compute loss
+    loss = F.l1_loss(student_patches_masked[mask], teacher_patches_masked)
     loss = loss * masks_weight[mask]
 
     return loss.sum()  # / student_masks.shape[0]

--- a/src/weathergen/train/loss_modules/loss_module_ssl.py
+++ b/src/weathergen/train/loss_modules/loss_module_ssl.py
@@ -238,9 +238,9 @@ def jepa_loss(student_patches_masked, student_masks, teacher_patches_masked, tea
         "mask.shape[0], batch dimension, has to match batch dimension for student_patches_masked."
     )
     # expand/repeat teacher_masks to match number of student samples
-    teacher_patches_masked = teacher_patches_masked.expand((mask.shape[0], -1, -1))[mask]
+    teacher_patches = teacher_patches_masked.expand((mask.shape[0], -1, -1))
     # compute loss
-    loss = F.l1_loss(student_patches_masked[mask], teacher_patches_masked)
+    loss = F.l1_loss(student_patches_masked[mask], teacher_patches[mask])
     loss = loss * masks_weight[mask]
 
     return loss.sum()  # / student_masks.shape[0]


### PR DESCRIPTION
## Description

Enable multiple student views for one target

## Issue Number

Closes #1616 

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
