### PR TITLE
Clessig/develop/fix finetuning 1640

### DIFF
--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -100,7 +100,7 @@ class EmbeddingEngine(torch.nn.Module):
                 for sample in batch.get_samples():
                     sdata += [sample.streams_data[stream_name].source_tokens_cells[istep]]
 
-            sdata = torch.cat(sdata)
+            sdata = torch.cat(sdata).to(tokens_all.dtype)
             # skip empty stream
             if len(sdata) == 0:
                 continue

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -313,6 +313,10 @@ class Model(torch.nn.Module):
             for i_stream, si in enumerate(cf.streams):
                 stream_name = self.stream_names[i_stream]
 
+                # skip decoder if channels are empty
+                if len(si.train_target_channels) == 0 and len(si.val_target_channels) == 0:
+                    continue
+
                 # extract and setup relevant parameters
                 etc = si["embed_target_coords"]
                 tro_type = (
@@ -494,16 +498,19 @@ class Model(torch.nn.Module):
 
         num_params_fe = get_num_parameters(self.forecast_engine.fe_blocks)
 
+        mdict = self.embed_target_coords
         num_params_embed_tcs = [
-            get_num_parameters(self.embed_target_coords[name]) if self.embed_target_coords else 0
+            get_num_parameters(mdict[name]) if mdict and name in mdict else 0
             for name in self.stream_names
         ]
+        mdict = self.target_token_engines
         num_params_tte = [
-            get_num_parameters(self.target_token_engines[name]) if self.target_token_engines else 0
+            get_num_parameters(mdict[name]) if mdict and name in mdict else 0
             for name in self.stream_names
         ]
+        mdict = self.pred_heads
         num_params_preds = [
-            get_num_parameters(self.pred_heads[name]) if self.pred_heads else 0
+            get_num_parameters(mdict[name]) if mdict and name in mdict else 0
             for name in self.stream_names
         ]
 


### PR DESCRIPTION
## Description

Fix bug with diagnostic streams and avoid that decoders are allocated for streams that has no target channels.

## Issue Number

Closes #1640 

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
