### PR TITLE
Fix test for empty targets in decoder creation

### DIFF
--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -314,7 +314,10 @@ class Model(torch.nn.Module):
                 stream_name = self.stream_names[i_stream]
 
                 # skip decoder if channels are empty
-                if len(si.train_target_channels) == 0 and len(si.val_target_channels) == 0:
+                if (
+                    len(si.get("train_target_channels", [])) == 0
+                    and len(si.get("val_target_channels", [])) == 0
+                ):
                     continue
 
                 # extract and setup relevant parameters


### PR DESCRIPTION
## Description

Fix test for empty targets in decoder creation

## Issue Number

Closes #1645 

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
