### PR TITLE
1654 Fixing forecast steps in model, loss, and data loader

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -147,8 +147,6 @@ training_config:
 
   time_window_step: 06:00:00
   time_window_len: 06:00:00
-
-  window_offset_prediction : 1
   
   learning_rate_scheduling :
     lr_start: 1e-6
@@ -189,6 +187,7 @@ training_config:
   forecast :
       time_step: 06:00:00
       num_steps: 2
+      offset: 1
       policy: "fixed"
 
 

--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -686,7 +686,7 @@ def get_shared_wg_path(local_path: str | Path) -> Path:
     return Path(pcfg.get("path_shared_working_dir")) / local_path
 
 
-def validate_forecast_policy_and_steps(forecast_cfg: OmegaConf):
+def validate_forecast_policy_and_steps(forecast_cfg: OmegaConf, mode: str):
     """
     Validates the forecast policy, steps and offset within a configuration object.
 
@@ -706,6 +706,7 @@ def validate_forecast_policy_and_steps(forecast_cfg: OmegaConf):
     Args:
         mode_cfg (OmegaConf): The training/validation/test configuration object containing the
                              `forecast.num_steps` and `forecast.policy` attributes.
+        mode (str): the training mode, i.e. training_config, validation_config, or test_config
 
     Raises:
         TypeError: If `forecast.offset` is not an integer of value 0 or 1.
@@ -715,21 +716,22 @@ def validate_forecast_policy_and_steps(forecast_cfg: OmegaConf):
                         if any of the forecast steps in a list are negative.
     """
     provide_forecast_policy = (
-        "A 'forecast.policy' must be specified when 'forecast.num_steps' is not zero and "
-        "'forecast.offset' is 1. "
+        f"'{mode}.forecast.policy' must be specified when '{mode}.forecast.num_steps' is not zero "
+        f"and '{mode}.forecast.offset' is 1. "
     )
     valid_forecast_policies = (
-        "Valid values for 'forecast.policy' are, e.g., 'fixed' when using constant number of "
-        "forecast steps throughout the training, or 'sequential' when varying the number of "
+        "Valid values for '{mode}.forecast.policy' are, e.g., 'fixed' when using constant number "
+        "of forecast steps throughout the training, or 'sequential' when varying the number of "
         "forecast steps over mini_epochs, such as, e.g., 'forecast.num_steps: [2, 2, 4, 4]'. "
     )
-    valid_forecast_offset = "'forecast.offset' must be an integer of either value 0 or 1. "
+    valid_forecast_offset = f"'{mode}.forecast.offset' must be an integer of either value 0 or 1. "
     valid_forecast_steps_offset0 = (
-        "For 'forecast.offset: 0', 'forecast.num_steps' must be an integer of value either 0 or 1. "
+        f"For '{mode}.forecast.offset: 0', '{mode}.forecast.num_steps' must be an integer of value "
+        f"either 0 or 1. "
     )
     valid_forecast_steps_offset1 = (
-        "For 'forecast.offset: 0', 'forecast.num_steps' must be an integer greater than 1 or a "
-        "non-empty list and all of its elements must be integers greater than 1."
+        f"For '{mode}.forecast.offset: 0', '{mode}.forecast.num_steps' must be an integer greater "
+        "than 1 or a non-empty list and all of its elements must be integers greater than 1."
     )
     assert isinstance(forecast_cfg.offset, int), TypeError(valid_forecast_offset)
     if forecast_cfg.offset == 0:

--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -715,6 +715,10 @@ def validate_forecast_policy_and_steps(forecast_cfg: OmegaConf, mode: str):
                         if `forecast_step` is negative while `forecast.policy` is provided, or
                         if any of the forecast steps in a list are negative.
     """
+
+    if len(forecast_cfg) == 0:
+        return
+
     provide_forecast_policy = (
         f"'{mode}.forecast.policy' must be specified when '{mode}.forecast.num_steps' is not zero "
         f"and '{mode}.forecast.offset' is 1. "
@@ -733,18 +737,23 @@ def validate_forecast_policy_and_steps(forecast_cfg: OmegaConf, mode: str):
         f"For '{mode}.forecast.offset: 0', '{mode}.forecast.num_steps' must be an integer greater "
         "than 1 or a non-empty list and all of its elements must be integers greater than 1."
     )
-    assert isinstance(forecast_cfg.offset, int), TypeError(valid_forecast_offset)
-    if forecast_cfg.offset == 0:
+
+    # get output_offset or set default to 0 as in multi_stream_data_sampler.py
+    output_offset = forecast_cfg.get("offset", 0)
+    assert isinstance(output_offset, int), TypeError(valid_forecast_offset)
+    if output_offset == 0:
         if isinstance(forecast_cfg.num_steps, int):
             assert forecast_cfg.num_steps in [0, 1], valid_forecast_steps_offset0
         else:
             raise TypeError(valid_forecast_steps_offset0)
-    if forecast_cfg.offset == 1:
+    elif output_offset == 1:
         assert forecast_cfg.policy, (provide_forecast_policy, valid_forecast_policies)
         if isinstance(forecast_cfg.num_steps, int):
             assert forecast_cfg.num_steps > 0, valid_forecast_steps_offset1
         elif isinstance(forecast_cfg.num_steps, ListConfig) and len(forecast_cfg.num_steps) > 0:
-            assert all(step > 0 for step in forecast_cfg.num_steps), valid_forecast_steps_offset1
+            assert all(step > 0 for step in forecast_cfg.num_steps), (
+                valid_forecast_steps_offset1
+            )
         else:
             raise TypeError(valid_forecast_steps_offset1)
     else:

--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -686,51 +686,64 @@ def get_shared_wg_path(local_path: str | Path) -> Path:
     return Path(pcfg.get("path_shared_working_dir")) / local_path
 
 
-def validate_forecast_policy_and_steps(cf: OmegaConf):
+def validate_forecast_policy_and_steps(forecast_cfg: OmegaConf):
     """
-    Validates the forecast policy and steps within a configuration object.
+    Validates the forecast policy, steps and offset within a configuration object.
 
-    This method enforces specific rules for the `forecast_steps` attribute, which can be
+    This method enforces specific rules for the `forecast.num_steps` attribute, which can be
     either a single integer or a list of integers, ensuring consistency with the
-    `forecast_policy` attribute.
+    `forecast.policy` attribute. Furthermore `forecast.offset` is enforeced to be either 0 or 1.
 
     The validation logic is as follows:
-    - If `cf.forecast_steps` is a single integer, a `forecast_policy` must be defined
-    (i.e., not None or empty) only if `forecast_steps` is unequal to 0.
-    - If `cf.forecast_steps` is a list, it must be non-empty, and all of its elements
-    must be non-negative integers. Additionally, a `forecast_policy` must be
-    defined if any of the forecast steps in the list are greater than 0.
+    - `forecast.offset` must either be 0 or 1.
+    - If `forecast.offset` is 0, `forecast.num_steps` must be an integer and can either be 0 (e.g.
+      used for SSL training without forecast engine) or 1 (e.g. used for diffusion in which the
+      forecast engine is used to denoise the current time window).
+    - If `forecast.offset` is 1, a `forecast.policy` must be specified and `forecast.num_steps` can
+      either be a single integer greater than 1 or a non-empty list and all of its elements must be
+      integers greater than 1.
 
     Args:
-        cf (OmegaConf): The configuration object containing the `forecast_steps`
-                        and `forecast_policy` attributes.
+        mode_cfg (OmegaConf): The training/validation/test configuration object containing the
+                             `forecast.num_steps` and `forecast.policy` attributes.
 
     Raises:
-        TypeError: If `cf.forecast_steps` is not an integer or a non-empty list.
-        AssertionError: If a `forecast_policy` is required but not provided, or
-                        if `forecast_step` is negative while `forecast_policy` is provided, or
+        TypeError: If `forecast.offset` is not an integer of value 0 or 1.
+        TypeError: If `forecast.num_steps` is not an integer or a non-empty list.
+        AssertionError: If a `forecast.policy` is required but not provided, or
+                        if `forecast_step` is negative while `forecast.policy` is provided, or
                         if any of the forecast steps in a list are negative.
     """
     provide_forecast_policy = (
-        "A 'forecast_policy' must be specified when 'forecast_steps' is not zero. "
+        "A 'forecast.policy' must be specified when 'forecast.num_steps' is not zero and "
+        "'forecast.offset' is 1. "
     )
     valid_forecast_policies = (
-        "Valid values for 'forecast_policy' are, e.g., 'fixed' when using constant "
-        "forecast steps throughout the training, or 'sequential' when varying the forecast "
-        "steps over mini_epochs, such as, e.g., 'forecast_steps: [2, 2, 4, 4]'. "
+        "Valid values for 'forecast.policy' are, e.g., 'fixed' when using constant number of "
+        "forecast steps throughout the training, or 'sequential' when varying the number of "
+        "forecast steps over mini_epochs, such as, e.g., 'forecast.num_steps: [2, 2, 4, 4]'. "
     )
-    valid_forecast_steps = (
-        "'forecast_steps' must be a positive integer or a non-empty list of positive integers. "
+    valid_forecast_offset = "'forecast.offset' must be an integer of either value 0 or 1. "
+    valid_forecast_steps_offset0 = (
+        "For 'forecast.offset: 0', 'forecast.num_steps' must be an integer of value either 0 or 1. "
     )
-    if isinstance(cf.forecast_steps, int):
-        assert cf.forecast_policy and cf.forecast_steps > 0 if cf.forecast_steps != 0 else True, (
-            provide_forecast_policy + valid_forecast_policies + valid_forecast_steps
-        )
-    elif isinstance(cf.forecast_steps, ListConfig) and len(cf.forecast_steps) > 0:
-        assert (
-            cf.forecast_policy and all(step >= 0 for step in cf.forecast_steps)
-            if any(n > 0 for n in cf.forecast_steps)
-            else True
-        ), provide_forecast_policy + valid_forecast_policies + valid_forecast_steps
+    valid_forecast_steps_offset1 = (
+        "For 'forecast.offset: 0', 'forecast.num_steps' must be an integer greater than 1 or a "
+        "non-empty list and all of its elements must be integers greater than 1."
+    )
+    assert isinstance(forecast_cfg.offset, int), TypeError(valid_forecast_offset)
+    if forecast_cfg.offset == 0:
+        if isinstance(forecast_cfg.num_steps, int):
+            assert forecast_cfg.num_steps in [0, 1], valid_forecast_steps_offset0
+        else:
+            raise TypeError(valid_forecast_steps_offset0)
+    if forecast_cfg.offset == 1:
+        assert forecast_cfg.policy, (provide_forecast_policy, valid_forecast_policies)
+        if isinstance(forecast_cfg.num_steps, int):
+            assert forecast_cfg.num_steps > 0, valid_forecast_steps_offset1
+        elif isinstance(forecast_cfg.num_steps, ListConfig) and len(forecast_cfg.num_steps) > 0:
+            assert all(step > 0 for step in forecast_cfg.num_steps), valid_forecast_steps_offset1
+        else:
+            raise TypeError(valid_forecast_steps_offset1)
     else:
-        raise TypeError(valid_forecast_steps)
+        raise TypeError(valid_forecast_offset)

--- a/src/weathergen/datasets/batch.py
+++ b/src/weathergen/datasets/batch.py
@@ -100,16 +100,6 @@ class Sample:
         assert self.streams_data.get(stream_name, -1) != -1, "stream name does not exist"
         return self.streams_data[stream_name]
 
-    def get_output_len(self) -> int:
-        for _, sdata in self.streams_data.items():
-            output_len = sdata.get_output_len()
-        return output_len
-
-    def get_forecast_idxs(self) -> int:
-        for _, sdata in self.streams_data.items():
-            forecast_idxs = sdata.get_forecast_idxs()
-        return forecast_idxs
-
 
 class BatchSamples:
     """
@@ -118,11 +108,15 @@ class BatchSamples:
 
     samples: list[Sample]
     tokens_lens: torch.Tensor | None
+    output_steps: int
+    output_idxs: list[int]
     device: str | None
 
-    def __init__(self, streams: dict, num_samples: int) -> None:
+    def __init__(self, streams: dict, num_samples: int, output_steps, output_idxs) -> None:
         self.samples = [Sample(streams) for _ in range(num_samples)]
         self.tokens_lens = None
+        self.output_steps = output_steps
+        self.output_idxs = output_idxs
         self.device = None
 
     def __len__(self) -> int:
@@ -166,21 +160,17 @@ class BatchSamples:
 
         return min(lens)
 
-    def get_forecast_idxs(self) -> int:
+    def get_output_idxs(self) -> int:
         """
         Get forecast indices
         """
-        # use sample 0 since forecast indices are identical across batch
-        # TODO: fix use of sample 0
-        return self.samples[0].get_forecast_idxs()
+        return self.output_idxs
 
     def get_output_len(self) -> int:
         """
         Get length of output
         """
-        # use sample 0 since the output length is constant across batch
-        # TODO: fix use of sample 0
-        return self.samples[0].get_output_len()
+        return self.output_steps
 
     def get_device(self) -> str | torch.device:
         """
@@ -219,14 +209,33 @@ class ModelBatch:
     source2target_matching_idxs: np.typing.NDArray[np.int32]
     target2source_matching_idxs: np.typing.NDArray[np.int32]
 
+    # indices of valid outputs
+    output_idxs: list[int]
+
     # device of the tensors in the batch
     device: str | torch.device
 
-    def __init__(self, streams: dict, num_source_samples: int, num_target_samples: int) -> None:
+    def __init__(
+        self,
+        streams: dict,
+        num_source_samples: int,
+        num_target_samples: int,
+        output_offset,
+        output_steps,
+    ) -> None:
         """ """
 
-        self.source_samples = BatchSamples(streams, num_source_samples)
-        self.target_samples = BatchSamples(streams, num_target_samples)
+        # define forecast indices
+        self.output_offset = output_offset
+        self.output_steps = output_steps
+        self.output_idxs = list(range(output_offset, output_steps))
+
+        self.source_samples = BatchSamples(
+            streams, num_source_samples, output_steps, self.output_idxs
+        )
+        self.target_samples = BatchSamples(
+            streams, num_target_samples, output_steps, self.output_idxs
+        )
 
         self.source2target_matching_idxs = np.full(num_source_samples, -1, dtype=np.int32)
         self.target2source_matching_idxs = [[] for _ in range(num_target_samples)]
@@ -359,21 +368,17 @@ class ModelBatch:
         """
         return int(self.source2target_matching_idxs[source_idx])
 
-    def get_forecast_idxs(self) -> int:
+    def get_output_idxs(self) -> int:
         """
-        Get forecast steps
+        Get valid output steps
         """
-        # use sample 0 since the number of forecast steps is constant across batch
-        # TODO: fix use of sample 0
-        return self.source_samples.get_forecast_idxs()
+        return self.output_idxs
 
     def get_output_len(self) -> int:
         """
-        Get lenght of output
+        Get length of output
         """
-        # use sample 0 since the output length is constant across batch
-        # TODO: fix use of sample 0
-        return self.source_samples.get_output_len()
+        return self.output_steps
 
     def get_device(self) -> str | torch.device:
         """

--- a/src/weathergen/datasets/batch.py
+++ b/src/weathergen/datasets/batch.py
@@ -105,10 +105,10 @@ class Sample:
             output_len = sdata.get_output_len()
         return output_len
 
-    def get_forecast_steps(self) -> int:
+    def get_forecast_idxs(self) -> int:
         for _, sdata in self.streams_data.items():
-            forecast_steps = sdata.get_forecast_steps()
-        return forecast_steps
+            forecast_idxs = sdata.get_forecast_idxs()
+        return forecast_idxs
 
 
 class BatchSamples:
@@ -166,13 +166,13 @@ class BatchSamples:
 
         return min(lens)
 
-    def get_forecast_steps(self) -> int:
+    def get_forecast_idxs(self) -> int:
         """
-        Get forecast steps
+        Get forecast indices
         """
-        # use sample 0 since the number of forecast steps is constant across batch
+        # use sample 0 since forecast indices are identical across batch
         # TODO: fix use of sample 0
-        return self.samples[0].get_forecast_steps()
+        return self.samples[0].get_forecast_idxs()
 
     def get_output_len(self) -> int:
         """
@@ -359,13 +359,13 @@ class ModelBatch:
         """
         return int(self.source2target_matching_idxs[source_idx])
 
-    def get_forecast_steps(self) -> int:
+    def get_forecast_idxs(self) -> int:
         """
         Get forecast steps
         """
         # use sample 0 since the number of forecast steps is constant across batch
         # TODO: fix use of sample 0
-        return self.source_samples.get_forecast_steps()
+        return self.source_samples.get_forecast_idxs()
 
     def get_output_len(self) -> int:
         """

--- a/src/weathergen/datasets/batch.py
+++ b/src/weathergen/datasets/batch.py
@@ -100,10 +100,15 @@ class Sample:
         assert self.streams_data.get(stream_name, -1) != -1, "stream name does not exist"
         return self.streams_data[stream_name]
 
+    def get_output_len(self) -> int:
+        for _, sdata in self.streams_data.items():
+            output_len = sdata.get_output_len()
+        return output_len
+
     def get_forecast_steps(self) -> int:
         for _, sdata in self.streams_data.items():
-            forecast_dt = sdata.get_forecast_steps()
-        return forecast_dt
+            forecast_steps = sdata.get_forecast_steps()
+        return forecast_steps
 
 
 class BatchSamples:
@@ -168,6 +173,14 @@ class BatchSamples:
         # use sample 0 since the number of forecast steps is constant across batch
         # TODO: fix use of sample 0
         return self.samples[0].get_forecast_steps()
+
+    def get_output_len(self) -> int:
+        """
+        Get length of output
+        """
+        # use sample 0 since the output length is constant across batch
+        # TODO: fix use of sample 0
+        return self.samples[0].get_output_len()
 
     def get_device(self) -> str | torch.device:
         """
@@ -353,6 +366,14 @@ class ModelBatch:
         # use sample 0 since the number of forecast steps is constant across batch
         # TODO: fix use of sample 0
         return self.source_samples.get_forecast_steps()
+
+    def get_output_len(self) -> int:
+        """
+        Get lenght of output
+        """
+        # use sample 0 since the output length is constant across batch
+        # TODO: fix use of sample 0
+        return self.source_samples.get_output_len()
 
     def get_device(self) -> str | torch.device:
         """

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -98,8 +98,6 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         if is_root():
             logger.info(self.time_window_handler)
 
-        self.forecast_offset = mode_cfg.window_offset_prediction
-
         # Handle forecast_delta_hrs which might be int (hours) or string (timedelta)
         if mode_cfg.get("forecast") is not None:
             f_cfg = mode_cfg.forecast
@@ -111,6 +109,8 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
             self.forecast_steps = np.array(
                 [f_cfg.num_steps] if isinstance(f_cfg.num_steps, int) else f_cfg.num_steps
             )
+
+            self.forecast_offset = f_cfg.offset
 
             self.forecast_policy = f_cfg.policy
 

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -104,7 +104,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
             # forecast step
             self.forecast_delta_dt = f_cfg.time_step
             # assert self.forecast_delta_dt == self.len_timedelta, "Only supported option."
-            self.forecast_steps = np.array(
+            self.list_num_forecast_steps = np.array(
                 [f_cfg.num_steps] if isinstance(f_cfg.num_steps, int) else f_cfg.num_steps
             )
             self.forecast_offset = f_cfg.offset
@@ -113,7 +113,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         else:
             # no forecast policy specified so set neutral default for no forecasting
             self.forecast_delta_dt = np.timedelta64(0, "ms")
-            self.forecast_steps = [0]
+            self.list_num_forecast_steps = [0]
             self.forecast_offset = 0
             self.forecast_policy = None
 
@@ -211,7 +211,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         perms_len = int(index_range.end - index_range.start)
 
         if mode_cfg.get("forecast") is not None:
-            fsm = self.forecast_steps[0]
+            fsm = self.list_num_forecast_steps[0]
             forecast_len = (self.forecast_delta_dt * (fsm + 1)) // self.step_timedelta
             perms_len = perms_len - (forecast_len + self.forecast_offset)
 
@@ -242,7 +242,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
 
         self.rng = None
         self.perms = None
-        self.perms_forecast_dt = None
+        self.perms_num_forecast_steps = None
 
     def advance(self):
         """
@@ -281,12 +281,14 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         self.rng = np.random.default_rng(self.data_loader_rng_seed)
 
         fsm = (
-            self.forecast_steps[min(self.mini_epoch, len(self.forecast_steps) - 1)]
+            self.list_num_forecast_steps[
+                min(self.mini_epoch, len(self.list_num_forecast_steps) - 1)
+            ]
             if self.forecast_policy != "random"
-            else self.forecast_steps.max()
+            else self.list_num_forecast_steps.max()
         )
         if fsm > 0:
-            logger.info(f"forecast_steps at mini_epoch={self.mini_epoch} : {fsm}")
+            logger.info(f"num_forecast_steps at mini_epoch={self.mini_epoch} : {fsm}")
 
         # data
         index_range = self.time_window_handler.get_index_range()
@@ -317,13 +319,16 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         # forecast time steps
         len_dt_samples = len(self) // self.batch_size
         if self.forecast_policy is None:
-            self.perms_forecast_dt = np.zeros(len_dt_samples, dtype=np.int64)
+            self.perms_num_forecast_steps = np.zeros(len_dt_samples, dtype=np.int64)
         elif self.forecast_policy == "fixed" or self.forecast_policy == "sequential":
-            self.perms_forecast_dt = fsm * np.ones(len_dt_samples, dtype=np.int64)
+            self.perms_num_forecast_steps = fsm * np.ones(len_dt_samples, dtype=np.int64)
         elif self.forecast_policy == "random" or self.forecast_policy == "sequential_random":
             # randint high=one-past
-            self.perms_forecast_dt = self.rng.integers(
-                low=self.forecast_steps.min(), high=fsm + 1, size=len_dt_samples, dtype=np.int64
+            self.perms_num_forecast_steps = self.rng.integers(
+                low=self.list_num_forecast_steps.min(),
+                high=fsm + 1,
+                size=len_dt_samples,
+                dtype=np.int64,
             )
         else:
             assert False
@@ -355,7 +360,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         Args:
             stream_data :
             base_idx: Time index for this sample
-            forecast_dt: Number of forecast steps
+            num_forecast_steps: Number of forecast steps
             view_meta: ViewMetadata describing spatial mask
             stream_info: Stream configuration dict
             stream_ds: List of dataset readers for this stream
@@ -398,7 +403,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         stream_data: StreamData,
         idx: TIndex,
         stream_info: dict,
-        forecast_dt: int,
+        num_forecast_steps: int,
         output_data: list,
         output_tokens: list,
         target_mask,
@@ -413,9 +418,9 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         # code.interact(local=locals())
 
         # collect for all forecast steps
-        dt = self._get_output_length(forecast_dt)
-        for step, fstep in enumerate(range(self.forecast_offset, dt)):
-            step_forecast_dt = idx + (self.forecast_delta_dt * fstep) // self.step_timedelta
+        num_timesteps = self._get_output_length(num_forecast_steps)
+        for step, timestep_idx in enumerate(range(self.forecast_offset, num_timesteps)):
+            step_forecast_dt = idx + (self.forecast_delta_dt * timestep_idx) // self.step_timedelta
             time_win_target = self.time_window_handler.window(step_forecast_dt)
 
             # collect all targets for current stream
@@ -432,7 +437,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                     (time_win_target.start, time_win_target.end),
                     target_mask,
                 )
-                stream_data.add_target_coords(fstep, tc, tc_l)
+                stream_data.add_target_coords(timestep_idx, tc, tc_l)
 
             if "target_values" in mode:
                 (tt_cells, tt_t, tt_c, idxs_inv) = self.tokenizer.get_target_values(
@@ -442,7 +447,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                     (time_win_target.start, time_win_target.end),
                     target_mask,
                 )
-                stream_data.add_target_values(fstep, tt_cells, tt_c, tt_t, idxs_inv)
+                stream_data.add_target_values(timestep_idx, tt_cells, tt_c, tt_t, idxs_inv)
 
         return stream_data
 
@@ -450,7 +455,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         self,
         modes: str,
         base_idx: TIndex,
-        forecast_dt: int,
+        num_forecast_steps: int,
         stream_info: dict,
         num_steps_input: int,
         input_data: list,
@@ -468,7 +473,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
             modes :
             stream_data :
             base_idx: Time index for this sample
-            forecast_dt: Number of forecast steps
+            num_forecast_steps: Number of forecast steps
             stream_info: Stream configuration dict
             stream_ds: List of dataset readers for this stream
 
@@ -480,9 +485,14 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
             StreamData with source and targets masked according to view_meta
         """
 
-        dt = self._get_output_length(forecast_dt)
+        num_timesteps = self._get_output_length(num_forecast_steps)
         stream_data = StreamData(
-            base_idx, num_steps_input, dt, forecast_dt, self.forecast_offset, self.num_healpix_cells
+            base_idx,
+            num_steps_input,
+            num_timesteps,
+            num_forecast_steps,
+            self.forecast_offset,
+            self.num_healpix_cells,
         )
 
         stream_data = self._build_stream_data_input(
@@ -501,7 +511,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
             stream_data,
             base_idx,
             stream_info,
-            forecast_dt,
+            num_forecast_steps,
             output_data,
             output_tokens,
             output_mask,
@@ -509,7 +519,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
 
         return stream_data
 
-    def _get_data_windows(self, base_idx, forecast_dt, num_steps_input_max, stream_ds):
+    def _get_data_windows(self, base_idx, num_forecast_steps, num_steps_input_max, stream_ds):
         """
         Collect all data needed for current stream to potentially amortize costs by
         generating multiple samples
@@ -539,8 +549,11 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
 
         # target data: collect for all forecast steps
         output_data = []
-        for fstep in range(self.forecast_offset, self.forecast_offset + forecast_dt + 1):
-            step_forecast_dt = base_idx + (self.forecast_delta_dt * fstep) // self.step_timedelta
+        num_timesteps = self._get_output_length(num_forecast_steps)
+        for timestep_idx in enumerate(range(self.forecast_offset, num_timesteps)):
+            step_forecast_dt = (
+                base_idx + (self.forecast_delta_dt * timestep_idx) // self.step_timedelta
+            )
 
             rdata = collect_datasources(stream_ds, step_forecast_dt, "target")
 
@@ -577,9 +590,9 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
 
         return masks, num_source_samples, num_target_samples
 
-    def _get_output_length(self, forecast_steps):
-        # self.forecast_offset and forecast_dt are zero for pure masking
-        return max(1, self.forecast_offset + forecast_steps)
+    def _get_output_length(self, num_forecast_steps):
+        # self.forecast_offset and num_forecast_steps are zero for pure masking
+        return max(1, self.forecast_offset + num_forecast_steps)
 
     def _preprocess_model_batch(
         self, batch: ModelBatch, source_input_steps: int, target_input_steps: int
@@ -596,7 +609,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
 
         return batch
 
-    def _get_batch(self, idx: int, forecast_dt: int):
+    def _get_batch(self, idx: int, num_forecast_steps: int):
         """
         Assemble a batch using the sample corresponding to idx
         """
@@ -638,7 +651,9 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
             # input_data and output_data is conceptually consecutive but differs
             # in source and target channels; overlap in one window when self.forecast_offset=0
             i_max = input_steps.max().item()
-            (input_data, output_data) = self._get_data_windows(idx, forecast_dt, i_max, stream_ds)
+            (input_data, output_data) = self._get_data_windows(
+                idx, num_forecast_steps, i_max, stream_ds
+            )
 
             # tokenize windows
             # *_tokens = [ (cells_idx, cells_idx_lens), ... ] with length = #time_steps
@@ -651,7 +666,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                 sdata = self._build_stream_data(
                     source_select,
                     idx,
-                    forecast_dt,
+                    num_forecast_steps,
                     stream_info,
                     source_masks.metadata[sidx].params.get("num_steps_input", 1),
                     input_data,
@@ -672,7 +687,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                 sdata = self._build_stream_data(
                     target_select,
                     idx,
-                    forecast_dt,
+                    num_forecast_steps,
                     stream_info,
                     target_masks.metadata[tidx].params.get("num_steps_input", 1),
                     input_data,
@@ -716,8 +731,8 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         # since there are empty batches
         idx_raw = iter_start
         for i, _bidx in enumerate(range(iter_start, iter_end, self.batch_size)):
-            # forecast_dt needs to be constant per batch (amortized through data parallel training)
-            forecast_dt = self.perms_forecast_dt[i]
+            # num_forecast_steps needs to be constant per batch (amortized through data parallel training)
+            num_forecast_steps = self.perms_num_forecast_steps[i]
 
             # use while loop due to the scattered nature of the data in time and to
             # ensure batches are not empty
@@ -725,7 +740,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                 idx: TIndex = self.perms[idx_raw % self.perms.shape[0]]
                 idx_raw += 1
 
-                batch = self._get_batch(idx, forecast_dt)
+                batch = self._get_batch(idx, num_forecast_steps)
 
                 # skip completely empty batch item or when all targets are empty -> no grad
                 if not batch.is_empty():

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -101,23 +101,20 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         # Handle forecast_delta_hrs which might be int (hours) or string (timedelta)
         if mode_cfg.get("forecast") is not None:
             f_cfg = mode_cfg.forecast
-
             # forecast step
             self.forecast_delta_dt = f_cfg.time_step
             # assert self.forecast_delta_dt == self.len_timedelta, "Only supported option."
-
             self.forecast_steps = np.array(
                 [f_cfg.num_steps] if isinstance(f_cfg.num_steps, int) else f_cfg.num_steps
             )
-
             self.forecast_offset = f_cfg.offset
-
             self.forecast_policy = f_cfg.policy
 
         else:
             # no forecast policy specified so set neutral default for no forecasting
             self.forecast_delta_dt = np.timedelta64(0, "ms")
             self.forecast_steps = [0]
+            self.forecast_offset = 0
             self.forecast_policy = None
 
         self.repeat_data = cf.data_loading.get("repeat_data_in_mini_epoch", False)
@@ -211,10 +208,13 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         # adjust len to split loading across all workers and ensure it is multiple of batch_size
         len_chunk = ((self.len // cf.world_size) // self.batch_size) * self.batch_size
         self.len = min(self.len, len_chunk)
+        perms_len = int(index_range.end - index_range.start)
 
-        fsm = self.forecast_steps[0]
-        forecast_len = (self.forecast_delta_dt * (fsm + 1)) // self.step_timedelta
-        perms_len = int(index_range.end - index_range.start) - (forecast_len + self.forecast_offset)
+        if mode_cfg.get("forecast") is not None:
+            fsm = self.forecast_steps[0]
+            forecast_len = (self.forecast_delta_dt * (fsm + 1)) // self.step_timedelta
+            perms_len = perms_len - (forecast_len + self.forecast_offset)
+
         n_duplicates = self.len - perms_len
         if n_duplicates > 0:
             # TODO fix this more permanently (#1085)

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -550,7 +550,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         # target data: collect for all forecast steps
         output_data = []
         num_timesteps = self._get_output_length(num_forecast_steps)
-        for timestep_idx in enumerate(range(self.forecast_offset, num_timesteps)):
+        for timestep_idx in range(self.forecast_offset, num_timesteps):
             step_forecast_dt = (
                 base_idx + (self.forecast_delta_dt * timestep_idx) // self.step_timedelta
             )
@@ -731,7 +731,8 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         # since there are empty batches
         idx_raw = iter_start
         for i, _bidx in enumerate(range(iter_start, iter_end, self.batch_size)):
-            # num_forecast_steps needs to be constant per batch (amortized through data parallel training)
+            # num_forecast_steps needs to be constant per batch
+            # (amortized through data parallel training)
             num_forecast_steps = self.perms_num_forecast_steps[i]
 
             # use while loop due to the scattered nature of the data in time and to

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -98,24 +98,34 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         if is_root():
             logger.info(self.time_window_handler)
 
+        index_range = self.time_window_handler.get_index_range()
+        perms_len = int(index_range.end - index_range.start)
+
         # Handle forecast_delta_hrs which might be int (hours) or string (timedelta)
-        if mode_cfg.get("forecast") is not None:
-            f_cfg = mode_cfg.forecast
+        self.forecast_cfg = mode_cfg.get("forecast", {})
+        if len(self.forecast_cfg) > 0:
+            self.output_offset = self.forecast_cfg.get("offset", 0)
+            self.time_step = self.forecast_cfg.get("time_step", np.timedelta64(0, "ms"))
+            self.forecast_policy = self.forecast_cfg.get("policy", None)
+
             # forecast step
-            self.forecast_delta_dt = f_cfg.time_step
-            # assert self.forecast_delta_dt == self.len_timedelta, "Only supported option."
             self.list_num_forecast_steps = np.array(
-                [f_cfg.num_steps] if isinstance(f_cfg.num_steps, int) else f_cfg.num_steps
+                [self.forecast_cfg.get("num_steps", 0)]
+                if isinstance(self.forecast_cfg.num_steps, int)
+                else self.forecast_cfg.num_steps,
+                dtype=np.int32,
             )
-            self.forecast_offset = f_cfg.offset
-            self.forecast_policy = f_cfg.policy
 
         else:
             # no forecast policy specified so set neutral default for no forecasting
-            self.forecast_delta_dt = np.timedelta64(0, "ms")
-            self.list_num_forecast_steps = [0]
-            self.forecast_offset = 0
+            self.list_num_forecast_steps = np.array([0], dtype=np.int32)
+            self.output_offset = 0
             self.forecast_policy = None
+            self.time_step = np.timedelta64(0, "ms")
+
+        fsm = self.list_num_forecast_steps[0]
+        forecast_len = (self.time_step * (fsm + 1)) // self.step_timedelta
+        perms_len = perms_len - (forecast_len + self.output_offset)
 
         self.repeat_data = cf.data_loading.get("repeat_data_in_mini_epoch", False)
 
@@ -185,10 +195,8 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
 
                 self.streams_datasets[stream_info["name"]] += [ds]
 
-        index_range = self.time_window_handler.get_index_range()
+        # length of dataset; check the repeat data flag and adjust len accordingly
         self.len = int(index_range.end - index_range.start)
-
-        # check the repeat data flag and adjust len accordingly
         if not self.repeat_data:
             if self.samples_per_mini_epoch:
                 if self.samples_per_mini_epoch <= self.len:
@@ -208,12 +216,6 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         # adjust len to split loading across all workers and ensure it is multiple of batch_size
         len_chunk = ((self.len // cf.world_size) // self.batch_size) * self.batch_size
         self.len = min(self.len, len_chunk)
-        perms_len = int(index_range.end - index_range.start)
-
-        if mode_cfg.get("forecast") is not None:
-            fsm = self.list_num_forecast_steps[0]
-            forecast_len = (self.forecast_delta_dt * (fsm + 1)) // self.step_timedelta
-            perms_len = perms_len - (forecast_len + self.forecast_offset)
 
         n_duplicates = self.len - perms_len
         if n_duplicates > 0:
@@ -291,15 +293,16 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
             logger.info(f"num_forecast_steps at mini_epoch={self.mini_epoch} : {fsm}")
 
         # data
+        forecast_offset = self.output_offset
         index_range = self.time_window_handler.get_index_range()
         idx_end = index_range.end
         # native length of datasets, independent of mini_epoch length that has potentially been
         # specified
-        forecast_len = (self.forecast_delta_dt * (fsm + 1)) // self.step_timedelta
-        adjusted_idx_end = idx_end - (forecast_len + self.forecast_offset)
+        forecast_len = (self.time_step * (fsm + 1)) // self.step_timedelta
+        adjusted_idx_end = idx_end - (forecast_len + forecast_offset)
         msg = (
             f"dataset size ({idx_end}) too small for forecast length plus offset "
-            f"({forecast_len + self.forecast_offset}) – dataset size must be strictly bigger. "
+            f"({forecast_len + forecast_offset}) – dataset size must be strictly bigger. "
             "to fix this, it usually suffices to increase the data range "
         )
         assert adjusted_idx_end > 0, msg
@@ -413,14 +416,10 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
 
         """
 
-        # import code
-
-        # code.interact(local=locals())
-
         # collect for all forecast steps
-        num_timesteps = self._get_output_length(num_forecast_steps)
-        for step, timestep_idx in enumerate(range(self.forecast_offset, num_timesteps)):
-            step_forecast_dt = idx + (self.forecast_delta_dt * timestep_idx) // self.step_timedelta
+        num_output_steps = self._get_output_length(num_forecast_steps)
+        for step, timestep_idx in enumerate(range(self.output_offset, num_output_steps)):
+            step_forecast_dt = idx + (self.time_step * timestep_idx) // self.step_timedelta
             time_win_target = self.time_window_handler.window(step_forecast_dt)
 
             # collect all targets for current stream
@@ -485,13 +484,11 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
             StreamData with source and targets masked according to view_meta
         """
 
-        num_timesteps = self._get_output_length(num_forecast_steps)
+        num_output_steps = self._get_output_length(num_forecast_steps)
         stream_data = StreamData(
             base_idx,
             num_steps_input,
-            num_timesteps,
-            num_forecast_steps,
-            self.forecast_offset,
+            num_output_steps,
             self.num_healpix_cells,
         )
 
@@ -549,18 +546,16 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
 
         # target data: collect for all forecast steps
         output_data = []
-        num_timesteps = self._get_output_length(num_forecast_steps)
-        for timestep_idx in range(self.forecast_offset, num_timesteps):
-            step_forecast_dt = (
-                base_idx + (self.forecast_delta_dt * timestep_idx) // self.step_timedelta
-            )
+        num_output_steps = self._get_output_length(num_forecast_steps)
+        for timestep_idx in range(self.output_offset, num_output_steps):
+            step_forecast_dt = base_idx + (self.time_step * timestep_idx) // self.step_timedelta
 
             rdata = collect_datasources(stream_ds, step_forecast_dt, "target")
 
             if rdata.is_empty():
                 # work around for https://github.com/pytorch/pytorch/issues/158719
                 # create non-empty mean data instead of empty tensor
-                time_win = self.time_window_handler.window(idx)
+                time_win = self.time_window_handler.window(timestep_idx)
                 rdata = spoof(
                     self.healpix_level,
                     time_win.start,
@@ -591,8 +586,8 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         return masks, num_source_samples, num_target_samples
 
     def _get_output_length(self, num_forecast_steps):
-        # self.forecast_offset and num_forecast_steps are zero for pure masking
-        return max(1, self.forecast_offset + num_forecast_steps)
+        # max(1, ...) : self.output_offset and num_forecast_steps are zero for pure masking
+        return max(1, self.output_offset + num_forecast_steps)
 
     def _preprocess_model_batch(
         self, batch: ModelBatch, source_input_steps: int, target_input_steps: int
@@ -633,7 +628,14 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         if len(source_select) == 0 or len(target_select) == 0:
             raise NotImplementedError(f"Unsupported training mode {mode}.")
 
-        batch = ModelBatch(self.streams, num_source_samples, num_target_samples)
+        num_output_steps = self._get_output_length(num_forecast_steps)
+        batch = ModelBatch(
+            self.streams,
+            num_source_samples,
+            num_target_samples,
+            self.output_offset,
+            num_output_steps,
+        )
 
         # for all streams
         for stream_info, (stream_name, stream_ds) in zip(
@@ -649,7 +651,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
             assert input_steps.min(), "Number of input steps has to be greater than zero."
 
             # input_data and output_data is conceptually consecutive but differs
-            # in source and target channels; overlap in one window when self.forecast_offset=0
+            # in source and target channels; overlap in one window when self.output_offset=0
             i_max = input_steps.max().item()
             (input_data, output_data) = self._get_data_windows(
                 idx, num_forecast_steps, i_max, stream_ds
@@ -665,7 +667,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                 tidx = source_to_target[sidx].item()
                 sdata = self._build_stream_data(
                     source_select,
-                    idx,
+                    tidx,
                     num_forecast_steps,
                     stream_info,
                     source_masks.metadata[sidx].params.get("num_steps_input", 1),
@@ -686,7 +688,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                 # Hence the target mask is also the source mask here!!
                 sdata = self._build_stream_data(
                     target_select,
-                    idx,
+                    tidx,
                     num_forecast_steps,
                     stream_info,
                     target_masks.metadata[tidx].params.get("num_steps_input", 1),

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -408,9 +408,13 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
 
         """
 
+        # import code
+
+        # code.interact(local=locals())
+
         # collect for all forecast steps
-        dt = self.forecast_offset + forecast_dt
-        for step, fstep in enumerate(range(self.forecast_offset, dt + 1)):
+        dt = self._get_output_length(forecast_dt)
+        for step, fstep in enumerate(range(self.forecast_offset, dt)):
             step_forecast_dt = idx + (self.forecast_delta_dt * fstep) // self.step_timedelta
             time_win_target = self.time_window_handler.window(step_forecast_dt)
 
@@ -476,9 +480,10 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
             StreamData with source and targets masked according to view_meta
         """
 
-        # self.forecast_offset and forecast_dt are zero for pure masking
-        dt = max(1, self.forecast_offset + forecast_dt)
-        stream_data = StreamData(base_idx, num_steps_input, dt, self.num_healpix_cells)
+        dt = self._get_output_length(forecast_dt)
+        stream_data = StreamData(
+            base_idx, num_steps_input, dt, forecast_dt, self.forecast_offset, self.num_healpix_cells
+        )
 
         stream_data = self._build_stream_data_input(
             modes,
@@ -571,6 +576,10 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
             num_source_samples = len(masks[stream_info["name"]][1])
 
         return masks, num_source_samples, num_target_samples
+
+    def _get_output_length(self, forecast_steps):
+        # self.forecast_offset and forecast_dt are zero for pure masking
+        return max(1, self.forecast_offset + forecast_steps)
 
     def _preprocess_model_batch(
         self, batch: ModelBatch, source_input_steps: int, target_input_steps: int

--- a/src/weathergen/datasets/stream_data.py
+++ b/src/weathergen/datasets/stream_data.py
@@ -56,8 +56,6 @@ class StreamData:
         idx: int,
         input_steps: int,
         output_steps: int,
-        num_forecast_steps,
-        forecast_offset,
         healpix_cells: int,
     ) -> None:
         """
@@ -72,10 +70,6 @@ class StreamData:
         output_steps : int
             Number of output steps
             Note -- Last input step and first output step always overlap.
-        num_forecast_steps : int
-            Number of forecast steps.
-        forecast_offset : int
-            Either 0 or 1. If 1, first output entry is empty.
         healpix_cells : int
             Number of healpix cells for source
 
@@ -92,11 +86,6 @@ class StreamData:
 
         self.source_is_spoof = False
         self.target_is_spoof = False
-
-        # define forecast indices
-        self.forecast_idxs = [
-            fs for fs in range(forecast_offset, forecast_offset + num_forecast_steps)
-        ]
 
         # initialize empty members
         self.sample_idx = idx
@@ -386,18 +375,6 @@ class StreamData:
         Either source or target is spoof
         """
         return self.source_is_spoof or self.target_is_spoof
-
-    def get_forecast_idxs(self) -> int:
-        """
-        Get forecast indices
-        """
-        return self.forecast_idxs
-
-    def get_output_len(self) -> int:
-        """
-        Get length of output
-        """
-        return self.output_steps
 
 
 def spoof(healpix_level: int, datetime, geoinfo_size, mean_of_data) -> IOReaderData:

--- a/src/weathergen/datasets/stream_data.py
+++ b/src/weathergen/datasets/stream_data.py
@@ -56,7 +56,7 @@ class StreamData:
         idx: int,
         input_steps: int,
         output_steps: int,
-        forecast_steps,
+        num_forecast_steps,
         forecast_offset,
         healpix_cells: int,
     ) -> None:
@@ -72,7 +72,7 @@ class StreamData:
         output_steps : int
             Number of output steps
             Note -- Last input step and first output step always overlap.
-        forecast_steps : int
+        num_forecast_steps : int
             Number of forecast steps.
         forecast_offset : int
             Either 0 or 1. If 1, first output entry is empty.
@@ -94,7 +94,9 @@ class StreamData:
         self.target_is_spoof = False
 
         # define forecast indices
-        self.forecast_idxs = [fs for fs in range(forecast_offset, forecast_offset + forecast_steps)]
+        self.forecast_idxs = [
+            fs for fs in range(forecast_offset, forecast_offset + num_forecast_steps)
+        ]
 
         # initialize empty members
         self.sample_idx = idx
@@ -385,9 +387,9 @@ class StreamData:
         """
         return self.source_is_spoof or self.target_is_spoof
 
-    def get_forecast_steps(self) -> int:
+    def get_forecast_idxs(self) -> int:
         """
-        Get number of forecast steps
+        Get forecast indices
         """
         return self.forecast_idxs
 

--- a/src/weathergen/datasets/stream_data.py
+++ b/src/weathergen/datasets/stream_data.py
@@ -51,14 +51,31 @@ class StreamData:
     for one stream.
     """
 
-    def __init__(self, idx: int, input_steps: int, forecast_steps: int, healpix_cells: int) -> None:
+    def __init__(
+        self,
+        idx: int,
+        input_steps: int,
+        output_steps: int,
+        forecast_steps,
+        forecast_offset,
+        healpix_cells: int,
+    ) -> None:
         """
         StreamData object
 
         Parameters
         ----------
+        idx: int
+            Time index for this sample
+        input_steps : int
+            Number of input steps
+        output_steps : int
+            Number of output steps
+            Note -- Last input step and first output step always overlap.
         forecast_steps : int
-            Number of forecast steps
+            Number of forecast steps.
+        forecast_offset : int
+            Either 0 or 1. If 1, first output entry is empty.
         healpix_cells : int
             Number of healpix cells for source
 
@@ -70,28 +87,29 @@ class StreamData:
         self.mask_value = 0.0
 
         self.input_steps = input_steps
-        self.forecast_steps = forecast_steps
+        self.output_steps = output_steps
         self.healpix_cells = healpix_cells
 
         self.source_is_spoof = False
         self.target_is_spoof = False
 
+        # define forecast indices
+        self.forecast_idxs = [fs for fs in range(forecast_offset, forecast_offset + forecast_steps)]
+
         # initialize empty members
         self.sample_idx = idx
-        self.target_coords = [torch.tensor([]) for _ in range(forecast_steps + 1)]
-        self.target_coords_raw = [[] for _ in range(forecast_steps + 1)]
-        self.target_times_raw = [
-            np.array([], dtype="datetime64[ns]") for _ in range(forecast_steps + 1)
-        ]
+        self.target_coords = [torch.tensor([]) for _ in range(output_steps)]
+        self.target_coords_raw = [[] for _ in range(output_steps)]
+        self.target_times_raw = [np.array([], dtype="datetime64[ns]") for _ in range(output_steps)]
         # this is not directly used but to precompute index in compute_idxs_predict()
         self.target_coords_lens = [
-            torch.tensor([0 for _ in range(self.healpix_cells)]) for _ in range(forecast_steps + 1)
+            torch.tensor([0 for _ in range(self.healpix_cells)]) for _ in range(output_steps)
         ]
-        self.target_tokens = [torch.tensor([]) for _ in range(forecast_steps + 1)]
+        self.target_tokens = [torch.tensor([]) for _ in range(output_steps)]
         self.target_tokens_lens = [
-            torch.tensor([0 for _ in range(self.healpix_cells)]) for _ in range(forecast_steps + 1)
+            torch.tensor([0 for _ in range(self.healpix_cells)]) for _ in range(output_steps)
         ]
-        self.idxs_inv = [torch.tensor([], dtype=torch.int64) for _ in range(forecast_steps + 1)]
+        self.idxs_inv = [torch.tensor([], dtype=torch.int64) for _ in range(output_steps)]
 
         # source tokens per cell
         self.source_tokens_cells = [None for _ in range(self.input_steps)]
@@ -371,7 +389,13 @@ class StreamData:
         """
         Get number of forecast steps
         """
-        return self.forecast_steps
+        return self.forecast_idxs
+
+    def get_output_len(self) -> int:
+        """
+        Get length of output
+        """
+        return self.output_steps
 
 
 def spoof(healpix_level: int, datetime, geoinfo_size, mean_of_data) -> IOReaderData:

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -465,6 +465,12 @@ class ForecastingEngine(torch.nn.Module):
             block.apply(init_weights_final)
 
     def forward(self, tokens, fstep):
+        if self.training:
+            # Impute noise to the latent state
+            noise_std = self.cf.get("fe_impute_latent_noise_std", 0.0)
+            if noise_std > 0.0:
+                tokens = tokens + torch.randn_like(tokens) * torch.norm(tokens) * noise_std
+
         aux_info = None
         for _b_idx, block in enumerate(self.fe_blocks):
             if isinstance(block, torch.nn.modules.normalization.LayerNorm):

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -575,7 +575,7 @@ class Model(torch.nn.Module):
         # collapse along input step dimension
         tokens = tokens.reshape(shape).sum(axis=1)
 
-        if batch.get_forecast_steps() > 1:
+        if batch.get_forecast_steps() > 0:
             # roll-out in latent space
             for fstep in range(forecast_offset, forecast_offset + batch.get_forecast_steps()):
                 if self.training:

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -611,6 +611,7 @@ class Model(torch.nn.Module):
         # safe latent prediction
         tokens_post_norm = self.latent_pre_norm(tokens) if step == 0 else None
         latent_state = self.tokens_to_latent_state(tokens_post_norm, tokens)
+        output.add_latent_prediction(step, "latent_state", latent_state)
 
         # latent predictions for SSL training
         for name, head in self.latent_heads.items():

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -566,7 +566,7 @@ class Model(torch.nn.Module):
             A list containing all prediction results
         """
 
-        output = ModelOutput(batch.get_forecast_steps() + 1)
+        output = ModelOutput(max(1, batch.get_forecast_steps() + forecast_offset))
 
         tokens, posteriors = self.encoder(model_params, batch)
 
@@ -574,7 +574,7 @@ class Model(torch.nn.Module):
         shape = (len(batch), batch.get_num_steps(), *tokens.shape[1:])
         # collapse along input step dimension
         tokens = tokens.reshape(shape).sum(axis=1)
-
+        breakpoint()
         if batch.get_forecast_steps() > 0:
             # roll-out in latent space
             for fstep in range(forecast_offset, forecast_offset + batch.get_forecast_steps()):
@@ -588,7 +588,7 @@ class Model(torch.nn.Module):
                 output = self.predict(model_params, fstep, tokens, batch, output)
                 # safe latent prediction
                 latent_state = self.get_latent_state(tokens, None)
-                output.add_latent_prediction(fstep, "latent_state", latent_state) 
+                output.add_latent_prediction(fstep, "latent_state", latent_state)
         else:
             # latents for output
             z = self.latent_pre_norm(tokens)
@@ -599,7 +599,6 @@ class Model(torch.nn.Module):
                 output.add_latent_prediction(0, name, head(latent_state))
             # prediction for final step
             output = self.predict(model_params, batch.get_forecast_steps(), tokens, batch, output)
-
 
         return output
 

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -600,8 +600,6 @@ class Model(torch.nn.Module):
             # prediction for final step
             output = self.predict(model_params, batch.get_forecast_steps(), tokens, batch, output)
 
-        return output
-
     def forecast(self, model_params: ModelParams, tokens: torch.Tensor, fstep: int) -> torch.Tensor:
         """Advances latent space representation in time
 

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -554,7 +554,7 @@ class Model(torch.nn.Module):
         )
 
     def forward(
-        self, model_params: ModelParams, batch: ModelBatch, forecast_offset: int
+        self, model_params: ModelParams, batch: ModelBatch
     ) -> ModelOutput:
         """Forward pass of the model
 
@@ -566,7 +566,7 @@ class Model(torch.nn.Module):
             A list containing all prediction results
         """
 
-        output = ModelOutput(max(1, batch.get_forecast_steps() + forecast_offset))
+        output = ModelOutput(batch.get_output_len())
 
         tokens, posteriors = self.encoder(model_params, batch)
 
@@ -575,9 +575,9 @@ class Model(torch.nn.Module):
         # collapse along input step dimension
         tokens = tokens.reshape(shape).sum(axis=1)
 
-        if batch.get_forecast_steps() > 0:
+        if len(batch.get_forecast_steps()) > 0:
             # roll-out in latent space
-            for fstep in range(forecast_offset, forecast_offset + batch.get_forecast_steps()):
+            for fstep in batch.get_forecast_steps():
                 if self.training:
                     # Impute noise to the latent state
                     noise_std = self.cf.get("fe_impute_latent_noise_std", 0.0)
@@ -598,7 +598,7 @@ class Model(torch.nn.Module):
             for name, head in self.latent_heads.items():
                 output.add_latent_prediction(0, name, head(latent_state))
             # prediction for final step
-            output = self.predict(model_params, batch.get_forecast_steps(), tokens, batch, output)
+            output = self.predict(model_params, 0, tokens, batch, output)
 
         return output
 

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -574,7 +574,7 @@ class Model(torch.nn.Module):
         shape = (len(batch), batch.get_num_steps(), *tokens.shape[1:])
         # collapse along input step dimension
         tokens = tokens.reshape(shape).sum(axis=1)
-        breakpoint()
+
         if batch.get_forecast_steps() > 0:
             # roll-out in latent space
             for fstep in range(forecast_offset, forecast_offset + batch.get_forecast_steps()):
@@ -599,6 +599,8 @@ class Model(torch.nn.Module):
                 output.add_latent_prediction(0, name, head(latent_state))
             # prediction for final step
             output = self.predict(model_params, batch.get_forecast_steps(), tokens, batch, output)
+
+        return output
 
     def forecast(self, model_params: ModelParams, tokens: torch.Tensor, fstep: int) -> torch.Tensor:
         """Advances latent space representation in time

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -545,6 +545,14 @@ class Model(torch.nn.Module):
         ]
         print("-----------------")
 
+    def get_latent_state(self, z, tokens):
+        return LatentState(
+            register_tokens=z[:, : self.register_token_idx],
+            class_token=z[:, self.register_token_idx : self.class_token_idx],
+            patch_tokens=z[:, self.class_token_idx :],
+            z_pre_norm=tokens,
+        )
+
     def forward(
         self, model_params: ModelParams, batch: ModelBatch, forecast_offset: int
     ) -> ModelOutput:
@@ -567,43 +575,31 @@ class Model(torch.nn.Module):
         # collapse along input step dimension
         tokens = tokens.reshape(shape).sum(axis=1)
 
-        # latents for output
-        z = self.latent_pre_norm(tokens)
-        latent_state = LatentState(
-            register_tokens=z[:, : self.register_token_idx],
-            class_token=z[:, self.register_token_idx : self.class_token_idx],
-            patch_tokens=z[:, self.class_token_idx :],
-            z_pre_norm=tokens,
-        )
-        output.add_latent_prediction(0, "posteriors", posteriors)
-        output.add_latent_prediction(0, "latent_state", latent_state)
-        for name, head in self.latent_heads.items():
-            output.add_latent_prediction(0, name, head(latent_state))
+        if batch.get_forecast_steps() > 1:
+            # roll-out in latent space
+            for fstep in range(forecast_offset, forecast_offset + batch.get_forecast_steps()):
+                if self.training:
+                    # Impute noise to the latent state
+                    noise_std = self.cf.get("fe_impute_latent_noise_std", 0.0)
+                    if noise_std > 0.0:
+                        tokens = tokens + torch.randn_like(tokens) * torch.norm(tokens) * noise_std
+                tokens = self.forecast(model_params, tokens, fstep)
+                # prediction
+                output = self.predict(model_params, fstep, tokens, batch, output)
+                # safe latent prediction
+                latent_state = self.get_latent_state(tokens, None)
+                output.add_latent_prediction(fstep, "latent_state", latent_state) 
+        else:
+            # latents for output
+            z = self.latent_pre_norm(tokens)
+            latent_state = self.get_latent_state(z, tokens)
+            output.add_latent_prediction(0, "posteriors", posteriors)
+            output.add_latent_prediction(0, "latent_state", latent_state)
+            for name, head in self.latent_heads.items():
+                output.add_latent_prediction(0, name, head(latent_state))
+            # prediction for final step
+            output = self.predict(model_params, batch.get_forecast_steps(), tokens, batch, output)
 
-        # roll-out in latent space
-        for fstep in range(forecast_offset, batch.get_forecast_steps()):
-            # prediction
-            output = self.predict(model_params, fstep, tokens, batch, output)
-
-            if self.training:
-                # Impute noise to the latent state
-                noise_std = self.cf.get("fe_impute_latent_noise_std", 0.0)
-                if noise_std > 0.0:
-                    tokens = tokens + torch.randn_like(tokens) * torch.norm(tokens) * noise_std
-
-            tokens = self.forecast(model_params, tokens, fstep)
-
-            # safe latent prediction
-            latent_state = LatentState(
-                register_tokens=tokens[:, : self.register_token_idx],
-                class_token=tokens[:, self.register_token_idx : self.class_token_idx],
-                patch_tokens=tokens[:, self.class_token_idx :],
-                z_pre_norm=None,
-            )
-            output.add_latent_prediction(fstep, "latent_state", latent_state)
-
-        # prediction for final step
-        output = self.predict(model_params, batch.get_forecast_steps(), tokens, batch, output)
 
         return output
 

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -279,8 +279,13 @@ class Model(torch.nn.Module):
         self.num_register_tokens = cf.num_register_tokens
         self.latent_heads = None
         self.latent_pre_norm = None
-        self.class_token_idx = cf.num_class_tokens + cf.num_register_tokens
-        self.register_token_idx = cf.num_register_tokens
+        # auxiliary tokens
+        self.class_token_idxs = list(
+            range(cf.num_register_tokens, cf.num_register_tokens + cf.num_class_tokens)
+        )
+        self.register_token_idxs = list(range(cf.num_register_tokens))
+        self.aux_tokens_idxs = list(range(cf.num_register_tokens + cf.num_class_tokens))
+        self.num_aux_tokens = cf.num_register_tokens + cf.num_class_tokens
 
     def create(self) -> "Model":
         """Create each individual module of the model"""
@@ -291,7 +296,9 @@ class Model(torch.nn.Module):
         )
 
         mode_cfg = cf.training_config
-        self.forecast_engine = ForecastingEngine(cf, mode_cfg, self.num_healpix_cells)
+        self.forecast_engine = None
+        if cf.fe_num_blocks > 0:
+            self.forecast_engine = ForecastingEngine(cf, mode_cfg, self.num_healpix_cells)
 
         # embed coordinates yielding one query token for each target token
         dropout_rate = cf.embed_dropout_rate
@@ -440,8 +447,6 @@ class Model(torch.nn.Module):
             # TODO implement later
             # shared_heads = cf.get("shared_heads", False)
             self.latent_pre_norm = nn.LayerNorm(cf.ae_global_dim_embed)
-            self.class_token_idx = cf.num_class_tokens + cf.num_register_tokens
-            self.register_token_idx = cf.num_register_tokens
             for loss, loss_conf in ssl_target_losses.loss_fcts.items():
                 if loss == "iBOT":
                     self.latent_heads[loss] = LatentPredictionHead(
@@ -545,11 +550,15 @@ class Model(torch.nn.Module):
         ]
         print("-----------------")
 
-    def get_latent_state(self, z, tokens):
+    def tokens_to_latent_state(self, tokens_post_norm, tokens) -> LatentState:
+        """
+        Extract separate parts from global latent space representation and store in LatentState
+        """
+        toks_pn = tokens_post_norm
         return LatentState(
-            register_tokens=z[:, : self.register_token_idx],
-            class_token=z[:, self.register_token_idx : self.class_token_idx],
-            patch_tokens=z[:, self.class_token_idx :],
+            register_tokens=toks_pn[:, self.register_token_idxs] if toks_pn is not None else None,
+            class_token=toks_pn[:, self.class_token_idxs] if tokens_post_norm is not None else None,
+            patch_tokens=toks_pn[:, self.num_aux_tokens :] if toks_pn is not None else None,
             z_pre_norm=tokens,
         )
 
@@ -567,65 +576,60 @@ class Model(torch.nn.Module):
         output = ModelOutput(batch.get_output_len())
 
         tokens, posteriors = self.encoder(model_params, batch)
+        output.add_latent_prediction(0, "posteriors", posteriors)
 
         # recover batch dimension and separate input_steps
         shape = (len(batch), batch.get_num_steps(), *tokens.shape[1:])
         # collapse along input step dimension
         tokens = tokens.reshape(shape).sum(axis=1)
 
-        if len(batch.get_forecast_idxs()) > 0:
-            # roll-out in latent space
-            for fstep in batch.get_forecast_idxs():
-                if self.training:
-                    # Impute noise to the latent state
-                    noise_std = self.cf.get("fe_impute_latent_noise_std", 0.0)
-                    if noise_std > 0.0:
-                        tokens = tokens + torch.randn_like(tokens) * torch.norm(tokens) * noise_std
-                tokens = self.forecast(model_params, tokens, fstep)
-                # prediction
-                output = self.predict(model_params, fstep, tokens, batch, output)
-                # safe latent prediction
-                latent_state = self.get_latent_state(tokens, None)
-                output.add_latent_prediction(fstep, "latent_state", latent_state)
-        else:
-            # latents for output
-            z = self.latent_pre_norm(tokens)
-            latent_state = self.get_latent_state(z, tokens)
-            output.add_latent_prediction(0, "posteriors", posteriors)
-            output.add_latent_prediction(0, "latent_state", latent_state)
-            for name, head in self.latent_heads.items():
-                output.add_latent_prediction(0, name, head(latent_state))
-            # prediction for final step
-            output = self.predict(model_params, 0, tokens, batch, output)
+        # roll-out in latent space, iterate and generate output over requested output steps
+        for step in batch.get_output_idxs():
+            # apply forecasting engine (if present)
+            if self.forecast_engine:
+                tokens = self.forecast_engine(tokens, step)
+
+            # decoder predictions
+            output = self.predict_decoders(model_params, step, tokens, batch, output)
+            # latent predictions (raw and with SSL heads)
+            output = self.predict_latent(model_params, step, tokens, batch, output)
 
         return output
 
-    def forecast(self, model_params: ModelParams, tokens: torch.Tensor, fstep: int) -> torch.Tensor:
-        """Advances latent space representation in time
-
-        Args:
-            model_params : Query and embedding parameters (never used)
-            tokens : Input tokens to be processed by the model.
-            fstep: Current forecast step index (can be used as aux info).
-        Returns:
-            Processed tokens
-        Raises:
-            ValueError: For unexpected arguments in checkpoint method
-        """
-
-        tokens = self.forecast_engine(tokens, fstep)
-
-        return tokens
-
-    def predict(
+    def predict_latent(
         self,
         model_params: ModelParams,
-        fstep: int,
+        step: int,
         tokens: torch.Tensor,
         batch: ModelBatch,
         output: ModelOutput,
-    ) -> list[torch.Tensor]:
-        """Predict outputs at the specific target coordinates based on the input weather state and
+    ) -> ModelOutput:
+        """
+        Compute latent predictions
+        """
+
+        # safe latent prediction
+        tokens_post_norm = self.latent_pre_norm(tokens) if step == 0 else None
+        latent_state = self.tokens_to_latent_state(tokens_post_norm, tokens)
+
+        # latent predictions for SSL training
+        for name, head in self.latent_heads.items():
+            output.add_latent_prediction(step, name, head(latent_state))
+
+        return output
+
+    def predict_decoders(
+        self,
+        model_params: ModelParams,
+        step: int,
+        tokens: torch.Tensor,
+        batch: ModelBatch,
+        output: ModelOutput,
+    ) -> ModelOutput:
+        """
+        Compute decoder-based predictions
+
+        Predict outputs at the specific target coordinates based on the input weather state and
         pre-training task and projects the latent space representation back to physical space.
 
         Args:
@@ -643,7 +647,7 @@ class Model(torch.nn.Module):
             return output
 
         # remove register  and class tokens
-        tokens = tokens[:, self.class_token_idx :]
+        tokens = tokens[:, self.num_aux_tokens :]
 
         # get 1-ring neighborhood for prediction
         batch_size = len(batch)
@@ -660,7 +664,7 @@ class Model(torch.nn.Module):
         for stream_name in self.stream_names:
             # extract target coords for current stream and fstep and convert to one tensor
             t_coords = [
-                batch.samples[i_b].streams_data[stream_name].target_coords[fstep]
+                batch.samples[i_b].streams_data[stream_name].target_coords[step]
                 for i_b in range(batch_size)
             ]
             t_coords_lens = [len(t) for t in t_coords]
@@ -691,7 +695,7 @@ class Model(torch.nn.Module):
                 # lens for varlen attention
                 tcls = torch.cat(
                     [
-                        sample.streams_data[stream_name].target_coords_lens[fstep]
+                        sample.streams_data[stream_name].target_coords_lens[step]
                         for sample in batch.samples
                     ]
                 )
@@ -719,6 +723,6 @@ class Model(torch.nn.Module):
 
             # recover batch dimension (ragged, so as list)
             pred = torch.split(pred, t_coords_lens, dim=1)
-            output.add_physical_prediction(fstep, stream_name, pred)
+            output.add_physical_prediction(step, stream_name, pred)
 
         return output

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -50,9 +50,9 @@ class ModelOutput:
     physical: list[dict[StreamName, torch.Tensor]]
     latent: list[dict[str, torch.Tensor | LatentState]]
 
-    def __init__(self, forecast_steps: int) -> None:
-        self.physical = [{} for _ in range(forecast_steps)]
-        self.latent = [{} for _ in range(forecast_steps)]
+    def __init__(self, len_output: int) -> None:
+        self.physical = [{} for _ in range(len_output)]
+        self.latent = [{} for _ in range(len_output)]
 
     def add_physical_prediction(
         self, fstep: int, stream_name: StreamName, pred: torch.Tensor
@@ -553,9 +553,7 @@ class Model(torch.nn.Module):
             z_pre_norm=tokens,
         )
 
-    def forward(
-        self, model_params: ModelParams, batch: ModelBatch
-    ) -> ModelOutput:
+    def forward(self, model_params: ModelParams, batch: ModelBatch) -> ModelOutput:
         """Forward pass of the model
 
         Tokens are processed through the model components, which were defined in the create method.
@@ -575,9 +573,9 @@ class Model(torch.nn.Module):
         # collapse along input step dimension
         tokens = tokens.reshape(shape).sum(axis=1)
 
-        if len(batch.get_forecast_steps()) > 0:
+        if len(batch.get_forecast_idxs()) > 0:
             # roll-out in latent space
-            for fstep in batch.get_forecast_steps():
+            for fstep in batch.get_forecast_idxs():
                 if self.training:
                     # Impute noise to the latent state
                     noise_std = self.cf.get("fe_impute_latent_noise_std", 0.0)

--- a/src/weathergen/model/model_interface.py
+++ b/src/weathergen/model/model_interface.py
@@ -62,7 +62,7 @@ def init_model_and_shard(
         if re.fullmatch(cf.freeze_modules, name) is not None:
             logger.info(f"Froze weights {name}")
             freeze_weights(module)
-        
+
     # TODO: this should be handled in the encoder to be close where q_cells is defined
     if "q_cells" in cf.freeze_modules:
         model.encoder.q_cells.requires_grad = False

--- a/src/weathergen/train/loss_modules/loss_functions.py
+++ b/src/weathergen/train/loss_modules/loss_functions.py
@@ -292,8 +292,8 @@ def cosine_latitude(target_coords, min_value=1e-3, max_value=1.0):
     return (max_value - min_value) * np.cos(latitudes_radian) + min_value
 
 
-def gamma_decay(forecast_steps, gamma):
-    fsteps = np.arange(forecast_steps)
+def gamma_decay(num_forecast_steps, gamma):
+    fsteps = np.arange(num_forecast_steps)
     weights = gamma**fsteps
     return weights * (len(fsteps) / np.sum(weights))
 

--- a/src/weathergen/train/loss_modules/loss_module_physical.py
+++ b/src/weathergen/train/loss_modules/loss_module_physical.py
@@ -222,25 +222,27 @@ class LossPhysical(LossModuleBase):
             if len(targets.physical) - len(targets.forecast_steps) > 0:
                 fstep_loss_weights.insert(0, None)
 
-            loss_fsteps = torch.tensor(0.0, device=self.device, requires_grad=True)
-            ctr_fsteps = 0
+            # loss_stream: loss for given stream
+            loss_stream = torch.tensor(0.0, device=self.device, requires_grad=True)
+            ctr_timesteps = 0
+            for timestep_idx, (preds_cur, target_cur) in enumerate(
+                zip(preds.physical, targets.physical, strict=False)
+            ):
+                preds_batch = preds_cur.get(stream_name, [])
+                if not preds_batch:
+                    # skip to next timestep if preds of current timestep are empty
+                    continue
 
-            # TODO loop directly through preds and targets
-            fstep_idxs = [0] if len(targets.forecast_steps) == 0 else targets.forecast_steps
-            for fstep in fstep_idxs:
-                fstep_weight = fstep_loss_weights[fstep]
+                targets_batch = target_cur[stream_name]["target"]
+                targets_coords_batch = target_cur[stream_name]["target_coords"]
+                targets_times_batch = target_cur[stream_name]["target_times"]
+                targets_params = target_cur[stream_name]["target_metda_data"]
+                targets_is_spoof = target_cur[stream_name]["is_spoof"]
 
-                # get current prediction and target
-                # TODO: consistent ordering of preds and targets
-                preds_batch = preds.physical[fstep].get(stream_name, [])
+                fstep_weight = fstep_loss_weights[timestep_idx]
 
-                targets_batch = targets.physical[fstep][stream_name]["target"]
-                targets_coords_batch = targets.physical[fstep][stream_name]["target_coords"]
-                targets_times_batch = targets.physical[fstep][stream_name]["target_times"]
-                targets_params = targets.physical[fstep][stream_name]["target_metda_data"]
-                targets_is_spoof = targets.physical[fstep][stream_name]["is_spoof"]
-
-                loss_batch = torch.tensor(0.0, device=self.device, requires_grad=True)
+                # loss_timestep: loss for given timestep
+                loss_timestep = torch.tensor(0.0, device=self.device, requires_grad=True)
                 ctr_batch = 0
                 for pred, pred_params in zip(preds_batch, output_info, strict=True):
                     # source has a unique target but index is not invariant with multiple
@@ -263,8 +265,8 @@ class LossPhysical(LossModuleBase):
                         stream_info, targets_coords_batch[target_idx]
                     )
 
-                    # accumulate loss from different loss functions
-                    loss_fstep = torch.tensor(0.0, device=self.device, requires_grad=True)
+                    # loss_st_corr: loss for give source-target correspondence
+                    loss_st_corr = torch.tensor(0.0, device=self.device, requires_grad=True)
                     ctr_loss_fcts = 0
                     for loss_fct, loss_fct_weight, loss_fct_name in self.loss_fcts:
                         # skip is loss is not computed for this sample
@@ -289,10 +291,15 @@ class LossPhysical(LossModuleBase):
                         assert pred.shape[1] > 0
 
                         # get masks for sub-time steps
-                        substep_masks = self._get_substep_masks(stream_info, fstep, target_times)
+                        substep_masks = self._get_substep_masks(
+                            stream_info, timestep_idx, target_times
+                        )
 
-                        losses_all[stream_name][str(fstep)][loss_fct_name] = defaultdict(dict)
-                        # loss for current loss function
+                        losses_all[stream_name][str(timestep_idx)][loss_fct_name] = defaultdict(
+                            dict
+                        )
+                        # loss_lfct: loss for given loss function aggregated over all channels
+                        # loss_lfct_chs: loss for given loss function per channel
                         loss_lfct, loss_lfct_chs = self._loss_per_loss_function(
                             loss_fct,
                             target,
@@ -303,26 +310,26 @@ class LossPhysical(LossModuleBase):
                         )
 
                         for ch_n, v in zip(target_channels, loss_lfct_chs, strict=True):
-                            losses_all[stream_name][str(fstep)][loss_fct_name][ch_n] = (
+                            losses_all[stream_name][str(timestep_idx)][loss_fct_name][ch_n] = (
                                 spoof_weight * v if v != 0.0 else torch.nan
                             )
 
                         # Add the weighted and normalized loss from this loss function to the total
                         # batch loss
                         loss_cur_w = spoof_weight * loss_fct_weight * loss_lfct * fstep_weight
-                        loss_fstep = loss_fstep + loss_cur_w
+                        loss_st_corr = loss_st_corr + loss_cur_w
                         ctr_loss_fcts += 1 if loss_lfct > 0.0 else 0
 
-                    loss_batch = loss_batch + loss_fstep
+                    loss_timestep = loss_timestep + loss_st_corr
                     ctr_batch += 1 if ctr_loss_fcts > 0.0 else 0
 
-                loss_fsteps = loss_fsteps + loss_batch
-                ctr_fsteps += 1 if ctr_batch > 0 else 0
+                loss_stream = loss_stream + loss_timestep
+                ctr_timesteps += 1 if ctr_batch > 0 else 0
 
-            denom = ctr_fsteps if ctr_fsteps > 0 else 1.0
-            loss = loss + (stream_loss_weight * loss_fsteps) / denom
+            denom = ctr_timesteps if ctr_timesteps > 0 else 1.0
+            loss = loss + (stream_loss_weight * loss_stream) / denom
 
-            ctr_streams += 1 if ctr_fsteps > 0 else 0
+            ctr_streams += 1 if ctr_timesteps > 0 else 0
 
         # normalize by all targets and forecast steps that were non-empty
         # (with each having an expected loss of 1 for an uninitalized neural net)

--- a/src/weathergen/train/loss_modules/loss_module_physical.py
+++ b/src/weathergen/train/loss_modules/loss_module_physical.py
@@ -224,7 +224,7 @@ class LossPhysical(LossModuleBase):
             loss_fsteps = torch.tensor(0.0, device=self.device, requires_grad=True)
             ctr_fsteps = 0
 
-            for fstep in range(self.forecast_offset, targets.num_forecast_steps):
+            for fstep in range(self.forecast_offset, self.forecast_offset + targets.num_forecast_steps):
                 fstep_weight = fstep_loss_weights[fstep]
 
                 # get current prediction and target

--- a/src/weathergen/train/loss_modules/loss_module_physical.py
+++ b/src/weathergen/train/loss_modules/loss_module_physical.py
@@ -56,9 +56,6 @@ class LossPhysical(LossModuleBase):
         self.device = device
         self.name = "LossPhysical"
 
-        # TODO remove forecast offset dependency by directly looping over preds and targets
-        self.forecast_offset = mode_cfg.get("forecast", {}).get("offset", 0)
-
         # dynamically load loss functions based on configuration and stage
         self.loss_fcts = [
             [
@@ -220,16 +217,17 @@ class LossPhysical(LossModuleBase):
 
             stream_loss_weight, weights_channels = self._get_weights(stream_info)
 
-            fstep_loss_weights = self._get_fstep_weights(targets.num_forecast_steps)
-            if self.forecast_offset == 1:
+            # TODO: make nicer
+            fstep_loss_weights = self._get_fstep_weights(len(targets.forecast_steps))
+            if len(targets.physical) - len(targets.forecast_steps) > 0:
                 fstep_loss_weights.insert(0, None)
 
             loss_fsteps = torch.tensor(0.0, device=self.device, requires_grad=True)
             ctr_fsteps = 0
 
-            for fstep in range(
-                self.forecast_offset, self.forecast_offset + targets.num_forecast_steps
-            ):
+            # TODO loop directly through preds and targets
+            fstep_idxs = [0] if len(targets.forecast_steps) == 0 else targets.forecast_steps
+            for fstep in fstep_idxs:
                 fstep_weight = fstep_loss_weights[fstep]
 
                 # get current prediction and target

--- a/src/weathergen/train/loss_modules/loss_module_physical.py
+++ b/src/weathergen/train/loss_modules/loss_module_physical.py
@@ -91,9 +91,9 @@ class LossPhysical(LossModuleBase):
 
         return stream_info_loss_weight, weights_channels
 
-    def _get_fstep_weights(self, len_forecast_steps):
-        timestep_weight_config = self.mode_cfg.forecast.get("timestep_weight")
-        if timestep_weight_config is None:
+    def _get_output_step_weights(self, len_forecast_steps):
+        timestep_weight_config = self.mode_cfg.get("forecast", {}).get("timestep_weight", {})
+        if len(timestep_weight_config) == 0:
             return [1.0 for _ in range(len_forecast_steps)]
         weights_timestep_fct = getattr(loss_fns, list(timestep_weight_config.keys())[0])
         decay_factor = list(timestep_weight_config.values())[0]["decay_factor"]
@@ -109,7 +109,7 @@ class LossPhysical(LossModuleBase):
 
         return weights_locations
 
-    def _get_substep_masks(self, stream_info, fstep, target_times):
+    def _get_substep_masks(self, stream_info, output_step, target_times):
         """
         Find substeps and create corresponding masks (reused across loss functions)
         """
@@ -168,7 +168,7 @@ class LossPhysical(LossModuleBase):
 
         The computed loss is:
 
-        Mean_{stream}( Mean_{fsteps}( Mean_{loss_fcts}( loss_fct( target, pred, weigths) )))
+        Mean_{stream}( Mean_{output_steps}( Mean_{loss_fcts}( loss_fct( target, pred, weigths) )))
 
         This method orchestrates the calculation of the overall loss by iterating through
         different data streams, forecast steps, channels, and configured loss functions.
@@ -218,15 +218,15 @@ class LossPhysical(LossModuleBase):
             stream_loss_weight, weights_channels = self._get_weights(stream_info)
 
             # TODO: make nicer
-            fstep_loss_weights = self._get_fstep_weights(len(targets.forecast_idxs))
-            if len(targets.physical) - len(targets.forecast_idxs) > 0:
-                fstep_loss_weights.insert(0, None)
+            output_step_loss_weights = self._get_output_step_weights(len(targets.output_idxs))
+            if len(targets.physical) - len(targets.output_idxs) > 0:
+                output_step_loss_weights.insert(0, None)
 
             # loss_stream: loss for given stream
             loss_stream = torch.tensor(0.0, device=self.device, requires_grad=True)
             ctr_timesteps = 0
             for timestep_idx, (preds_cur, target_cur) in enumerate(
-                zip(preds.physical, targets.physical, strict=False)
+                zip(preds.physical, targets.physical, strict=True)
             ):
                 preds_batch = preds_cur.get(stream_name, [])
                 if not preds_batch:
@@ -239,7 +239,7 @@ class LossPhysical(LossModuleBase):
                 targets_params = target_cur[stream_name]["target_metda_data"]
                 targets_is_spoof = target_cur[stream_name]["is_spoof"]
 
-                fstep_weight = fstep_loss_weights[timestep_idx]
+                output_step_weight = output_step_loss_weights[timestep_idx]
 
                 # loss_timestep: loss for given timestep
                 loss_timestep = torch.tensor(0.0, device=self.device, requires_grad=True)
@@ -316,7 +316,7 @@ class LossPhysical(LossModuleBase):
 
                         # Add the weighted and normalized loss from this loss function to the total
                         # batch loss
-                        loss_cur_w = spoof_weight * loss_fct_weight * loss_lfct * fstep_weight
+                        loss_cur_w = spoof_weight * loss_fct_weight * loss_lfct * output_step_weight
                         loss_st_corr = loss_st_corr + loss_cur_w
                         ctr_loss_fcts += 1 if loss_lfct > 0.0 else 0
 
@@ -343,23 +343,23 @@ class LossPhysical(LossModuleBase):
         def _nested_dict():
             return defaultdict(dict)
 
-        # Reorder losses_all to [stream_name][loss_fct_name][ch_n][fstep]
+        # Reorder losses_all to [stream_name][loss_fct_name][ch_n][output_step]
         reordered_losses = defaultdict(dict)
-        for stream_name, fstep_dict in losses_all.items():
+        for stream_name, output_step_dict in losses_all.items():
             reordered_losses[stream_name] = defaultdict(_nested_dict)
-            for fstep, lfct_dict in fstep_dict.items():
+            for output_step, lfct_dict in output_step_dict.items():
                 for loss_fct_name, ch_dict in lfct_dict.items():
                     for ch_n, v in ch_dict.items():
-                        reordered_losses[stream_name][loss_fct_name][ch_n][fstep] = v
+                        reordered_losses[stream_name][loss_fct_name][ch_n][output_step] = v
 
-        # Calculate per stream, per lfct average across channels and fsteps
+        # Calculate per stream, per lfct average across channels and output_steps
         for stream_name, lfct_dict in reordered_losses.items():
             for loss_fct_name, ch_dict in lfct_dict.items():
                 reordered_losses[stream_name][loss_fct_name]["avg"] = 0
                 count = 0
-                for ch_n, fstep_dict in ch_dict.items():
+                for ch_n, output_step_dict in ch_dict.items():
                     if ch_n != "avg":
-                        for _, v in fstep_dict.items():
+                        for _, v in output_step_dict.items():
                             reordered_losses[stream_name][loss_fct_name]["avg"] += v
                             count += 1
                 reordered_losses[stream_name][loss_fct_name]["avg"] /= count

--- a/src/weathergen/train/loss_modules/loss_module_physical.py
+++ b/src/weathergen/train/loss_modules/loss_module_physical.py
@@ -91,13 +91,13 @@ class LossPhysical(LossModuleBase):
 
         return stream_info_loss_weight, weights_channels
 
-    def _get_fstep_weights(self, forecast_steps):
+    def _get_fstep_weights(self, len_forecast_steps):
         timestep_weight_config = self.mode_cfg.forecast.get("timestep_weight")
         if timestep_weight_config is None:
-            return [1.0 for _ in range(forecast_steps)]
+            return [1.0 for _ in range(len_forecast_steps)]
         weights_timestep_fct = getattr(loss_fns, list(timestep_weight_config.keys())[0])
         decay_factor = list(timestep_weight_config.values())[0]["decay_factor"]
-        return weights_timestep_fct(forecast_steps, decay_factor)
+        return weights_timestep_fct(len_forecast_steps, decay_factor)
 
     def _get_location_weights(self, stream_info, target_coords):
         location_weight_type = stream_info.get("location_weight", None)
@@ -218,8 +218,8 @@ class LossPhysical(LossModuleBase):
             stream_loss_weight, weights_channels = self._get_weights(stream_info)
 
             # TODO: make nicer
-            fstep_loss_weights = self._get_fstep_weights(len(targets.forecast_steps))
-            if len(targets.physical) - len(targets.forecast_steps) > 0:
+            fstep_loss_weights = self._get_fstep_weights(len(targets.forecast_idxs))
+            if len(targets.physical) - len(targets.forecast_idxs) > 0:
                 fstep_loss_weights.insert(0, None)
 
             # loss_stream: loss for given stream

--- a/src/weathergen/train/loss_modules/loss_module_physical.py
+++ b/src/weathergen/train/loss_modules/loss_module_physical.py
@@ -56,7 +56,8 @@ class LossPhysical(LossModuleBase):
         self.device = device
         self.name = "LossPhysical"
 
-        self.forecast_offset = mode_cfg.get("window_offset_prediction", 0)
+        # TODO remove forecast offset dependency by directly looping over preds and targets
+        self.forecast_offset = mode_cfg.get("forecast", {}).get("offset", 0)
 
         # dynamically load loss functions based on configuration and stage
         self.loss_fcts = [
@@ -220,22 +221,26 @@ class LossPhysical(LossModuleBase):
             stream_loss_weight, weights_channels = self._get_weights(stream_info)
 
             fstep_loss_weights = self._get_fstep_weights(targets.num_forecast_steps)
+            if self.forecast_offset == 1:
+                fstep_loss_weights.insert(0, None)
 
             loss_fsteps = torch.tensor(0.0, device=self.device, requires_grad=True)
             ctr_fsteps = 0
 
-            for fstep in range(self.forecast_offset, self.forecast_offset + targets.num_forecast_steps):
+            for fstep in range(
+                self.forecast_offset, self.forecast_offset + targets.num_forecast_steps
+            ):
                 fstep_weight = fstep_loss_weights[fstep]
 
                 # get current prediction and target
                 # TODO: consistent ordering of preds and targets
                 preds_batch = preds.physical[fstep].get(stream_name, [])
 
-                targets_batch = targets.physical[stream_name][fstep]["target"]
-                targets_coords_batch = targets.physical[stream_name][fstep]["target_coords"]
-                targets_times_batch = targets.physical[stream_name][fstep]["target_times"]
-                targets_params = targets.physical[stream_name][fstep]["target_metda_data"]
-                targets_is_spoof = targets.physical[stream_name][fstep]["is_spoof"]
+                targets_batch = targets.physical[fstep][stream_name]["target"]
+                targets_coords_batch = targets.physical[fstep][stream_name]["target_coords"]
+                targets_times_batch = targets.physical[fstep][stream_name]["target_times"]
+                targets_params = targets.physical[fstep][stream_name]["target_metda_data"]
+                targets_is_spoof = targets.physical[fstep][stream_name]["is_spoof"]
 
                 loss_batch = torch.tensor(0.0, device=self.device, requires_grad=True)
                 ctr_batch = 0

--- a/src/weathergen/train/target_and_aux_module_base.py
+++ b/src/weathergen/train/target_and_aux_module_base.py
@@ -36,16 +36,21 @@ class TargetAuxOutput:
         self.latent = [{} for _ in range(len_target)]
         self.aux_outputs = {}
 
-    def add_physical_target(self, fstep: int, stream_name: StreamName, pred: torch.Tensor) -> None:
-        self.physical[fstep][stream_name] = pred
+    def add_physical_target(
+        self, timestep_idx: int, stream_name: StreamName, pred: torch.Tensor
+    ) -> None:
+        self.physical[timestep_idx][stream_name] = pred
 
-    def add_latent_target(self, fstep: int, latent_name: str, pred: torch.Tensor) -> None:
-        self.latent[fstep][latent_name] = pred
+    def add_latent_target(self, timestep_idx: int, latent_name: str, pred: torch.Tensor) -> None:
+        self.latent[timestep_idx][latent_name] = pred
 
     def get_physical_target(
-        self, fstep: int, stream_name: StreamName | None = None, sample_idx: int | None = None
+        self,
+        timestep_idx: int,
+        stream_name: StreamName | None = None,
+        sample_idx: int | None = None,
     ):
-        pred = self.physical[fstep]
+        pred = self.physical[timestep_idx]
         if stream_name is not None:
             pred = pred.get(stream_name, None)
             if sample_idx is not None:
@@ -53,8 +58,8 @@ class TargetAuxOutput:
                 pred = pred[sample_idx]
         return pred
 
-    def get_latent_target(self, fstep: int):
-        return self.latent[fstep]
+    def get_latent_target(self, timestep_idx: int):
+        return self.latent[timestep_idx]
 
 
 class TargetAndAuxModuleBase:
@@ -99,16 +104,16 @@ class PhysicalTargetAndAux(TargetAndAuxModuleBase):
 
         # collect all targets, concatenating across batch dimension since this is also how it
         # happens for predictions in the model
-        fstep_idxs = [0] if len(forecast_steps) == 0 else forecast_steps
+        timestep_idxs = [0] if len(forecast_steps) == 0 else forecast_steps
         for stream_name in stream_names:
             # collect targets for all forecast steps
-            for fstep in fstep_idxs:
+            for t_idx in timestep_idxs:
                 targets_cur, target_times_cur, target_coords_cur, meta_data = [], [], [], []
                 is_spoof = []
                 for sample in batch.samples:
-                    targets_cur += [sample.streams_data[stream_name].target_tokens[fstep]]
-                    target_times_cur += [sample.streams_data[stream_name].target_times_raw[fstep]]
-                    target_coords_cur += [sample.streams_data[stream_name].target_coords_raw[fstep]]
+                    targets_cur += [sample.streams_data[stream_name].target_tokens[t_idx]]
+                    target_times_cur += [sample.streams_data[stream_name].target_times_raw[t_idx]]
+                    target_coords_cur += [sample.streams_data[stream_name].target_coords_raw[t_idx]]
                     meta_data += [sample.meta_info]
                     is_spoof += [sample.streams_data[stream_name].is_spoof()]
 
@@ -120,7 +125,7 @@ class PhysicalTargetAndAux(TargetAndAuxModuleBase):
                         "is_spoof": is_spoof,
                     }
 
-                    targets.add_physical_target(fstep, stream_name, targets_cur)
+                    targets.add_physical_target(t_idx, stream_name, targets_cur)
 
         return targets
 

--- a/src/weathergen/train/target_and_aux_module_base.py
+++ b/src/weathergen/train/target_and_aux_module_base.py
@@ -24,15 +24,14 @@ class TargetAuxOutput:
     A dataclass to encapsulate the TargetAndAuxCalculator output and give a clear API.
     """
 
-    num_forecast_steps: int
+    forecast_steps: list
 
     physical: list[dict[StreamName, torch.Tensor]]
     latent: list[dict[str, torch.Tensor | LatentState]]
     aux_outputs: dict[str, torch.Tensor]
 
-    def __init__(self, forecast_offset: int, forecast_steps: int) -> None:
-        len_target = max(1, forecast_offset + forecast_steps)
-        self.num_forecast_steps = forecast_steps
+    def __init__(self, len_target: int, forecast_steps: list) -> None:
+        self.forecast_steps = forecast_steps
         self.physical = [{} for _ in range(len_target)]
         self.latent = [{} for _ in range(len_target)]
         self.aux_outputs = {}
@@ -91,18 +90,19 @@ class PhysicalTargetAndAux(TargetAndAuxModuleBase):
     def update_state_post_opt_step(self, istep, batch, model, **kwargs):
         return
 
-    def compute(self, bidx, batch, model_params, model, forecast_offset) -> TargetAuxOutput:
+    def compute(self, bidx, batch, model_params, model) -> TargetAuxOutput:
         # TODO: properly retrieve/define these
         stream_names = [k for k, _ in batch.samples[0].streams_data.items()]
         forecast_steps = batch.get_forecast_steps()
 
-        targets = TargetAuxOutput(forecast_offset, forecast_steps)
+        targets = TargetAuxOutput(batch.get_output_len(), forecast_steps)
 
         # collect all targets, concatenating across batch dimension since this is also how it
         # happens for predictions in the model
+        fstep_idxs = [0] if len(forecast_steps) == 0 else forecast_steps
         for stream_name in stream_names:
             # collect targets for all forecast steps
-            for fstep in range(forecast_offset, forecast_offset + forecast_steps):
+            for fstep in fstep_idxs:
                 targets_cur, target_times_cur, target_coords_cur, meta_data = [], [], [], []
                 is_spoof = []
                 for sample in batch.samples:

--- a/src/weathergen/train/target_and_aux_module_base.py
+++ b/src/weathergen/train/target_and_aux_module_base.py
@@ -13,6 +13,10 @@ import dataclasses
 
 import torch
 
+from weathergen.model.engines import LatentState
+
+type StreamName = str
+
 
 @dataclasses.dataclass
 class TargetAuxOutput:
@@ -22,9 +26,36 @@ class TargetAuxOutput:
 
     num_forecast_steps: int
 
-    physical: dict[str, torch.Tensor]
-    latent: dict[str, torch.Tensor]
+    physical: list[dict[StreamName, torch.Tensor]]
+    latent: list[dict[str, torch.Tensor | LatentState]]
     aux_outputs: dict[str, torch.Tensor]
+
+    def __init__(self, forecast_offset: int, forecast_steps: int) -> None:
+        len_target = max(1, forecast_offset + forecast_steps)
+        self.num_forecast_steps = forecast_steps
+        self.physical = [{} for _ in range(len_target)]
+        self.latent = [{} for _ in range(len_target)]
+        self.aux_outputs = {}
+
+    def add_physical_target(self, fstep: int, stream_name: StreamName, pred: torch.Tensor) -> None:
+        self.physical[fstep][stream_name] = pred
+
+    def add_latent_target(self, fstep: int, latent_name: str, pred: torch.Tensor) -> None:
+        self.latent[fstep][latent_name] = pred
+
+    def get_physical_target(
+        self, fstep: int, stream_name: StreamName | None = None, sample_idx: int | None = None
+    ):
+        pred = self.physical[fstep]
+        if stream_name is not None:
+            pred = pred.get(stream_name, None)
+            if sample_idx is not None:
+                assert sample_idx < len(pred), "Invalid sample index."
+                pred = pred[sample_idx]
+        return pred
+
+    def get_latent_target(self, fstep: int):
+        return self.latent[fstep]
 
 
 class TargetAndAuxModuleBase:
@@ -60,18 +91,18 @@ class PhysicalTargetAndAux(TargetAndAuxModuleBase):
     def update_state_post_opt_step(self, istep, batch, model, **kwargs):
         return
 
-    def compute(self, istep, batch, *args, **kwargs) -> TargetAuxOutput:
+    def compute(self, bidx, batch, model_params, model, forecast_offset) -> TargetAuxOutput:
         # TODO: properly retrieve/define these
         stream_names = [k for k, _ in batch.samples[0].streams_data.items()]
         forecast_steps = batch.get_forecast_steps()
 
+        targets = TargetAuxOutput(forecast_offset, forecast_steps)
+
         # collect all targets, concatenating across batch dimension since this is also how it
         # happens for predictions in the model
-        targets = {}
         for stream_name in stream_names:
             # collect targets for all forecast steps
-            targets[stream_name] = []
-            for fstep in range(forecast_steps):
+            for fstep in range(forecast_offset, forecast_offset + forecast_steps):
                 targets_cur, target_times_cur, target_coords_cur, meta_data = [], [], [], []
                 is_spoof = []
                 for sample in batch.samples:
@@ -81,18 +112,17 @@ class PhysicalTargetAndAux(TargetAndAuxModuleBase):
                     meta_data += [sample.meta_info]
                     is_spoof += [sample.streams_data[stream_name].is_spoof()]
 
-                targets[stream_name].append(
-                    {
+                    targets_cur = {
                         "target": targets_cur,
                         "target_times": target_times_cur,
                         "target_coords": target_coords_cur,
                         "target_metda_data": meta_data,
                         "is_spoof": is_spoof,
                     }
-                )
 
-        aux_outputs = {}
-        return TargetAuxOutput(forecast_steps, targets, None, aux_outputs)
+                    targets.add_physical_target(fstep, stream_name, targets_cur)
+
+        return targets
 
     def to_device(self, device) -> PhysicalTargetAndAux:
         return self

--- a/src/weathergen/train/target_and_aux_module_base.py
+++ b/src/weathergen/train/target_and_aux_module_base.py
@@ -24,14 +24,14 @@ class TargetAuxOutput:
     A dataclass to encapsulate the TargetAndAuxCalculator output and give a clear API.
     """
 
-    forecast_steps: list
+    forecast_idxs: list
 
     physical: list[dict[StreamName, torch.Tensor]]
     latent: list[dict[str, torch.Tensor | LatentState]]
     aux_outputs: dict[str, torch.Tensor]
 
-    def __init__(self, len_target: int, forecast_steps: list) -> None:
-        self.forecast_steps = forecast_steps
+    def __init__(self, len_target: int, forecast_idxs: list) -> None:
+        self.forecast_idxs = forecast_idxs
         self.physical = [{} for _ in range(len_target)]
         self.latent = [{} for _ in range(len_target)]
         self.aux_outputs = {}
@@ -98,13 +98,13 @@ class PhysicalTargetAndAux(TargetAndAuxModuleBase):
     def compute(self, bidx, batch, model_params, model) -> TargetAuxOutput:
         # TODO: properly retrieve/define these
         stream_names = [k for k, _ in batch.samples[0].streams_data.items()]
-        forecast_steps = batch.get_forecast_steps()
+        forecast_idxs = batch.get_forecast_idxs()
 
-        targets = TargetAuxOutput(batch.get_output_len(), forecast_steps)
+        targets = TargetAuxOutput(batch.get_output_len(), forecast_idxs)
 
         # collect all targets, concatenating across batch dimension since this is also how it
         # happens for predictions in the model
-        timestep_idxs = [0] if len(forecast_steps) == 0 else forecast_steps
+        timestep_idxs = [0] if len(forecast_idxs) == 0 else forecast_idxs
         for stream_name in stream_names:
             # collect targets for all forecast steps
             for t_idx in timestep_idxs:

--- a/src/weathergen/train/target_and_aux_module_base.py
+++ b/src/weathergen/train/target_and_aux_module_base.py
@@ -24,14 +24,14 @@ class TargetAuxOutput:
     A dataclass to encapsulate the TargetAndAuxCalculator output and give a clear API.
     """
 
-    forecast_idxs: list
+    output_idxs: list[int]
 
     physical: list[dict[StreamName, torch.Tensor]]
     latent: list[dict[str, torch.Tensor | LatentState]]
     aux_outputs: dict[str, torch.Tensor]
 
-    def __init__(self, len_target: int, forecast_idxs: list) -> None:
-        self.forecast_idxs = forecast_idxs
+    def __init__(self, len_target: int, output_idxs: list) -> None:
+        self.output_idxs = output_idxs
         self.physical = [{} for _ in range(len_target)]
         self.latent = [{} for _ in range(len_target)]
         self.aux_outputs = {}
@@ -98,26 +98,26 @@ class PhysicalTargetAndAux(TargetAndAuxModuleBase):
     def compute(self, bidx, batch, model_params, model) -> TargetAuxOutput:
         # TODO: properly retrieve/define these
         stream_names = [k for k, _ in batch.samples[0].streams_data.items()]
-        forecast_idxs = batch.get_forecast_idxs()
+        output_idxs = batch.get_output_idxs()
+        assert len(output_idxs) > 0
 
-        targets = TargetAuxOutput(batch.get_output_len(), forecast_idxs)
+        targets = TargetAuxOutput(batch.get_output_len(), output_idxs)
 
         # collect all targets, concatenating across batch dimension since this is also how it
         # happens for predictions in the model
-        timestep_idxs = [0] if len(forecast_idxs) == 0 else forecast_idxs
         for stream_name in stream_names:
             # collect targets for all forecast steps
-            for t_idx in timestep_idxs:
+            for step in output_idxs:
                 targets_cur, target_times_cur, target_coords_cur, meta_data = [], [], [], []
                 is_spoof = []
                 for sample in batch.samples:
-                    targets_cur += [sample.streams_data[stream_name].target_tokens[t_idx]]
-                    target_times_cur += [sample.streams_data[stream_name].target_times_raw[t_idx]]
-                    target_coords_cur += [sample.streams_data[stream_name].target_coords_raw[t_idx]]
+                    targets_cur += [sample.streams_data[stream_name].target_tokens[step]]
+                    target_times_cur += [sample.streams_data[stream_name].target_times_raw[step]]
+                    target_coords_cur += [sample.streams_data[stream_name].target_coords_raw[step]]
                     meta_data += [sample.meta_info]
                     is_spoof += [sample.streams_data[stream_name].is_spoof()]
 
-                    targets_cur = {
+                    targets_step = {
                         "target": targets_cur,
                         "target_times": target_times_cur,
                         "target_coords": target_coords_cur,
@@ -125,7 +125,7 @@ class PhysicalTargetAndAux(TargetAndAuxModuleBase):
                         "is_spoof": is_spoof,
                     }
 
-                    targets.add_physical_target(t_idx, stream_name, targets_cur)
+                    targets.add_physical_target(step, stream_name, targets_step)
 
         return targets
 

--- a/src/weathergen/train/target_and_aux_module_base.py
+++ b/src/weathergen/train/target_and_aux_module_base.py
@@ -117,15 +117,15 @@ class PhysicalTargetAndAux(TargetAndAuxModuleBase):
                     meta_data += [sample.meta_info]
                     is_spoof += [sample.streams_data[stream_name].is_spoof()]
 
-                    targets_step = {
-                        "target": targets_cur,
-                        "target_times": target_times_cur,
-                        "target_coords": target_coords_cur,
-                        "target_metda_data": meta_data,
-                        "is_spoof": is_spoof,
-                    }
+                targets_step = {
+                    "target": targets_cur,
+                    "target_times": target_times_cur,
+                    "target_coords": target_coords_cur,
+                    "target_metda_data": meta_data,
+                    "is_spoof": is_spoof,
+                }
 
-                    targets.add_physical_target(step, stream_name, targets_step)
+                targets.add_physical_target(step, stream_name, targets_step)
 
         return targets
 

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -123,8 +123,7 @@ class Trainer(TrainerBase):
             [self.training_cfg, self.validation_cfg, self.test_cfg],
             strict=True,
         ):
-            if mode_cfg.get("forecast", {}):
-                config.validate_forecast_policy_and_steps(mode_cfg.forecast, mode)
+            config.validate_forecast_policy_and_steps(mode_cfg.get("forecast", {}), mode)
 
         self.mixed_precision_dtype = get_dtype(cf.mixed_precision_dtype)
 

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -390,7 +390,6 @@ class Trainer(TrainerBase):
         self.model.train()
 
         dataset_iter = iter(self.data_loader)
-        forecast_offset = self.training_cfg.get("forecast", {}).get("offset", 0)
 
         self.optimizer.zero_grad()
 
@@ -411,7 +410,6 @@ class Trainer(TrainerBase):
                 preds = self.model(
                     self.model_params,
                     batch.get_source_samples(),
-                    forecast_offset,
                 )
 
                 targets_and_auxs = {}
@@ -424,7 +422,6 @@ class Trainer(TrainerBase):
                         batch.get_target_samples(target_idxs),
                         self.model_params,
                         self.model,
-                        forecast_offset,
                     )
 
             loss = self.loss_calculator.compute_loss(
@@ -510,7 +507,6 @@ class Trainer(TrainerBase):
         self.model.eval()
 
         dataset_val_iter = iter(self.data_loader_validation)
-        forecast_offset = mode_cfg.get("forecast", {}).get("offset", 0)
 
         with torch.no_grad():
             # print progress bar but only in interactive mode, i.e. when without ddp
@@ -532,13 +528,11 @@ class Trainer(TrainerBase):
                             preds = self.model(
                                 self.model_params,
                                 batch.get_source_samples(),
-                                forecast_offset,
                             )
                         else:
                             preds = self.ema_model.forward_eval(
                                 self.model_params,
                                 batch.get_source_samples(),
-                                forecast_offset,
                             )
 
                         targets_and_auxs = {}
@@ -549,7 +543,6 @@ class Trainer(TrainerBase):
                                 batch.get_target_samples(target_idxs),
                                 self.model_params,
                                 self.model,
-                                forecast_offset,
                             )
 
                     _ = self.loss_calculator_val.compute_loss(

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -390,6 +390,7 @@ class Trainer(TrainerBase):
         self.model.train()
 
         dataset_iter = iter(self.data_loader)
+        forecast_offset = self.training_cfg.get("forecast", {}).get("offset", 0)
 
         self.optimizer.zero_grad()
 
@@ -410,7 +411,7 @@ class Trainer(TrainerBase):
                 preds = self.model(
                     self.model_params,
                     batch.get_source_samples(),
-                    self.training_cfg.forecast.offset,
+                    forecast_offset,
                 )
 
                 targets_and_auxs = {}
@@ -423,7 +424,7 @@ class Trainer(TrainerBase):
                         batch.get_target_samples(target_idxs),
                         self.model_params,
                         self.model,
-                        self.training_cfg.forecast.offset,
+                        forecast_offset,
                     )
 
             loss = self.loss_calculator.compute_loss(
@@ -509,6 +510,7 @@ class Trainer(TrainerBase):
         self.model.eval()
 
         dataset_val_iter = iter(self.data_loader_validation)
+        forecast_offset = mode_cfg.get("forecast", {}).get("offset", 0)
 
         with torch.no_grad():
             # print progress bar but only in interactive mode, i.e. when without ddp
@@ -530,13 +532,13 @@ class Trainer(TrainerBase):
                             preds = self.model(
                                 self.model_params,
                                 batch.get_source_samples(),
-                                mode_cfg.forecast.offset,
+                                forecast_offset,
                             )
                         else:
                             preds = self.ema_model.forward_eval(
                                 self.model_params,
                                 batch.get_source_samples(),
-                                mode_cfg.forecast.offset,
+                                forecast_offset,
                             )
 
                         targets_and_auxs = {}
@@ -547,7 +549,7 @@ class Trainer(TrainerBase):
                                 batch.get_target_samples(target_idxs),
                                 self.model_params,
                                 self.model,
-                                mode_cfg.forecast.offset,
+                                forecast_offset,
                             )
 
                     _ = self.loss_calculator_val.compute_loss(

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -118,7 +118,12 @@ class Trainer(TrainerBase):
         self.batch_size_validation_per_gpu = get_batch_size_from_config(self.validation_cfg)
         self.batch_size_test_per_gpu = get_batch_size_from_config(self.test_cfg)
 
-        # config.validate_forecast_policy_and_steps(cf=cf)
+        if self.training_cfg.get("forecast", {}):
+            config.validate_forecast_policy_and_steps(self.training_cfg.forecast)
+        if self.validation_cfg.get("forecast", {}):
+            config.validate_forecast_policy_and_steps(self.validation_cfg.forecast)
+        if self.test_cfg.get("forecast", {}):
+            config.validate_forecast_policy_and_steps(self.test_cfg.forecast)
 
         self.mixed_precision_dtype = get_dtype(cf.mixed_precision_dtype)
 

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -118,12 +118,13 @@ class Trainer(TrainerBase):
         self.batch_size_validation_per_gpu = get_batch_size_from_config(self.validation_cfg)
         self.batch_size_test_per_gpu = get_batch_size_from_config(self.test_cfg)
 
-        if self.training_cfg.get("forecast", {}):
-            config.validate_forecast_policy_and_steps(self.training_cfg.forecast)
-        if self.validation_cfg.get("forecast", {}):
-            config.validate_forecast_policy_and_steps(self.validation_cfg.forecast)
-        if self.test_cfg.get("forecast", {}):
-            config.validate_forecast_policy_and_steps(self.test_cfg.forecast)
+        for mode, mode_cfg in zip(
+            ["training_config", "validation_config", "test_config"],
+            [self.training_cfg, self.validation_cfg, self.test_cfg],
+            strict=True,
+        ):
+            if mode_cfg.get("forecast", {}):
+                config.validate_forecast_policy_and_steps(mode_cfg.forecast, mode)
 
         self.mixed_precision_dtype = get_dtype(cf.mixed_precision_dtype)
 

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -410,7 +410,7 @@ class Trainer(TrainerBase):
                 preds = self.model(
                     self.model_params,
                     batch.get_source_samples(),
-                    self.training_cfg.window_offset_prediction,
+                    self.training_cfg.forecast.offset,
                 )
 
                 targets_and_auxs = {}
@@ -423,7 +423,7 @@ class Trainer(TrainerBase):
                         batch.get_target_samples(target_idxs),
                         self.model_params,
                         self.model,
-                        self.training_cfg.window_offset_prediction,
+                        self.training_cfg.forecast.offset,
                     )
 
             loss = self.loss_calculator.compute_loss(
@@ -530,13 +530,13 @@ class Trainer(TrainerBase):
                             preds = self.model(
                                 self.model_params,
                                 batch.get_source_samples(),
-                                mode_cfg.window_offset_prediction,
+                                mode_cfg.forecast.offset,
                             )
                         else:
                             preds = self.ema_model.forward_eval(
                                 self.model_params,
                                 batch.get_source_samples(),
-                                mode_cfg.window_offset_prediction,
+                                mode_cfg.forecast.offset,
                             )
 
                         targets_and_auxs = {}
@@ -547,7 +547,7 @@ class Trainer(TrainerBase):
                                 batch.get_target_samples(target_idxs),
                                 self.model_params,
                                 self.model,
-                                mode_cfg.window_offset_prediction,
+                                mode_cfg.forecast.offset,
                             )
 
                     _ = self.loss_calculator_val.compute_loss(

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -105,10 +105,9 @@ def write_output(
             sources[-1] += [stream_data.source_raw[0]]
 
     sample_idxs = [
-        [sdata.sample_idx for _, sdata in sample.streams_data.items()]
+        list(sample.streams_data.values())[0].sample_idx
         for sample in batch.get_source_samples().get_samples()
     ]
-    sample_idxs = [s[0].item() for s in sample_idxs]
 
     # more prep work
 

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -40,12 +40,12 @@ def write_output(
     fp32 = torch.float32
     preds_all, targets_all, targets_coords_all, targets_times_all = [], [], [], []
 
-    fstep_idxs = [0] if len(batch.get_forecast_steps()) == 0 else batch.get_forecast_steps()
-    forecast_offset = fstep_idxs[0]
+    timestep_idxs = [0] if len(batch.get_forecast_idxs()) == 0 else batch.get_forecast_idxs()
+    forecast_offset = timestep_idxs[0]
     targets_lens = []
 
     # TODO Maybe stopping at forecast_steps explained #1657
-    for fstep in fstep_idxs:
+    for t_idx in timestep_idxs:
         preds_all += [[]]
         targets_all += [[]]
         targets_coords_all += [[]]
@@ -54,8 +54,8 @@ def write_output(
         for stream_info in cf.streams:
             sname = stream_info["name"]
             # predictions
-            preds = model_output.get_physical_prediction(fstep, sname)
-            targets = target_aux_out.physical[fstep][sname]["target"]
+            preds = model_output.get_physical_prediction(t_idx, sname)
+            targets = target_aux_out.physical[t_idx][sname]["target"]
 
             preds_s, targets_s, t_coords_s, t_times_s = [], [], [], []
             targets_lens[-1] += [[]]
@@ -74,9 +74,9 @@ def write_output(
                 targets_s += [dn_data(sname, target).detach().cpu().numpy()]
 
                 key = "target_coords"
-                t_coords_s += [target_aux_out.physical[fstep][sname][key][i_batch].cpu().numpy()]
+                t_coords_s += [target_aux_out.physical[t_idx][sname][key][i_batch].cpu().numpy()]
                 key = "target_times"
-                t_times_s += [target_aux_out.physical[fstep][sname][key][i_batch]]
+                t_times_s += [target_aux_out.physical[t_idx][sname][key][i_batch]]
 
             targets_lens[-1][-1] += [t.shape[0] for t in targets_s]
 
@@ -89,8 +89,8 @@ def write_output(
     #           if len(idxs_inv) > 0:
     #               pred = pred[:, idxs_inv]
     #               target = target[idxs_inv]
-    #               targets_coords_raw[fstep][i_strm] = targets_coords_raw[fstep][i_strm][idxs_inv]
-    #               targets_times_raw[fstep][i_strm] = targets_times_raw[fstep][i_strm][idxs_inv]
+    #               targets_coords_raw[t_idx][i_strm] = targets_coords_raw[t_idx][i_strm][idxs_inv]
+    #               targets_times_raw[t_idx][i_strm] = targets_times_raw[t_idx][i_strm][idxs_inv]
 
     if len(preds_all) == 0:
         _logger.warning("Writing no data since predictions are empty.")

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -40,12 +40,12 @@ def write_output(
     fp32 = torch.float32
     preds_all, targets_all, targets_coords_all, targets_times_all = [], [], [], []
 
-    forecast_offset = val_cfg.get("forecast", {}).get("offset", 0)
-    forecast_steps = max(1, val_cfg.get("forecast", {}).get("num_steps", 1))
+    fstep_idxs = [0] if len(batch.get_forecast_steps()) == 0 else batch.get_forecast_steps()
+    forecast_offset = fstep_idxs[0]
     targets_lens = []
-    # TODO why does this stop at forecast_steps? Maybe explains #1657
-    # for fstep in range(forecast_offset, forecast_steps + 1):
-    for fstep in range(forecast_offset, forecast_steps):
+
+    # TODO Maybe stopping at forecast_steps explained #1657
+    for fstep in fstep_idxs:
         preds_all += [[]]
         targets_all += [[]]
         targets_coords_all += [[]]
@@ -54,8 +54,8 @@ def write_output(
         for stream_info in cf.streams:
             sname = stream_info["name"]
             # predictions
-            preds = model_output.get_physical_prediction(fstep, stream_info["name"])
-            targets = target_aux_out.physical[stream_info["name"]][fstep]["target"]
+            preds = model_output.get_physical_prediction(fstep, sname)
+            targets = target_aux_out.physical[fstep][sname]["target"]
 
             preds_s, targets_s, t_coords_s, t_times_s = [], [], [], []
             targets_lens[-1] += [[]]
@@ -74,9 +74,9 @@ def write_output(
                 targets_s += [dn_data(sname, target).detach().cpu().numpy()]
 
                 key = "target_coords"
-                t_coords_s += [target_aux_out.physical[sname][fstep][key][i_batch].cpu().numpy()]
+                t_coords_s += [target_aux_out.physical[fstep][sname][key][i_batch].cpu().numpy()]
                 key = "target_times"
-                t_times_s += [target_aux_out.physical[sname][fstep][key][i_batch]]
+                t_times_s += [target_aux_out.physical[fstep][sname][key][i_batch]]
 
             targets_lens[-1][-1] += [t.shape[0] for t in targets_s]
 

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -40,7 +40,7 @@ def write_output(
     fp32 = torch.float32
     preds_all, targets_all, targets_coords_all, targets_times_all = [], [], [], []
 
-    timestep_idxs = [0] if len(batch.get_forecast_idxs()) == 0 else batch.get_forecast_idxs()
+    timestep_idxs = [0] if len(batch.get_output_idxs()) == 0 else batch.get_output_idxs()
     forecast_offset = timestep_idxs[0]
     targets_lens = []
 

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -40,11 +40,12 @@ def write_output(
     fp32 = torch.float32
     preds_all, targets_all, targets_coords_all, targets_times_all = [], [], [], []
 
-    window_offset_prediction = val_cfg.get("window_offset_prediction", 0)
+    forecast_offset = val_cfg.get("forecast", {}).get("offset", 0)
     forecast_steps = max(1, val_cfg.get("forecast", {}).get("num_steps", 1))
     targets_lens = []
-    # for fstep in range(window_offset_prediction, forecast_steps + 1):
-    for fstep in range(window_offset_prediction, forecast_steps):
+    # TODO why does this stop at forecast_steps? Maybe explains #1657
+    # for fstep in range(forecast_offset, forecast_steps + 1):
+    for fstep in range(forecast_offset, forecast_steps):
         preds_all += [[]]
         targets_all += [[]]
         targets_coords_all += [[]]
@@ -156,7 +157,7 @@ def write_output(
         source_channels,
         geoinfo_channels,
         sample_start,
-        val_cfg.get("window_offset_prediction", 0),
+        forecast_offset,
     )
     with zarrio_writer(config.get_path_output(cf, mini_epoch)) as zio:
         for subset in data.items():


### PR DESCRIPTION
## Description

This PR makes sure that: 

- [x]  In forecast mode we get `len(pred) = len(forecast_steps) + forecast_offset`.

- [x]  `batch.get_forecast_steps()` corresponds to `forecast.num_steps`.

- [x]  The loops over forecast steps in the model forward and in the loss calculator go from `forecast_offset` to `forecast_offset + num_forecast_steps` .

- [x]  The tokens go first through the forecasting engine before going through the decoder. 


## Issue Number

Closes #1654 

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
