### PR TITLE
SYNOP datareader functionality for German stations

### DIFF
--- a/config/streams/era5_nppatms_synop/synop.yml
+++ b/config/streams/era5_nppatms_synop/synop.yml
@@ -6,6 +6,8 @@
 SurfaceCombined :
   type : obs
   filenames : ['observations-ea-ofb-0001-1979-2023-combined-surface-v2.zarr']
+  mean_key : ''     # key for stored mean in dataset
+  stdev_key : ''    # key for stored stdev in dataset
   loss_weight : 1.0
   masking_rate : 0.6
   masking_rate_none : 0.05

--- a/config/streams/era5_nppatms_synop/synop.yml
+++ b/config/streams/era5_nppatms_synop/synop.yml
@@ -6,8 +6,9 @@
 SurfaceCombined :
   type : obs
   filenames : ['observations-ea-ofb-0001-1979-2023-combined-surface-v2.zarr']
-  mean_key : ''     # key for stored mean in dataset
-  stdev_key : ''    # key for stored stdev in dataset
+  mean_key :       # key for stored mean in dataset
+  stdev_key :      # key for stored stdev in dataset
+  fillvalue :      # fill value for missing data
   loss_weight : 1.0
   masking_rate : 0.6
   masking_rate_none : 0.05

--- a/config/streams/era5_nppatms_synop/synop.yml
+++ b/config/streams/era5_nppatms_synop/synop.yml
@@ -4,8 +4,8 @@
 # 2 : conventional observations
 
 SurfaceCombined :
-  type : obs
-  filenames : ['observations-ea-ofb-0001-1979-2023-combined-surface-v2.zarr']
+  type : station
+  filenames : []
   mean_key :       # key for stored mean in dataset
   stdev_key :      # key for stored stdev in dataset
   fillvalue :      # fill value for missing data

--- a/src/weathergen/datasets/data_reader_anemoi.py
+++ b/src/weathergen/datasets/data_reader_anemoi.py
@@ -24,6 +24,8 @@ from weathergen.datasets.data_reader_base import (
     TIndex,
     check_reader_data,
     str_to_timedelta,
+    _clip_lat,
+    _clip_lon,
 )
 
 _logger = logging.getLogger(__name__)
@@ -251,17 +253,3 @@ class DataReaderAnemoi(DataReaderTimestep):
         )
 
         return chs_idx
-
-
-def _clip_lat(lats: NDArray) -> NDArray[np.float32]:
-    """
-    Clip latitudes to the range [-90, 90] and ensure periodicity.
-    """
-    return (2 * np.clip(lats, -90.0, 90.0) - lats).astype(np.float32)
-
-
-def _clip_lon(lons: NDArray) -> NDArray[np.float32]:
-    """
-    Clip longitudes to the range [-180, 180] and ensure periodicity.
-    """
-    return ((lons + 180.0) % 360.0 - 180.0).astype(np.float32)

--- a/src/weathergen/datasets/data_reader_base.py
+++ b/src/weathergen/datasets/data_reader_base.py
@@ -626,6 +626,18 @@ class DataReaderTimestep(DataReaderBase):
             self.time_window_handler,
         )
 
+    def _clip_lat(lats: NDArray) -> NDArray[np.float32]:
+        """
+        Clip latitudes to the range [-90, 90] and ensure periodicity.
+        """
+        return (2 * np.clip(lats, -90.0, 90.0) - lats).astype(np.float32)
+
+    def _clip_lon(lons: NDArray) -> NDArray[np.float32]:
+        """
+        Clip longitudes to the range [-180, 180] and ensure periodicity.
+        """
+        return ((lons + 180.0) % 360.0 - 180.0).astype(np.float32)
+
 
 # to avoid rounding issues
 # The basic time precision is 1 millisecond.

--- a/src/weathergen/datasets/data_reader_base.py
+++ b/src/weathergen/datasets/data_reader_base.py
@@ -185,7 +185,7 @@ class ReaderData:
     datetimes: NDArray[NPDT64]
 
     @staticmethod
-    def empty(num_data_fields: int, num_geo_fields: int, num_coord_fields: int = 2) -> "ReaderData":
+    def empty(num_data_fields: int, num_geo_fields: int) -> "ReaderData":
         """
         Create an empty ReaderData object
 
@@ -195,7 +195,7 @@ class ReaderData:
             Empty ReaderData object
         """
         return ReaderData(
-            coords=np.zeros((0, num_coord_fields), dtype=np.float32),
+            coords=np.zeros((0, 2), dtype=np.float32),
             geoinfos=np.zeros((0, num_geo_fields), dtype=np.float32),
             data=np.zeros((0, num_data_fields), dtype=np.float32),
             datetimes=np.zeros((0,), dtype=np.datetime64),

--- a/src/weathergen/datasets/data_reader_base.py
+++ b/src/weathergen/datasets/data_reader_base.py
@@ -232,8 +232,8 @@ def check_reader_data(rdata: ReaderData, dtr: DTRange) -> None:
     """
 
     assert rdata.coords.ndim == 2, f"coords must be 2D {rdata.coords.shape}"
-    assert rdata.coords.shape[1] == 2 or rdata.coords.shape[1] == 3, (
-        f"coords must have 2 or 3 columns (lat, lon(, height)), got {rdata.coords.shape}"
+    assert rdata.coords.shape[1] == 2, (
+        f"coords must have 2 columns (lat, lon), got {rdata.coords.shape}"
     )
     assert rdata.geoinfos.ndim == 2, f"geoinfos must be 2D, got {rdata.geoinfos.shape}"
     assert rdata.data.ndim == 2, f"data must be 2D {rdata.data.shape}"

--- a/src/weathergen/datasets/data_reader_base.py
+++ b/src/weathergen/datasets/data_reader_base.py
@@ -185,7 +185,7 @@ class ReaderData:
     datetimes: NDArray[NPDT64]
 
     @staticmethod
-    def empty(num_data_fields: int, num_geo_fields: int) -> "ReaderData":
+    def empty(num_data_fields: int, num_geo_fields: int, num_coord_fields: int = 2) -> "ReaderData":
         """
         Create an empty ReaderData object
 
@@ -195,7 +195,7 @@ class ReaderData:
             Empty ReaderData object
         """
         return ReaderData(
-            coords=np.zeros((0, 2), dtype=np.float32),
+            coords=np.zeros((0, num_coord_fields), dtype=np.float32),
             geoinfos=np.zeros((0, num_geo_fields), dtype=np.float32),
             data=np.zeros((0, num_data_fields), dtype=np.float32),
             datetimes=np.zeros((0,), dtype=np.datetime64),
@@ -232,8 +232,8 @@ def check_reader_data(rdata: ReaderData, dtr: DTRange) -> None:
     """
 
     assert rdata.coords.ndim == 2, f"coords must be 2D {rdata.coords.shape}"
-    assert rdata.coords.shape[1] == 2, (
-        f"coords must have 2 columns (lat, lon), got {rdata.coords.shape}"
+    assert rdata.coords.shape[1] == 2 or rdata.coords.shape[1] == 3, (
+        f"coords must have 2 or 3 columns (lat, lon(, height)), got {rdata.coords.shape}"
     )
     assert rdata.geoinfos.ndim == 2, f"geoinfos must be 2D, got {rdata.geoinfos.shape}"
     assert rdata.data.ndim == 2, f"data must be 2D {rdata.data.shape}"

--- a/src/weathergen/datasets/data_reader_base.py
+++ b/src/weathergen/datasets/data_reader_base.py
@@ -626,18 +626,6 @@ class DataReaderTimestep(DataReaderBase):
             self.time_window_handler,
         )
 
-    def _clip_lat(self, lats: NDArray) -> NDArray[np.float32]:
-        """
-        Clip latitudes to the range [-90, 90] and ensure periodicity.
-        """
-        return (2 * np.clip(lats, -90.0, 90.0) - lats).astype(np.float32)
-
-    def _clip_lon(self, lons: NDArray) -> NDArray[np.float32]:
-        """
-        Clip longitudes to the range [-180, 180] and ensure periodicity.
-        """
-        return ((lons + 180.0) % 360.0 - 180.0).astype(np.float32)
-
 
 # to avoid rounding issues
 # The basic time precision is 1 millisecond.
@@ -706,3 +694,17 @@ def get_dataset_indexes_timestep(
     end_didx = start_didx + int((dtr.end - dtr.start - t_epsilon) / period)
 
     return (np.arange(start_didx, end_didx + 1, dtype=np.int64), dtr)
+
+
+def _clip_lat(lats: NDArray) -> NDArray[np.float32]:
+    """
+    Clip latitudes to the range [-90, 90] and ensure periodicity.
+    """
+    return (2 * np.clip(lats, -90.0, 90.0) - lats).astype(np.float32)
+
+
+def _clip_lon(lons: NDArray) -> NDArray[np.float32]:
+    """
+    Clip longitudes to the range [-180, 180] and ensure periodicity.
+    """
+    return ((lons + 180.0) % 360.0 - 180.0).astype(np.float32)

--- a/src/weathergen/datasets/data_reader_base.py
+++ b/src/weathergen/datasets/data_reader_base.py
@@ -626,13 +626,13 @@ class DataReaderTimestep(DataReaderBase):
             self.time_window_handler,
         )
 
-    def _clip_lat(lats: NDArray) -> NDArray[np.float32]:
+    def _clip_lat(self, lats: NDArray) -> NDArray[np.float32]:
         """
         Clip latitudes to the range [-90, 90] and ensure periodicity.
         """
         return (2 * np.clip(lats, -90.0, 90.0) - lats).astype(np.float32)
 
-    def _clip_lon(lons: NDArray) -> NDArray[np.float32]:
+    def _clip_lon(self, lons: NDArray) -> NDArray[np.float32]:
         """
         Clip longitudes to the range [-180, 180] and ensure periodicity.
         """

--- a/src/weathergen/datasets/data_reader_synop.py
+++ b/src/weathergen/datasets/data_reader_synop.py
@@ -90,18 +90,7 @@ class DataReaderSynop(DataReaderTimestep):
             self.ds = ds
             self.len = len(ds)
 
-        # handle MetNo SYNOP netCDF files
-        if "air_temperature" in ds.keys():
-            self.ds_type = "MetNo"
-        elif "TT_10" in ds.keys():
-            self.ds_type = "Germany"
-        else:
-            self.ds_type = "Unknown"
-            assert False, "Unknown dataset type"
-
-        if self.ds_type == "MetNo":
-            self.fillvalue = ds["air_temperature"][0, 0].values.item()
-
+        self.fillvalue = self.stream_info.get("fillvalue", None)
         self.channels_file = list(ds.keys())
 
         # Resolve coordinates
@@ -184,7 +173,7 @@ class DataReaderSynop(DataReaderTimestep):
 
         for ch in self.channels_file:
             data = np.array(self.ds[ch], np.float64)
-            if self.ds_type == "MetNo":
+            if self.fillvalue is not None:
                 mask = data == self.fillvalue
                 data[mask] = np.nan
             mean += [np.nanmean(data.flatten())]

--- a/src/weathergen/datasets/data_reader_synop.py
+++ b/src/weathergen/datasets/data_reader_synop.py
@@ -274,7 +274,7 @@ class DataReaderSynop(DataReaderTimestep):
         # flatten along time dimension
         data = data.transpose([1, 2, 0]).reshape((data.shape[1] * data.shape[2], data.shape[0]))
         # set invalid values to NaN for MetNo nc files
-        if self.ds_type == "MetNo":
+        if self.fillvalue is not None:
             mask = data == self.fillvalue
             data[mask] = np.nan
 

--- a/src/weathergen/datasets/data_reader_synop.py
+++ b/src/weathergen/datasets/data_reader_synop.py
@@ -27,7 +27,7 @@ _logger = logging.getLogger(__name__)
 
 
 class DataReaderSynop(DataReaderTimestep):
-    "Wrapper for SYNOP datasets from MetNo in NetCDF"
+    "Wrapper for SYNOP datasets in NetCDF"
 
     def __init__(
         self,
@@ -88,21 +88,49 @@ class DataReaderSynop(DataReaderTimestep):
             self.ds = ds
             self.len = len(ds)
 
-        self.offset_data_channels = 4
-        self.fillvalue = ds["air_temperature"][0, 0].values.item()
-        self.channels_file = [k for k in self.ds.keys()]
+        # handle MetNo SYNOP netCDF files
+        if "air_temperature" in ds.keys():
+            self.ds_type = "MetNo"
+        elif "TT_10" in ds.keys():
+            self.ds_type = "Germany"
+        else:
+            self.ds_type = "Unknown"
+            assert False, "Unknown dataset type"
 
-        # caches lats and lons
+        if self.ds_type == "MetNo":
+            self.fillvalue = ds["air_temperature"][0, 0].values.item()
+
+        self.channels_file = list(ds.keys())
+
+        # helper to get 1D station-static data for german stations
+        def _get_1d(var_name):
+            v = ds[var_name]
+            if self.ds_type == "Germany":
+                return v.isel(time=0)
+                
+            return v
+
+        # Resolve coordinates
         lat_name = stream_info.get("latitude_name", "latitude")
-        self.latitudes = _clip_lat(np.array(ds[lat_name], dtype=np32))
         lon_name = stream_info.get("longitude_name", "longitude")
-        self.longitudes = _clip_lon(np.array(ds[lon_name], dtype=np32))
+        height_name = stream_info.get("height_name", "height") # height for german, altitude for MetNo stations
+        
+        self.latitudes = _clip_lat(np.array(_get_1d(lat_name), dtype=np32))
+        self.longitudes = _clip_lon(np.array(_get_1d(lon_name), dtype=np32))
+        self.heights = np.array(_get_1d(height_name), dtype=np32)
 
+        # Resolve geoinfos
         self.geoinfo_channels = stream_info.get("geoinfos", [])
         self.geoinfo_idx = [self.channels_file.index(ch) for ch in self.geoinfo_channels]
-        # cache geoinfos
-        self.geoinfo_data = np.stack([np.array(ds[ch], dtype=np32) for ch in self.geoinfo_channels])
-        self.geoinfo_data = self.geoinfo_data.transpose()
+        # cache geoinfos (use _get_1d for consistent 1D arrays)
+        geoinfo_data_list = []
+        for ch in self.geoinfo_channels:
+            geoinfo_data_list.append(np.array(_get_1d(ch), dtype=np32))
+        
+        if geoinfo_data_list:
+            self.geoinfo_data = np.stack(geoinfo_data_list).transpose()
+        else:
+            self.geoinfo_data = np.zeros((len(self.latitudes), 0), dtype=np32)
 
         # select/filter requested source channels
         self.source_idx = self.select_channels(ds, "source")
@@ -133,8 +161,9 @@ class DataReaderSynop(DataReaderTimestep):
 
         for ch in self.channels_file:
             data = np.array(self.ds[ch], np.float64)
-            mask = data == self.fillvalue
-            data[mask] = np.nan
+            if self.ds_type == "MetNo":
+                mask = data == self.fillvalue
+                data[mask] = np.nan
             mean += [np.nanmean(data.flatten())]
             stdev += [np.nanstd(data.flatten())]
 
@@ -182,7 +211,9 @@ class DataReaderSynop(DataReaderTimestep):
 
         if self.ds is None or self.len == 0 or len(t_idxs) == 0:
             return ReaderData.empty(
-                num_data_fields=len(channels_idx), num_geo_fields=len(self.geoinfo_idx)
+                num_data_fields=len(channels_idx),
+                num_geo_fields=len(self.geoinfo_idx),
+                num_coord_fields=3,
             )
 
         assert t_idxs[0] >= 0, "index must be non-negative"
@@ -195,18 +226,29 @@ class DataReaderSynop(DataReaderTimestep):
         # subsetting is pushed to the ctor via frequency argument; this also ensures that no sub-
         # sampling is required here
         sel_channels = [self.channels_file[i] for i in channels_idx]
-        data = self.ds[sel_channels].isel(time=slice(didx_start, didx_end)).to_array().values
+        data = self.ds[sel_channels].isel(time=slice(didx_start, didx_end)).to_array()
+        
+        # Ensure dimensions are (variables, time, spatial)
+        # German files are (variables, spatial, time)
+        # MetNo files are (variables, time, spatial)
+        spatial_dim = "location" if "location" in data.dims else "station_id"
+        if data.dims[1] == spatial_dim:
+             data = data.transpose("variable", "time", spatial_dim)
+
+        data = data.values
         # flatten along time dimension
         data = data.transpose([1, 2, 0]).reshape((data.shape[1] * data.shape[2], data.shape[0]))
-        # set invalid values to NaN
-        mask = data == self.fillvalue
-        data[mask] = np.nan
+        # set invalid values to NaN for MetNo nc files
+        if self.ds_type == "MetNo":
+            mask = data == self.fillvalue
+            data[mask] = np.nan
 
-        # construct lat/lon coords
+        # construct lat/lon/height coords
         latlon = np.concatenate(
             [
                 np.expand_dims(self.latitudes, 0),
                 np.expand_dims(self.longitudes, 0),
+                np.expand_dims(self.heights, 0),
             ],
             axis=0,
         ).transpose()

--- a/src/weathergen/datasets/data_reader_synop.py
+++ b/src/weathergen/datasets/data_reader_synop.py
@@ -105,7 +105,7 @@ class DataReaderSynop(DataReaderTimestep):
         self.geoinfo_idx = [self.channels_file.index(ch) for ch in self.geoinfo_channels]
         geoinfo_data_list = []
         for ch in self.geoinfo_channels:
-            geoinfo_data_list.append(np.array(ch, dtype=np32))
+            geoinfo_data_list.append(np.array(ds[ch], dtype=np32))
 
         if geoinfo_data_list:
             self.geoinfo_data = np.stack(geoinfo_data_list).transpose()
@@ -159,8 +159,8 @@ class DataReaderSynop(DataReaderTimestep):
                 )
                 return self._compute_mean_stdev()
 
-            _logger.info(f"Finished loading mean and stdev.")
-            
+            _logger.info("Finished loading mean and stdev.")
+
             return mean, stdev
 
         # Fall back to computing mean and stdev
@@ -244,7 +244,7 @@ class DataReaderSynop(DataReaderTimestep):
         # flatten (time, spatial) into a single leading dimension
         data = data.reshape(-1, len(sel_channels))
 
-        # set invalid values to NaN for MetNo nc files
+        # replace fill values with NaN
         if self.fillvalue is not None:
             mask = data == self.fillvalue
             data[mask] = np.nan

--- a/src/weathergen/datasets/data_reader_synop.py
+++ b/src/weathergen/datasets/data_reader_synop.py
@@ -223,9 +223,7 @@ class DataReaderSynop(DataReaderTimestep):
 
         if self.ds is None or self.len == 0 or len(t_idxs) == 0:
             return ReaderData.empty(
-                num_data_fields=len(channels_idx),
-                num_geo_fields=len(self.geoinfo_idx),
-                num_coord_fields=3,
+                num_data_fields=len(channels_idx), num_geo_fields=len(self.geoinfo_idx),
             )
 
         assert t_idxs[0] >= 0, "index must be non-negative"
@@ -240,16 +238,15 @@ class DataReaderSynop(DataReaderTimestep):
         sel_channels = [self.channels_file[i] for i in channels_idx]
         data = self.ds[sel_channels].isel(time=slice(didx_start, didx_end)).to_array()
 
-        # Ensure dimensions are (variables, time, spatial)
-        # German files are (variables, spatial, time)
-        # MetNo files are (variables, time, spatial)
-        spatial_dim = "location" if "location" in data.dims else "station_id"
-        if data.dims[1] == spatial_dim:
-            data = data.transpose("variable", "time", spatial_dim)
+        # filter the spatial dimension and reorder to (time * spatial, var)
+        dims = list(data.dims)
+        ax_var = dims.index("variable")
+        ax_time = dims.index("time")
+        ax_spatial = next(i for i in range(len(dims)) if i not in (ax_var, ax_time))
+        data = np.transpose(data.values, [ax_time, ax_spatial, ax_var])
+        # flatten (time, spatial) into a single leading dimension
+        data = data.reshape(-1, len(sel_channels))
 
-        data = data.values
-        # flatten along time dimension
-        data = data.transpose([1, 2, 0]).reshape((data.shape[1] * data.shape[2], data.shape[0]))
         # set invalid values to NaN for MetNo nc files
         if self.fillvalue is not None:
             mask = data == self.fillvalue

--- a/src/weathergen/datasets/data_reader_synop.py
+++ b/src/weathergen/datasets/data_reader_synop.py
@@ -116,8 +116,8 @@ class DataReaderSynop(DataReaderTimestep):
         # height for german stations and altitude for MetNo stations
         height_name = stream_info.get("height_name", "height")
 
-        self.latitudes = _clip_lat(np.array(_get_1d(lat_name), dtype=np32))
-        self.longitudes = _clip_lon(np.array(_get_1d(lon_name), dtype=np32))
+        self.latitudes = self._clip_lat(np.array(_get_1d(lat_name), dtype=np32))
+        self.longitudes = self._clip_lon(np.array(_get_1d(lon_name), dtype=np32))
         self.heights = np.array(_get_1d(height_name), dtype=np32)
 
         # Resolve geoinfos

--- a/src/weathergen/datasets/data_reader_synop.py
+++ b/src/weathergen/datasets/data_reader_synop.py
@@ -21,6 +21,8 @@ from weathergen.datasets.data_reader_base import (
     TimeWindowHandler,
     TIndex,
     check_reader_data,
+    _clip_lat,
+    _clip_lon,
 )
 
 _logger = logging.getLogger(__name__)
@@ -116,8 +118,8 @@ class DataReaderSynop(DataReaderTimestep):
         # height for german stations and altitude for MetNo stations
         height_name = stream_info.get("height_name", "height")
 
-        self.latitudes = self._clip_lat(np.array(_get_1d(lat_name), dtype=np32))
-        self.longitudes = self._clip_lon(np.array(_get_1d(lon_name), dtype=np32))
+        self.latitudes = _clip_lat(np.array(_get_1d(lat_name), dtype=np32))
+        self.longitudes = _clip_lon(np.array(_get_1d(lon_name), dtype=np32))
         self.heights = np.array(_get_1d(height_name), dtype=np32)
 
         # Resolve geoinfos

--- a/src/weathergen/datasets/data_reader_synop.py
+++ b/src/weathergen/datasets/data_reader_synop.py
@@ -107,14 +107,15 @@ class DataReaderSynop(DataReaderTimestep):
             v = ds[var_name]
             if self.ds_type == "Germany":
                 return v.isel(time=0)
-                
+
             return v
 
         # Resolve coordinates
         lat_name = stream_info.get("latitude_name", "latitude")
         lon_name = stream_info.get("longitude_name", "longitude")
-        height_name = stream_info.get("height_name", "height") # height for german, altitude for MetNo stations
-        
+        # height for german stations and altitude for MetNo stations
+        height_name = stream_info.get("height_name", "height")
+
         self.latitudes = _clip_lat(np.array(_get_1d(lat_name), dtype=np32))
         self.longitudes = _clip_lon(np.array(_get_1d(lon_name), dtype=np32))
         self.heights = np.array(_get_1d(height_name), dtype=np32)
@@ -126,7 +127,7 @@ class DataReaderSynop(DataReaderTimestep):
         geoinfo_data_list = []
         for ch in self.geoinfo_channels:
             geoinfo_data_list.append(np.array(_get_1d(ch), dtype=np32))
-        
+
         if geoinfo_data_list:
             self.geoinfo_data = np.stack(geoinfo_data_list).transpose()
         else:
@@ -227,13 +228,13 @@ class DataReaderSynop(DataReaderTimestep):
         # sampling is required here
         sel_channels = [self.channels_file[i] for i in channels_idx]
         data = self.ds[sel_channels].isel(time=slice(didx_start, didx_end)).to_array()
-        
+
         # Ensure dimensions are (variables, time, spatial)
         # German files are (variables, spatial, time)
         # MetNo files are (variables, time, spatial)
         spatial_dim = "location" if "location" in data.dims else "station_id"
         if data.dims[1] == spatial_dim:
-             data = data.transpose("variable", "time", spatial_dim)
+            data = data.transpose("variable", "time", spatial_dim)
 
         data = data.values
         # flatten along time dimension

--- a/src/weathergen/datasets/data_reader_synop.py
+++ b/src/weathergen/datasets/data_reader_synop.py
@@ -299,19 +299,3 @@ class DataReaderSynop(DataReaderTimestep):
         chs_idx = np.sort([self.channels_file.index(ch) for ch in channels])
 
         return np.array(chs_idx)
-
-
-# TODO: move to base class
-def _clip_lat(lats: NDArray) -> NDArray[np.float32]:
-    """
-    Clip latitudes to the range [-90, 90] and ensure periodicity.
-    """
-    return (2 * np.clip(lats, -90.0, 90.0) - lats).astype(np.float32)
-
-
-# TODO: move to base class
-def _clip_lon(lons: NDArray) -> NDArray[np.float32]:
-    """
-    Clip longitudes to the range [-180, 180] and ensure periodicity.
-    """
-    return ((lons + 180.0) % 360.0 - 180.0).astype(np.float32)

--- a/src/weathergen/datasets/data_reader_synop.py
+++ b/src/weathergen/datasets/data_reader_synop.py
@@ -38,7 +38,7 @@ class DataReaderSynop(DataReaderTimestep):
         stream_info: dict,
     ) -> None:
         """
-        Construct data reader for anemoi dataset
+        Construct data reader for synop dataset
 
         Parameters
         ----------
@@ -97,8 +97,8 @@ class DataReaderSynop(DataReaderTimestep):
         lat_name = stream_info.get("latitude_name", "latitude")
         lon_name = stream_info.get("longitude_name", "longitude")
 
-        self.latitudes = _clip_lat(np.array(lat_name, dtype=np32))
-        self.longitudes = _clip_lon(np.array(lon_name, dtype=np32))
+        self.latitudes = _clip_lat(np.array(ds[lat_name], dtype=np32))
+        self.longitudes = _clip_lon(np.array(ds[lon_name], dtype=np32))
 
         # Resolve geoinfos
         self.geoinfo_channels = stream_info.get("geoinfos", [])
@@ -232,9 +232,6 @@ class DataReaderSynop(DataReaderTimestep):
         didx_end = t_idxs[-1] + 1
 
         # extract number of time steps and collapse ensemble dimension
-        # ds is a wrapper around zarr with get_coordinate_selection not being exposed since
-        # subsetting is pushed to the ctor via frequency argument; this also ensures that no sub-
-        # sampling is required here
         sel_channels = [self.channels_file[i] for i in channels_idx]
         data = self.ds[sel_channels].isel(time=slice(didx_start, didx_end)).to_array()
 
@@ -284,22 +281,20 @@ class DataReaderSynop(DataReaderTimestep):
 
         Parameters
         ----------
-        ds0 :
-            raw anemoi dataset with available channels
+        ds :
+            raw synop dataset with available channels
         ch_type :
             "source" or "target", i.e channel type to select
 
         Returns
         -------
-        ReaderData providing coords, geoinfos, data, datetimes
+        numpy array of indices of selected channels
 
         """
 
         channels = self.stream_info.get(ch_type)
         assert channels is not None, f"{ch_type} channels need to be specified"
-        # sanity check
-        is_empty = len(channels) == 0 if channels is not None else False
-        if is_empty:
+        if not channels:
             stream_name = self.stream_info["name"]
             _logger.warning(f"No channel for {stream_name} for {ch_type}.")
 

--- a/src/weathergen/datasets/data_reader_synop.py
+++ b/src/weathergen/datasets/data_reader_synop.py
@@ -150,10 +150,42 @@ class DataReaderSynop(DataReaderTimestep):
             "stream_id": 0,
         }
 
-        # TODO: this should be stored/cached
-        self.mean, self.stdev = self._compute_mean_stdev()
+        # Load mean and stdev from data file if specified in stream config, otherwise compute
+        self.mean, self.stdev = self._load_or_compute_mean_stdev()
         self.mean_geoinfo = self.mean[self.geoinfo_idx]
         self.stdev_geoinfo = self.stdev[self.geoinfo_idx]
+
+    def _load_or_compute_mean_stdev(self) -> tuple(np.array, np.array):
+        """
+        Load mean and stdev from data file if specified in stream config, otherwise compute.
+
+        Returns: tuple(np.array, np.array)
+            Mean and standard deviation arrays for all channels
+        """
+        mean_key = self.stream_info.get("mean_key")
+        stdev_key = self.stream_info.get("stdev_key")
+
+        if mean_key and mean_key in self.ds.keys() and stdev_key and stdev_key in self.ds.keys():
+            _logger.info(f"Loading mean from '{mean_key}' and stdev from '{stdev_key}'")
+            mean = np.array(self.ds[mean_key], dtype=np.float64)
+            stdev = np.array(self.ds[stdev_key], dtype=np.float64)
+            
+            # Validate that the loaded statistics have the correct shape
+            expected_len = len(self.channels_file)
+            if len(mean) != expected_len or len(stdev) != expected_len:
+                _logger.warning(
+                    f"Pre-computed statistics have incorrect shape "
+                    f"(mean: {len(mean)}, stdev: {len(stdev)}, expected: {expected_len}). "
+                    f"Falling back to computation."
+                )
+                return self._compute_mean_stdev()
+
+            _logger.info(f"Finished loading mean and stdev.")
+            
+            return mean, stdev
+
+        # Fall back to computing mean and stdev
+        return self._compute_mean_stdev()
 
     def _compute_mean_stdev(self) -> (np.array, np.array):
         _logger.info("Starting computation of mean and stdev.")

--- a/src/weathergen/datasets/data_reader_synop.py
+++ b/src/weathergen/datasets/data_reader_synop.py
@@ -155,11 +155,11 @@ class DataReaderSynop(DataReaderTimestep):
         self.mean_geoinfo = self.mean[self.geoinfo_idx]
         self.stdev_geoinfo = self.stdev[self.geoinfo_idx]
 
-    def _load_or_compute_mean_stdev(self) -> tuple(np.array, np.array):
+    def _load_or_compute_mean_stdev(self) -> (np.array, np.array):
         """
         Load mean and stdev from data file if specified in stream config, otherwise compute.
 
-        Returns: tuple(np.array, np.array)
+        Returns: (np.array, np.array)
             Mean and standard deviation arrays for all channels
         """
         mean_key = self.stream_info.get("mean_key")
@@ -170,7 +170,7 @@ class DataReaderSynop(DataReaderTimestep):
             mean = np.array(self.ds[mean_key], dtype=np.float64)
             stdev = np.array(self.ds[stdev_key], dtype=np.float64)
             
-            # Validate that the loaded statistics have the correct shape
+            # Validate that the loaded mean and stdev have the correct shape
             expected_len = len(self.channels_file)
             if len(mean) != expected_len or len(stdev) != expected_len:
                 _logger.warning(

--- a/src/weathergen/datasets/data_reader_synop.py
+++ b/src/weathergen/datasets/data_reader_synop.py
@@ -104,31 +104,19 @@ class DataReaderSynop(DataReaderTimestep):
 
         self.channels_file = list(ds.keys())
 
-        # helper to get 1D station-static data for german stations
-        def _get_1d(var_name):
-            v = ds[var_name]
-            if self.ds_type == "Germany":
-                return v.isel(time=0)
-
-            return v
-
         # Resolve coordinates
         lat_name = stream_info.get("latitude_name", "latitude")
         lon_name = stream_info.get("longitude_name", "longitude")
-        # height for german stations and altitude for MetNo stations
-        height_name = stream_info.get("height_name", "height")
 
-        self.latitudes = _clip_lat(np.array(_get_1d(lat_name), dtype=np32))
-        self.longitudes = _clip_lon(np.array(_get_1d(lon_name), dtype=np32))
-        self.heights = np.array(_get_1d(height_name), dtype=np32)
+        self.latitudes = _clip_lat(np.array(lat_name, dtype=np32))
+        self.longitudes = _clip_lon(np.array(lon_name, dtype=np32))
 
         # Resolve geoinfos
         self.geoinfo_channels = stream_info.get("geoinfos", [])
         self.geoinfo_idx = [self.channels_file.index(ch) for ch in self.geoinfo_channels]
-        # cache geoinfos (use _get_1d for consistent 1D arrays)
         geoinfo_data_list = []
         for ch in self.geoinfo_channels:
-            geoinfo_data_list.append(np.array(_get_1d(ch), dtype=np32))
+            geoinfo_data_list.append(np.array(ch, dtype=np32))
 
         if geoinfo_data_list:
             self.geoinfo_data = np.stack(geoinfo_data_list).transpose()
@@ -278,12 +266,11 @@ class DataReaderSynop(DataReaderTimestep):
             mask = data == self.fillvalue
             data[mask] = np.nan
 
-        # construct lat/lon/height coords
+        # construct lat/lon coords
         latlon = np.concatenate(
             [
                 np.expand_dims(self.latitudes, 0),
                 np.expand_dims(self.longitudes, 0),
-                np.expand_dims(self.heights, 0),
             ],
             axis=0,
         ).transpose()

--- a/tests/test_german_synop_reader.py
+++ b/tests/test_german_synop_reader.py
@@ -1,0 +1,39 @@
+import numpy as np
+from pathlib import Path
+from weathergen.datasets.data_reader_synop import DataReaderSynop
+from weathergen.datasets.data_reader_base import TimeWindowHandler
+
+def test_reader():
+    test_file = Path("/p/project1/hclimrep/hauer1/synop/data/datasetv1/2019.nc")
+    
+    tw_handler = TimeWindowHandler(
+        t_start=np.datetime64("2019-03-01T00:00:00"),
+        t_end=np.datetime64("2019-03-01T06:00:00"),
+        t_window_len_hours=6,
+        t_window_step_hours=6,
+    )
+    
+    stream_info = {
+        "name": "GermanReal",
+        "type": "station",
+        "filenames": [str(test_file)],
+        "source": ["TT_10"],
+        "target": ["TT_10"],
+        "geoinfos": ["height"],
+        "latitude_name": "latitude",
+        "longitude_name": "longitude",
+        "height_name": "height",
+    }
+    
+    reader = DataReaderSynop(tw_handler, test_file, stream_info)
+    print("Reader initialized successfully.")
+    
+    rd = reader._get(0, reader.source_idx)
+    print(f"Data shape: {rd.data.shape}")
+    print(f"Coords shape: {rd.coords.shape}")
+    print(f"Geoinfos shape: {rd.geoinfos.shape}")
+    
+    print("Test finished!")
+
+if __name__ == "__main__":
+    test_reader()


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->

This PR changes the SYNOP datareader to also work on german SYNOP station data instead of just the one from MetNorway. The following bullet points are an explanation of all my changes.

**The bullet points are partially outdated**

- added height dimension, which affected the base class as well
- German data does not need to handle missing values as they are already included as np.nan (e.g. ll. 164-166)
- German data is structured after time and station_id. Geoinfo has to be flattened to 1-D before usage (ll.105-113)
- German data dimensions needed to be transformed as they are (variables, spatial, time) instead of (variables, time, spatial) (ll. 231-238)
- I've added a file for testing, which will be removed after the review (The test only works on juwels, as the underlying data is only available there)

## Issue Number

This PR closes no issue, but is related to #862 

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
