### PR TITLE
add default streams + fix lead time error

### DIFF
--- a/config/evaluate/eval_config.yml
+++ b/config/evaluate/eval_config.yml
@@ -76,12 +76,14 @@ run_ids :
     #NEW: if "streams" is not specified, the default streams are used
   
   ###############################
-  
+
   #How to define custom variables different than default_streams (default_streams will be ignored for this run_id):
 
   jjc9ym62:
     label: "2 steps window"
     results_base_dir : "./results/"
+    epoch: 1 #optional: if not specified epoch 0 (in inference it is always 0) is used
+    rank: 2 #optional: if not specified rank 0 is used
     streams:
       ERA5:
         channels: ["2t", "10u", "10v"] 
@@ -112,8 +114,6 @@ run_ids :
     metrics_dir: "./merge_test/metrics/" #<------- VERY IMPORTANT
     label: "Merged Results"
     results_base_dir : "./results/"
-    epoch: 0
-    rank: 0
     streams:
       ERA5:
         channels: ["z_500", "t_850", "u_850", "v_850", "q_850"]
@@ -130,8 +130,6 @@ run_ids :
     type: "json" # <------- VERY IMPORTANT
     label: "WeatherGenerator"
     results_base_dir : "./results/"
-    epoch: 0
-    rank: 0
     streams:
       ERA5:
         channels: ["z_500", "t_850", "u_850", "v_850", "q_850"]

--- a/config/evaluate/eval_config.yml
+++ b/config/evaluate/eval_config.yml
@@ -34,49 +34,57 @@ evaluation:
   num_processes: 0  #options: int, "auto", 0 means no parallelism (default)
   # baseline: "ar40mckx"
 
+
+default_streams:
+  ERA5:
+    channels: ["2t", "10u"] #, "10v", "z_500", "t_850", "u_850", "v_850", "q_850", ]
+    evaluation:
+      forecast_step: "all"
+      sample: "all"
+      ensemble: "all" #supported: "all", "mean", [0,1,2]
+    plotting:
+      sample: [1, 3]
+      forecast_step: [1,3, 2]
+      ensemble: [0,2,5] #supported: "all", "mean", [0,1,2]
+      plot_maps: true
+      plot_target: false
+      plot_histograms: true
+      plot_animations: true
+  CERRA:
+    channels: ["z_500", "t_850", "u_850"] #, "blah"]
+    evaluation:
+      forecast_step: "all"
+      sample: "all"
+    plotting:
+      sample: [2, 3, 0]
+      forecast_step: [1,3, 4, 5]
+      plot_maps: true
+      plot_target: false
+      plot_histograms: true
+      plot_animations: true
+      
 run_ids :
   ar40mckx:
     label: "pretrained model ar40mckx"
     results_base_dir : "./results/"
-    mini_epoch: 0
-    rank: 0
-    streams:
-      ERA5:
-        channels: ["2t", "10u"] #, "10v", "z_500", "t_850", "u_850", "v_850", "q_850", ]
-        evaluation:
-          forecast_step: "all"
-          sample: "all"
-          ensemble: "all" #supported: "all", "mean", [0,1,2]
-        plotting:
-          sample: [1, 3]
-          forecast_step: [1,3, 2] #supported: "all", [1,2,3,...], "1-50" (equivalent of [1,2,3,...50])
-          ensemble: [0,2,5] #supported: "all", "mean", [0,1,2]
-          plot_maps: true
-          plot_target: false
-          plot_histograms: true
-          plot_animations: true
-      CERRA:
-        channels: ["z_500", "t_850", "u_850"] #, "blah"]
-        evaluation:
-          forecast_step: "all"
-          sample: "all"
-        plotting:
-          sample: [2, 3, 0]
-          forecast_step: [1,3, 4, 5]
-          plot_maps: true
-          plot_target: false
-          plot_histograms: true
-          plot_animations: true
+    #NEW: if "streams" is not specified, the default streams are used
+    
       
   c8g5katp:
     label: "2 steps window"
     results_base_dir : "./results/"
-    mini_epoch: 0
-    rank: 0
+    #NEW: if "streams" is not specified, the default streams are used
+  
+  ###############################
+  
+  #How to define custom variables different than default_streams (default_streams will be ignored for this run_id):
+
+  jjc9ym62:
+    label: "2 steps window"
+    results_base_dir : "./results/"
     streams:
       ERA5:
-        #climatology_path: "<path>/aifs-ea-an-oper-0001-mars-o96-1980-2020-6h-v6_climatology.zarr"
-        channels: ["2t", "10u", "10v"] #, "10v", "z_500", "t_850", "u_850", "v_850", "q_850", ]
+        channels: ["2t", "10u", "10v"] 
         evaluation:
           forecast_step: "all"
           sample: "all"
@@ -90,13 +98,18 @@ run_ids :
           plot_histograms: true
           plot_animations: true
 
+  
+
+  #WeatherGeneratorMerge example:
+  ###############################
+
   #Example of syntax to stack multiple runs over the ensemble dimension  
-  merge_test: <------ This is the new run_id name of the merged dataset. NB. you always need to specify one
-    type: "merge" <------- VERY IMPORTANT
+  merge_test: #<------ This is the new run_id name of the merged dataset. NB. you always need to specify one
+    type: "merge" # <------- VERY IMPORTANT
     merge_run_ids:
       - so67dku4
       - c9cg8ql3
-    metrics_dir: "./merge_test/metrics/" <------- VERY IMPORTANT
+    metrics_dir: "./merge_test/metrics/" #<------- VERY IMPORTANT
     label: "Merged Results"
     results_base_dir : "./results/"
     epoch: 0
@@ -109,9 +122,12 @@ run_ids :
           sample: [0, 1, 2, 3]
           ensemble: "all" 
 
+  #WeatherGeneratorJSON example:
+  ##############################
+
   #Example of syntax to run over pre-computed scores when the .zarr output is not available anymore
   so67dku1:
-    type: "json"
+    type: "json" # <------- VERY IMPORTANT
     label: "WeatherGenerator"
     results_base_dir : "./results/"
     epoch: 0
@@ -123,6 +139,10 @@ run_ids :
           forecast_step: [2,4,6] 
           sample: [0, 1, 2, 3]
           ensemble: "all" #supported
+
+
+  # CSV Reader example:
+  ###############################
 
   #ADVANCED (please handle with care): example of how to use the csv reader to Plot PanguWeather scores computed with quaver
   pangu:

--- a/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
@@ -39,8 +39,8 @@ class WeatherGenReader(Reader):
         super().__init__(eval_cfg, run_id, private_paths)
 
         # TODO: remove backwards compatibility to "epoch" in Feb. 2026
-        self.mini_epoch = eval_cfg.get("mini_epoch", eval_cfg.get("epoch"))
-        self.rank = eval_cfg.rank
+        self.mini_epoch = eval_cfg.get("mini_epoch", 0)
+        self.rank = eval_cfg.get("rank", 0)
         # Load model configuration and set (run-id specific) directories
         self.inference_cfg = self.get_inference_config()
 
@@ -512,15 +512,32 @@ class WeatherGenZarrReader(WeatherGenReader):
 
     ######## reader utils ########
 
-    def add_lead_time_coord(self, da: xr.DataArray) -> xr.DataArray:
+    def add_lead_time_coord(self, da: xr.DataArray, sample_dim="ipoint") -> xr.DataArray:
         """
         Add lead_time coordinate computed as:
         valid_time - source_interval_end
 
         lead_time has dims (sample, ipoint) and dtype timedelta64[ns].
+
+        Parameters
+        ----------
+        da :
+            Input DataArray
+        sample_dim :
+            The name of the sample dimension (default is "ipoint"). collapse over this
+            dimension and **keep** the others (e.g. sample).
+        Returns
+        -------
+            Returns a Dataset with an added lead_time coordinate.
         """
 
-        lead_time = np.unique(da["valid_time"]) - da["source_interval_start"]
+        vt = da["valid_time"]
+        sis = da["source_interval_start"]
+
+        vt_reduced = vt.min(dim=[d for d in vt.dims if d != sample_dim])
+
+        lead_time = vt_reduced - sis
+
         return da.assign_coords(lead_time=lead_time)
 
     def scale_z_channels(self, data: xr.DataArray, stream: str) -> xr.DataArray:
@@ -662,7 +679,7 @@ def _force_consistent_grids(ref: list[xr.DataArray]) -> xr.DataArray:
     sort_idx = np.lexsort((ref_lon.values, ref_lat.values))
     npoints = sort_idx.size
     aligned = []
-    for a in ref:
+    for i, a in enumerate(ref):
         a_sorted = a.isel(ipoint=sort_idx)
 
         a_sorted = a_sorted.assign_coords(
@@ -670,6 +687,10 @@ def _force_consistent_grids(ref: list[xr.DataArray]) -> xr.DataArray:
             lat=("ipoint", ref_lat.values[sort_idx]),
             lon=("ipoint", ref_lon.values[sort_idx]),
         )
+
+        if "sample" not in a_sorted.dims:
+            a_sorted = a_sorted.expand_dims(sample=[i])
+
         aligned.append(a_sorted)
 
     return xr.concat(aligned, dim="sample")

--- a/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
@@ -512,7 +512,7 @@ class WeatherGenZarrReader(WeatherGenReader):
 
     ######## reader utils ########
 
-    def add_lead_time_coord(self, da: xr.DataArray, sample_dim="ipoint") -> xr.DataArray:
+    def add_lead_time_coord(self, da: xr.DataArray, sample_dim="sample") -> xr.DataArray:
         """
         Add lead_time coordinate computed as:
         valid_time - source_interval_end
@@ -524,8 +524,8 @@ class WeatherGenZarrReader(WeatherGenReader):
         da :
             Input DataArray
         sample_dim :
-            The name of the sample dimension (default is "ipoint"). collapse over this
-            dimension and **keep** the others (e.g. sample).
+            The name of the sample dimension (default is "sample") which should be kept.
+            Collapse over the others.
         Returns
         -------
             Returns a Dataset with an added lead_time coordinate.

--- a/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
@@ -280,6 +280,8 @@ def evaluate_from_config(
     plot_score_maps = cfg.evaluation.get("plot_score_maps", False)
     global_plotting_opts = cfg.get("global_plotting_options", {})
     use_parallel = cfg.evaluation.get("num_processes", 0)
+    default_streams = cfg.get("default_streams", {})
+
     if use_parallel == "auto":
         num_processes = mp.cpu_count()
     elif isinstance(use_parallel, int):
@@ -302,9 +304,14 @@ def evaluate_from_config(
     # Build tasks per stream
     for run_id, run in runs.items():
         type_ = run.get("type", "zarr")
-        reader = get_reader(
-            type_, run, run_id, private_paths, cfg.evaluation.regions, cfg.evaluation.metrics
-        )
+
+        if "streams" not in run:
+            run["streams"] = default_streams
+
+        regions = cfg.evaluation.regions
+        metrics = cfg.evaluation.metrics
+
+        reader = get_reader(type_, run, run_id, private_paths, regions, metrics)
 
         for stream in reader.streams:
             tasks.append(

--- a/src/weathergen/model/model_interface.py
+++ b/src/weathergen/model/model_interface.py
@@ -62,7 +62,7 @@ def init_model_and_shard(
         if re.fullmatch(cf.freeze_modules, name) is not None:
             logger.info(f"Froze weights {name}")
             freeze_weights(module)
-        
+
     # TODO: this should be handled in the encoder to be close where q_cells is defined
     if "q_cells" in cf.freeze_modules:
         model.encoder.q_cells.requires_grad = False


### PR DESCRIPTION
## Description

New features:

- add `default_streams` option to facilitate multi-run comparisons
- add default options for rank and epoch 
- fix error with lead_time in case of 1 sample (it would be great if more people can test this one)


## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/1497
Closes https://github.com/ecmwf/WeatherGenerator/issues/1627

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
