### PR TITLE
remove misleading logging of `mini_epoch`

### DIFF
--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -285,8 +285,6 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
             if self.forecast_policy != "random"
             else self.forecast_steps.max()
         )
-        if fsm > 0:
-            logger.info(f"forecast_steps at mini_epoch={self.mini_epoch} : {fsm}")
 
         # data
         index_range = self.time_window_handler.get_index_range()

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -285,6 +285,8 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
             if self.forecast_policy != "random"
             else self.forecast_steps.max()
         )
+        if fsm > 0:
+            logger.info(f"forecast_steps : {fsm}")
 
         # data
         index_range = self.time_window_handler.get_index_range()


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->

When continuing runs we track both the mini_epoch since the beginning of the first run and since the beginning of the current run. Through this PR the logging of mini_epoch since the beginning of a current run, which was misleading.

CC @MatKbauer 

## Issue Number

Closes #848 

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
