### PR TITLE
Correct a bug creating aggr issues on scores

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
@@ -512,7 +512,7 @@ class WeatherGenZarrReader(WeatherGenReader):
 
     ######## reader utils ########
 
-    def add_lead_time_coord(self, da: xr.DataArray, sample_dim="ipoint") -> xr.DataArray:
+    def add_lead_time_coord(self, da: xr.DataArray, sample_dim="sample") -> xr.DataArray:
         """
         Add lead_time coordinate computed as:
         valid_time - source_interval_end
@@ -524,8 +524,8 @@ class WeatherGenZarrReader(WeatherGenReader):
         da :
             Input DataArray
         sample_dim :
-            The name of the sample dimension (default is "ipoint"). collapse over this
-            dimension and **keep** the others (e.g. sample).
+            The name of the sample dimension (default is "sample") which should be kept.
+            Collapse over the others.
         Returns
         -------
             Returns a Dataset with an added lead_time coordinate.

--- a/src/weathergen/model/model_interface.py
+++ b/src/weathergen/model/model_interface.py
@@ -62,7 +62,7 @@ def init_model_and_shard(
         if re.fullmatch(cf.freeze_modules, name) is not None:
             logger.info(f"Froze weights {name}")
             freeze_weights(module)
-        
+
     # TODO: this should be handled in the encoder to be close where q_cells is defined
     if "q_cells" in cf.freeze_modules:
         model.encoder.q_cells.requires_grad = False


### PR DESCRIPTION
## Description

There was a bug where the default value of `sample_dim` was set to be `ipoint`. As a result, `sample` collapses in 

`vt_reduced = vt.min(dim=[d for d in vt.dims if d != sample_dim])`

Then `lead_time` still has dimensions `(ipoint, sample)` and as a result when scores are calculated ( there we aggregate over `ipoint` ), the `lead_time` collapses and is not plotted later on.