### PR TITLE
Fix bug for missing run_id path in model path

### DIFF
--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -227,7 +227,7 @@ def load_run_config(run_id: str, mini_epoch: int | None, model_path: str | None)
         if model_path is None:
             path = get_path_model(run_id=run_id)
         else:
-            path = Path(model_path)
+            path = Path(model_path) / run_id
 
         fname = path / _get_model_config_file_read_name(run_id, mini_epoch)
         if not fname.exists():
@@ -260,6 +260,7 @@ def _get_model_config_file_write_name(run_id: str, mini_epoch: int | None):
 
     return f"model_{run_id}{mini_epoch_str}.json"
 
+
 def _get_model_config_file_read_name(run_id: str, mini_epoch: int | None, use_old_name=False):
     """Generate the filename for reading a model config file."""
     if mini_epoch is None:
@@ -267,11 +268,12 @@ def _get_model_config_file_read_name(run_id: str, mini_epoch: int | None, use_ol
     elif mini_epoch == -1:
         mini_epoch_str = "_latest"
     elif use_old_name:
-        mini_epoch_str = f"_epoch{mini_epoch:05d}" # TODO remove compatibility
+        mini_epoch_str = f"_epoch{mini_epoch:05d}"  # TODO remove compatibility
     else:
         mini_epoch_str = f"_chkpt{mini_epoch:05d}"
 
     return f"model_{run_id}{mini_epoch_str}.json"
+
 
 def get_model_results(run_id: str, mini_epoch: int, rank: int) -> Path:
     """


### PR DESCRIPTION
## Description

This is a minor PR, it just adds the `run_id ` to the (default) model path


## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/1702

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [X] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
