### PR TITLE
Fix output generation during inference

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -1527,7 +1527,6 @@ class BarPlots:
             squeeze=False,
         )
         ax = ax.flatten()
-        single_run = False
         if self.baseline and self.baseline in runs:
             baseline_idx = runs.index(self.baseline)
             runs = [runs[baseline_idx]] + runs[:baseline_idx] + runs[baseline_idx + 1 :]
@@ -1539,7 +1538,6 @@ class BarPlots:
             ones_array = xr.full_like(data[0], 1.0)
             runs = [""] + runs
             data = [ones_array] + data
-            single_run = True
 
 
         for run_index in range(1, len(runs)):

--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -48,7 +48,7 @@ def inference_from_args(argl: list[str]):
             start_date=args.start_date,
             end_date=args.end_date,
             samples_per_mini_epoch=args.samples,
-            output=dict(write_num_samples=args.samples if args.save_samples else 0),
+            output=dict(num_samples=args.samples if args.save_samples else 0),
             streams_output=args.streams_output,
         )
     }


### PR DESCRIPTION
## Description

After the config update, no outputs are written to disk during inference because `write_num_samples` was renamed to `num_samples` in the `output` dictionary. This PR updates the inference entry point accordingly.


## Issue Number

Closes #1706 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
