### PR TITLE
Fix duplicate run_id in results and runplots paths

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
@@ -26,6 +26,7 @@ from weathergen.common.config import (
     load_run_config,
 )
 from weathergen.common.io import zarrio_reader
+
 from weathergen.evaluate.io.io_reader import Reader, ReaderOutput
 from weathergen.evaluate.scores.score_utils import to_list
 from weathergen.evaluate.utils.derived_channels import DeriveChannels
@@ -66,7 +67,7 @@ class WeatherGenReader(Reader):
         )
         # for backward compatibility allow metric_dir to be specified in the run config
         self.metrics_dir = Path(
-            self.eval_cfg.get("metrics_dir", self.metrics_base_dir / self.run_id / "evaluation")
+            self.eval_cfg.get("metrics_dir", self.metrics_base_dir / "evaluation")
         )
 
     def get_inference_config(self):

--- a/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
@@ -61,8 +61,8 @@ class WeatherGenReader(Reader):
         self.step_hrs = self.inference_cfg.get("step_hrs", 1)
 
         self.results_dir, self.runplot_dir = (
-            Path(self.results_base_dir) / self.run_id,
-            Path(self.runplot_base_dir) / self.run_id,
+            Path(self.results_base_dir),
+            Path(self.runplot_base_dir),
         )
         # for backward compatibility allow metric_dir to be specified in the run config
         self.metrics_dir = Path(
@@ -693,7 +693,7 @@ def _force_consistent_grids(ref: list[xr.DataArray]) -> xr.DataArray:
             a_sorted = a_sorted.expand_dims(sample=[i])
 
         aligned.append(a_sorted)
-    
+
     return xr.concat(aligned, dim="sample").assign_coords({"sample": samples})
 
 

--- a/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
@@ -26,7 +26,6 @@ from weathergen.common.config import (
     load_run_config,
 )
 from weathergen.common.io import zarrio_reader
-
 from weathergen.evaluate.io.io_reader import Reader, ReaderOutput
 from weathergen.evaluate.scores.score_utils import to_list
 from weathergen.evaluate.utils.derived_channels import DeriveChannels

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -1539,12 +1539,8 @@ class BarPlots:
             runs = [""] + runs
             data = [ones_array] + data
 
-
         for run_index in range(1, len(runs)):
-
-            score, channels_per_comparison = self.calc_ratio_per_run_id(
-                data, channels, run_index
-            )
+            score, channels_per_comparison = self.calc_ratio_per_run_id(data, channels, run_index)
             if len(score) > 0:
                 ax[run_index - 1].barh(
                     np.arange(len(score)),
@@ -1554,9 +1550,7 @@ class BarPlots:
                     edgecolor="black",
                     linewidth=0.5,
                 )
-                ax[run_index - 1].set_yticks(
-                    np.arange(len(score)), labels=channels_per_comparison
-                )
+                ax[run_index - 1].set_yticks(np.arange(len(score)), labels=channels_per_comparison)
                 ax[run_index - 1].invert_yaxis()
 
                 xlabel = (
@@ -1625,7 +1619,7 @@ class BarPlots:
         """
         ratio_score = []
         channels_per_comparison = []
-        
+
         for _, var in enumerate(channels):
             if var not in data[0].channel.values or var not in data[run_index].channel.values:
                 continue
@@ -1636,12 +1630,12 @@ class BarPlots:
             baseline_score, model_score = calculate_average_over_dim(x_dim, baseline_var, data_var)
 
             ratio_score.append(model_score / baseline_score)
-        
+
         if np.allclose(baseline_score, 1.0, atol=1e-6):
             ratio_score = np.array(ratio_score)
         else:
             ratio_score = np.array(ratio_score) - 1
-        
+
         return ratio_score, channels_per_comparison
 
     def colors(self, ratio_score: np.array, metric: str) -> list[tuple]:

--- a/packages/evaluate/src/weathergen/evaluate/utils/utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils/utils.py
@@ -199,7 +199,7 @@ def calc_scores_per_stream(
             }
             if "ens" in combined_metrics.dims:
                 criteria["ens"] = combined_metrics.ens.values
-        
+
             metric_stream.loc[criteria] = combined_metrics
 
             lead_time_map[fstep] = (


### PR DESCRIPTION
## Description

See issue Closes https://github.com/ecmwf/WeatherGenerator/issues/1713 for description. This is a minor PR.

## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/1713

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
