### PR TITLE
added several aux_info options and remove aux_info=None hardcoding

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -60,7 +60,8 @@ fe_num_heads: 16
 fe_dropout_rate: 0.1
 fe_with_qk_lnorm: True
 fe_layer_norm_after_blocks: []  # Index starts at 0. Thus, [3] adds a LayerNorm after the fourth layer
-fe_impute_latent_noise_std: 0.0  # 1e-4
+fe_aux_encoding_type: None # None, fstep, positional, fourier, or learnable
+e_impute_latent_noise_std: 0.0  # 1e-4
 # currently fixed to 1.0 (due to limitations with flex_attention and triton)
 forecast_att_dense_rate: 1.0
 

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -399,8 +399,28 @@ class ForecastingEngine(torch.nn.Module):
         self.cf = cf
         self.num_healpix_cells = num_healpix_cells
         self.fe_blocks = torch.nn.ModuleList()
-
         global_rate = int(1 / self.cf.forecast_att_dense_rate)
+        fe_aux_encoding_type = cf.get("fe_aux_encoding_type", "fstep")
+        if fe_aux_encoding_type == "fstep":
+            self.fstep_embedder = nn.Identity()
+            dim_aux = 1
+        elif fe_aux_encoding_type == "None":
+            self.fstep_embedder = nn.Identity()
+            dim_aux = None
+        elif fe_aux_encoding_type == "positional":
+            dim_aux = cf.get("fe_aux_channels", 64)
+            self.fstep_embedder = PositionalEmbedding(dim_aux)
+        elif fe_aux_encoding_type == "fourier":
+            dim_aux = cf.get("fe_aux_channels", 64)
+            self.fstep_embedder = FourierEmbedding(dim_aux)
+        elif fe_aux_encoding_type == "learnable":
+            dim_aux = cf.get("fe_aux_channels", 64)
+            self.fstep_embedder = LearnableEmbedding(dim_aux)
+        else:
+            raise NotImplementedError(
+                f"{fe_aux_encoding_type} is not known, options are ",
+                "identity, zero, positional, fourier or learnable",
+            )
         if mode_cfg.get("forecast", {}).get("policy") is not None:
             for i in range(self.cf.fe_num_blocks):
                 # Alternate between global and local attention
@@ -462,18 +482,17 @@ class ForecastingEngine(torch.nn.Module):
             block.apply(init_weights_final)
 
     def forward(self, tokens, fstep):
+        fstep_embed = self.fstep_embedder(torch.tensor([fstep], device=tokens.device))
         if self.training:
             # Impute noise to the latent state
             noise_std = self.cf.get("fe_impute_latent_noise_std", 0.0)
             if noise_std > 0.0:
                 tokens = tokens + torch.randn_like(tokens) * torch.norm(tokens) * noise_std
-
-        aux_info = None
         for _b_idx, block in enumerate(self.fe_blocks):
             if isinstance(block, torch.nn.modules.normalization.LayerNorm):
                 tokens = block(tokens)
             else:
-                tokens = block(tokens, aux_info)
+                tokens = block(tokens, fstep_embed)
         return tokens
 
 

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -410,7 +410,7 @@ class ForecastingEngine(torch.nn.Module):
             self.fstep_embedder = nn.Identity()
             dim_aux = 1
         elif fe_aux_encoding_type == "None":
-            self.fstep_embedder = nn.Identity()
+            self.fstep_embedder = lambda x: None
             dim_aux = None
         elif fe_aux_encoding_type == "positional":
             dim_aux = cf.get("fe_aux_channels", 64)
@@ -424,7 +424,7 @@ class ForecastingEngine(torch.nn.Module):
         else:
             raise NotImplementedError(
                 f"{fe_aux_encoding_type} is not known, options are ",
-                "identity, zero, positional, fourier or learnable",
+                "fstep, None, positional, fourier or learnable",
             )
         if mode_cfg.get("forecast", {}).get("policy") is not None:
             for i in range(self.cf.fe_num_blocks):
@@ -487,7 +487,7 @@ class ForecastingEngine(torch.nn.Module):
             block.apply(init_weights_final)
 
     def forward(self, tokens, fstep):
-        fstep_embed = self.fstep_embedder(torch.tensor([fstep], device=tokens.device))
+        fstep_embed = self.fstep_embedder(torch.tensor([fstep], device=tokens.device, dtype=get_dtype(self.cf.attention_dtype)))
         if self.training:
             # Impute noise to the latent state
             noise_std = self.cf.get("fe_impute_latent_noise_std", 0.0)

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -27,6 +27,11 @@ from weathergen.model.embeddings import (
     StreamEmbedLinear,
     StreamEmbedTransformer,
 )
+from weathergen.model.positional_encoding import (
+        PositionalEmbedding,
+        FourierEmbedding,
+        LearnableEmbedding
+)
 from weathergen.model.layers import MLP
 from weathergen.model.utils import ActivationFactory
 from weathergen.utils.utils import get_dtype

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -27,12 +27,12 @@ from weathergen.model.embeddings import (
     StreamEmbedLinear,
     StreamEmbedTransformer,
 )
-from weathergen.model.positional_encoding import (
-        PositionalEmbedding,
-        FourierEmbedding,
-        LearnableEmbedding
-)
 from weathergen.model.layers import MLP
+from weathergen.model.positional_encoding import (
+    FourierEmbedding,
+    LearnableEmbedding,
+    PositionalEmbedding,
+)
 from weathergen.model.utils import ActivationFactory
 from weathergen.utils.utils import get_dtype
 

--- a/src/weathergen/model/positional_encoding.py
+++ b/src/weathergen/model/positional_encoding.py
@@ -13,6 +13,45 @@ import numpy as np
 import torch
 
 
+class PositionalEmbedding(torch.nn.Module):
+    def __init__(self, num_channels, max_positions=10000, endpoint=False):
+        super().__init__()
+        self.num_channels = num_channels
+        self.max_positions = max_positions
+        self.endpoint = endpoint
+
+    def forward(self, x):
+        freqs = torch.arange(
+            start=0, end=self.num_channels // 2, dtype=torch.float32, device=x.device
+        )
+        freqs = freqs / (self.num_channels // 2 - (1 if self.endpoint else 0))
+        freqs = (1 / self.max_positions) ** freqs
+        x = x.ger(freqs.to(x.dtype))
+        x = torch.cat([x.cos(), x.sin()], dim=1)
+        return x
+
+
+class FourierEmbedding(torch.nn.Module):
+    def __init__(self, num_channels, scale=16):
+        super().__init__()
+        self.register_buffer("freqs", torch.randn(num_channels // 2) * scale)
+
+    def forward(self, x):
+        x = x.ger((2 * np.pi * self.freqs).to(x.dtype))
+        x = torch.cat([x.cos(), x.sin()], dim=1)
+        return x
+
+
+class LearnableEmbedding(torch.nn.Module):
+    def __init__(self, num_channels):
+        super().__init__()
+        self.embedding = torch.nn.Embedding(10000, num_channels)
+
+    def forward(self, x):
+        x = self.embedding(x.int())
+        return x
+
+
 ####################################################################################################
 def positional_encoding_harmonic(x):
     """space time harmonic positional encoding"""


### PR DESCRIPTION
## Description

Added several `aux_info` type for forecasting engine.
It also takes care of hardcoding it to None


## Issue Number

Closes #1630  

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
