### PR TITLE
Change forecasting.masking_strategy from 'random' to 'forecast'

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -180,7 +180,7 @@ training_config:
   model_input: {
     "forecasting" : {
       # masking strategy: "random", "healpix", "forecast"
-      masking_strategy: "random",
+      masking_strategy: "forecast",
       num_samples: 2,
       masking_strategy_config: { rate: 0.5, rate_sampling: False }
       },

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -181,8 +181,6 @@ training_config:
     "forecasting" : {
       # masking strategy: "random", "healpix", "forecast"
       masking_strategy: "forecast",
-      num_samples: 2,
-      masking_strategy_config: { rate: 0.5, rate_sampling: False }
       },
     }
 


### PR DESCRIPTION
## Description

When `forecast_offset ` is 1 then `forecasting.masking_strategy ` should be `"forecast"`.


## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/1725

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
