### PR TITLE
[1687][model] Flag for setting eval mode (on develop)

### DIFF
--- a/src/weathergen/model/model_interface.py
+++ b/src/weathergen/model/model_interface.py
@@ -70,6 +70,9 @@ def init_model_and_shard(
         if re.fullmatch(cf.freeze_modules, name) is not None:
             logger.info(f"Froze weights {name}")
             freeze_weights(module)
+            module.eval()
+        else:
+            logger.info(f"Did not freeze weights {name}")
 
     # TODO: this should be handled in the encoder to be close where q_cells is defined
     if "q_cells" in cf.freeze_modules:

--- a/src/weathergen/model/model_interface.py
+++ b/src/weathergen/model/model_interface.py
@@ -70,7 +70,6 @@ def init_model_and_shard(
         if re.fullmatch(cf.freeze_modules, name) is not None:
             logger.info(f"Froze weights {name}")
             freeze_weights(module)
-            module.eval()
         else:
             logger.info(f"Did not freeze weights {name}")
 

--- a/src/weathergen/model/model_interface.py
+++ b/src/weathergen/model/model_interface.py
@@ -11,7 +11,6 @@
 
 import itertools
 import logging
-import re
 from pathlib import Path
 
 import omegaconf
@@ -33,10 +32,7 @@ from weathergen.model.attention import (
 from weathergen.model.ema import EMAModel
 from weathergen.model.layers import MLP
 from weathergen.model.model import Model, ModelParams
-from weathergen.model.utils import (
-    freeze_weights,
-    apply_fct_to_blocks
-)
+from weathergen.model.utils import apply_fct_to_blocks, freeze_weights
 from weathergen.train.target_and_aux_module_base import PhysicalTargetAndAux
 from weathergen.train.target_and_aux_ssl_teacher import EMATeacher
 from weathergen.utils.distributed import is_root

--- a/src/weathergen/model/model_interface.py
+++ b/src/weathergen/model/model_interface.py
@@ -33,7 +33,10 @@ from weathergen.model.attention import (
 from weathergen.model.ema import EMAModel
 from weathergen.model.layers import MLP
 from weathergen.model.model import Model, ModelParams
-from weathergen.model.utils import freeze_weights
+from weathergen.model.utils import (
+    freeze_weights,
+    apply_fct_to_blocks
+)
 from weathergen.train.target_and_aux_module_base import PhysicalTargetAndAux
 from weathergen.train.target_and_aux_ssl_teacher import EMATeacher
 from weathergen.utils.distributed import is_root
@@ -62,16 +65,7 @@ def init_model_and_shard(
         model = get_model(cf, training_mode, dataset, overrides)
 
     # freeze request model part
-    for name, module in model.named_modules():
-        name = module.name if hasattr(module, "name") else name
-        # avoid the whole model element which has name ''
-        if name == "":
-            continue
-        if re.fullmatch(cf.freeze_modules, name) is not None:
-            logger.info(f"Froze weights {name}")
-            freeze_weights(module)
-        else:
-            logger.info(f"Did not freeze weights {name}")
+    apply_fct_to_blocks(model, cf.freeze_modules, freeze_weights)
 
     # TODO: this should be handled in the encoder to be close where q_cells is defined
     if "q_cells" in cf.freeze_modules:

--- a/src/weathergen/model/utils.py
+++ b/src/weathergen/model/utils.py
@@ -8,7 +8,9 @@
 # nor does it submit to any jurisdiction.
 
 
+import logging
 import re
+
 import torch
 import torch.nn as nn
 

--- a/src/weathergen/model/utils.py
+++ b/src/weathergen/model/utils.py
@@ -7,8 +7,12 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+
+import re
 import torch
 import torch.nn as nn
+
+logger = logging.getLogger(__name__)
 
 
 #########################################
@@ -19,8 +23,34 @@ def get_num_parameters(block):
 
 #########################################
 def freeze_weights(block):
+    if hasattr(block, "name"):
+        logger.info(f"Freeze block {block.name}")
     for p in block.parameters():
         p.requires_grad = False
+
+
+#########################################
+def set_to_eval(block):
+    if hasattr(block, "name"):
+        logger.info(f"Set block {block.name} to eval mode")
+    block.eval()
+
+
+#########################################
+def apply_fct_to_blocks(model, blocks, fct):
+    """
+    Apply a function to specific blocks of a model.
+    Args:
+        model : model instance with attribute named_modules
+        blocks : regex pattern to match block names
+        fct : function to apply to matching blocks
+    """
+
+    for name, module in model.named_modules():
+        name = module.name if hasattr(module, "name") else name
+        # avoid the whole model element which has name ''
+        if (re.fullmatch(blocks, name) is not None) and (name != ""):
+            fct(module)
 
 
 #########################################

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -10,7 +10,6 @@
 # nor does it submit to any jurisdiction.
 import copy
 import logging
-import re
 import time
 
 import numpy as np
@@ -29,6 +28,7 @@ from weathergen.model.model_interface import (
     get_target_aux_calculator,
     init_model_and_shard,
 )
+from weathergen.model.utils import apply_fct_to_blocks, set_to_eval
 from weathergen.train.loss_calculator import LossCalculator
 from weathergen.train.lr_scheduler import LearningRateScheduler
 from weathergen.train.trainer_base import TrainerBase
@@ -406,14 +406,7 @@ class Trainer(TrainerBase):
         cf = self.cf
         self.model.train()
 
-        # TODO: ablate this vs. just using no_grad
-        for name, module in self.model.named_modules():
-            name = module.name if hasattr(module, "name") else name
-            # avoid the whole model element which has name ''
-            if name == "":
-                continue
-            if re.fullmatch(cf.freeze_modules, name) is not None:
-                module.eval()
+        apply_fct_to_blocks(self.model, cf.freeze_modules, set_to_eval)
 
         dataset_iter = iter(self.data_loader)
 

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -11,6 +11,7 @@
 import copy
 import logging
 import time
+import re
 
 import numpy as np
 import torch
@@ -404,6 +405,15 @@ class Trainer(TrainerBase):
 
         cf = self.cf
         self.model.train()
+
+        #TODO: ablate this vs. just using no_grad
+        for name, module in self.model.named_modules():
+            name = module.name if hasattr(module, "name") else name
+            # avoid the whole model element which has name ''
+            if name == "":
+                continue
+            if re.fullmatch(cf.freeze_modules, name) is not None:
+                module.eval()
 
         dataset_iter = iter(self.data_loader)
 

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -10,8 +10,8 @@
 # nor does it submit to any jurisdiction.
 import copy
 import logging
-import time
 import re
+import time
 
 import numpy as np
 import torch
@@ -406,7 +406,7 @@ class Trainer(TrainerBase):
         cf = self.cf
         self.model.train()
 
-        #TODO: ablate this vs. just using no_grad
+        # TODO: ablate this vs. just using no_grad
         for name, module in self.model.named_modules():
             name = module.name if hasattr(module, "name") else name
             # avoid the whole model element which has name ''


### PR DESCRIPTION
## Description

This PR introduces the flag described in https://github.com/ecmwf/WeatherGenerator/issues/1687.


## Issue Number

Closes #1687 


## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
