### PR TITLE
[DRAFT] Handle None preds when no target channels for a stream

### DIFF
--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -60,6 +60,20 @@ def write_output(
             preds_s, targets_s, t_coords_s, t_times_s = [], [], [], []
             targets_lens[-1] += [[]]
 
+            # for the case where no target channels are defined
+            # for a stream, e.g., when only using it as input
+            # we produce None preds and we need to handle this case
+            if preds is None or targets is None:
+                num_channels = len(stream_info.get("val_target_channels", []))
+                ens_size = int(stream_info.get("pred_head", {}).get("ens_size", 1))
+
+                preds_all[-1] += [np.zeros((ens_size, 0, num_channels), dtype=np.float32)]
+                targets_all[-1] += [np.zeros((0, num_channels), dtype=np.float32)]
+                targets_coords_all[-1] += [np.zeros((0, 2), dtype=np.float32)]
+                targets_times_all[-1] += [np.array([], dtype="datetime64[ns]")]
+                targets_lens[-1] += [[0 for _ in range(batch_size)]]
+                continue
+
             for i_batch, (pred, target) in enumerate(zip(preds, targets, strict=True)):
                 pred, target = pred.to(fp32), target.to(fp32)
 

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -71,7 +71,7 @@ def write_output(
                 targets_all[-1] += [np.zeros((0, num_channels), dtype=np.float32)]
                 targets_coords_all[-1] += [np.zeros((0, 2), dtype=np.float32)]
                 targets_times_all[-1] += [np.array([], dtype="datetime64[ns]")]
-                targets_lens[-1] += [[0 for _ in range(batch_size)]]
+                targets_lens[-1][-1] = [0 for _ in range(batch_size)]
                 continue
 
             for i_batch, (pred, target) in enumerate(zip(preds, targets, strict=True)):


### PR DESCRIPTION
Illustrative hack to fix current problem of generating None preds with no target channels for e.g. synop physical prediction for finetuned JEPA trained model case. Not sure that this works completely, currently writing out zarrs with 0s at evaluation.


## Description

Some illustrative code to highlight the issue of None preds in some fine-tuning of JEPA models cases.

## Issue Number

Closes #1724 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
