### PR TITLE
fix base config flag when running launch slurm

### DIFF
--- a/src/weathergen/utils/cli.py
+++ b/src/weathergen/utils/cli.py
@@ -116,10 +116,12 @@ def _add_general_arguments(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--base-config",
         type=Path,
+        nargs="?",
         help=(
             "Path to the base configuration file."
             "If not provided, ./config/default_config.yml is used."
         ),
+        default=None,
     )
 
 


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->
closes #1737,
goes together with [!117](https://gitlab.jsc.fz-juelich.de/esde/WeatherGenerator-private/-/merge_requests/117)

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
