### PR TITLE
[1332][infra] Remove getattr() and prevent future use

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ ignore = [
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "numpy.ndarray".msg = "Do not use 'ndarray' to describe a numpy array type, it is a function. Use numpy.typing.NDArray or numpy.typing.NDArray[np.float32] for example"
+"builtins.getattr".msg = "getattr() is not allowed"
 
 [tool.ruff.format]
 # Use Unix `\n` line endings for all files

--- a/src/weathergen/datasets/tokenizer_masking.py
+++ b/src/weathergen/datasets/tokenizer_masking.py
@@ -316,12 +316,10 @@ class TokenizerMasking(Tokenizer):
         if max_num_targets is None or max_num_targets <= 0 or num_points <= max_num_targets:
             return None
 
-        rng = getattr(self, "rng", None)
-        if rng is None:
-            rng = np.random.default_rng()
-            self.rng = rng
+        if self.rng is None:
+            self.rng = np.random.default_rng()
 
-        selected = np.sort(rng.choice(num_points, max_num_targets, replace=False))
+        selected = np.sort(self.rng.choice(num_points, max_num_targets, replace=False))
 
         return torch.from_numpy(selected).to(torch.long)
 

--- a/src/weathergen/train/loss_calculator.py
+++ b/src/weathergen/train/loss_calculator.py
@@ -67,7 +67,7 @@ class LossCalculator:
                     [
                         (
                             params.get("weight", 1.0),
-                            getattr(LossModules, params.type)(
+                            LossModules.__dict__[params.type](
                                 cf, mode_cfg, stage, self.device, **params.loss_fcts
                             ),
                         )

--- a/src/weathergen/train/loss_modules/loss_module_physical.py
+++ b/src/weathergen/train/loss_modules/loss_module_physical.py
@@ -59,7 +59,7 @@ class LossPhysical(LossModuleBase):
         # dynamically load loss functions based on configuration and stage
         self.loss_fcts = [
             [
-                getattr(loss_fns, name),
+                loss_fns.__dict__[name],
                 params.get("weight", 1.0),
                 name,
             ]
@@ -95,7 +95,8 @@ class LossPhysical(LossModuleBase):
         timestep_weight_config = self.mode_cfg.get("forecast", {}).get("timestep_weight", {})
         if len(timestep_weight_config) == 0:
             return [1.0 for _ in range(len_forecast_steps)]
-        weights_timestep_fct = getattr(loss_fns, list(timestep_weight_config.keys())[0])
+        weights_timestep_fct_name = list(timestep_weight_config.keys())[0]
+        weights_timestep_fct = loss_fns.__dict__[weights_timestep_fct_name]
         decay_factor = list(timestep_weight_config.values())[0]["decay_factor"]
         return weights_timestep_fct(len_forecast_steps, decay_factor)
 
@@ -103,7 +104,7 @@ class LossPhysical(LossModuleBase):
         location_weight_type = stream_info.get("location_weight", None)
         if location_weight_type is None:
             return None
-        weights_locations_fct = getattr(loss_fns, location_weight_type)
+        weights_locations_fct = loss_fns.__dict__[location_weight_type]
         weights_locations = weights_locations_fct(target_coords)
         weights_locations = weights_locations.to(device=self.device, non_blocking=True)
 

--- a/src/weathergen/utils/better_abc.py
+++ b/src/weathergen/utils/better_abc.py
@@ -29,11 +29,17 @@ class ABCMeta(NativeABCMeta):
     def __call__(cls, *args, **kwargs):
         instance = NativeABCMeta.__call__(cls, *args, **kwargs)
         # pylint: disable-next=attribute-defined-outside-init
-        abstract_attributes = {
-            name
-            for name in dir(instance)
-            if hasattr(getattr(instance, name), "__is_abstract_attribute__")
-        }
+        abstract_attributes = set()
+
+        for name in dir(instance):
+            # Search the attribute name in the class hierarchy
+            for base in type(instance).__mro__:
+                if name in base.__dict__:
+                    attr = base.__dict__[name]
+                    if hasattr(attr, "__is_abstract_attribute__"):
+                        abstract_attributes.add(name)
+                    break
+
         if abstract_attributes:
             raise NotImplementedError(
                 "Can't instantiate abstract class {} with abstract attributes: {}".format(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -88,10 +88,11 @@ def test_inference_defaults(inference_parser):
     default_values[:2] = [cli._format_date(date) for date in default_values[:2]]
 
     args = inference_parser.parse_args(BASIC_ARGLIST)
+    args_dict = vars(args)
 
     assert all(
         [
-            getattr(args, arg) == default_value
+            args_dict[arg] == default_value
             for arg, default_value in zip(default_args, default_values, strict=True)
         ]
     )


### PR DESCRIPTION
## Description
In this DRAFT PR, we remove the use of `getattr()` from several places:
- `tokenizer_masking.py`
  The use of `getattr()` was unnecessary, since `self.rng = None` is explicitly defined in `__init__()`.
- `loss_calculator.py` and `loss_module_physical.py`
  We now rely on `__dict__` instead of `getattr()`. However, this approach is still not safe.
    - A possible improvement would be to introduce a **REGISTRY** for both `loss_fns` and `LossModules`.
- `test_cli.py`
- `better_abc.py`

Additionally, in `pyproject.toml`, I attempted to enable automatic detection of `getattr()` usage, but it is currently not working as expected.

## Issue Number
- Closes #1332 

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
