### PR TITLE
Disable validation before training in config/config_physical_jepa.yml

### DIFF
--- a/config/config_physical_jepa.yml
+++ b/config/config_physical_jepa.yml
@@ -91,7 +91,7 @@ zarr_store: "zip" # "zarr" for LocalStore, "zip" for ZipStore
 
 #####################################
 
-streams_directory: "./config/streams/era5_1deg/"
+streams_directory: "./config/streams/era5_nppatms_synop/
 streams: ???
 
 general:

--- a/config/config_physical_jepa.yml
+++ b/config/config_physical_jepa.yml
@@ -91,7 +91,7 @@ zarr_store: "zip" # "zarr" for LocalStore, "zip" for ZipStore
 
 #####################################
 
-streams_directory: "./config/streams/era5_nppatms_synop/
+streams_directory: "./config/streams/era5_nppatms_synop/"
 streams: ???
 
 general:

--- a/config/config_physical_jepa.yml
+++ b/config/config_physical_jepa.yml
@@ -91,7 +91,7 @@ zarr_store: "zip" # "zarr" for LocalStore, "zip" for ZipStore
 
 #####################################
 
-streams_directory: "./config/streams/era5_nppatms_synop/"
+streams_directory: "./config/streams/era5_1deg/"
 streams: ???
 
 general:
@@ -267,12 +267,12 @@ validation_config:
     ema_halflife_in_thousands: 1e-3
 
   # run validation before training starts (mainly for model development)
-  validate_before_training: 8
+  validate_before_training: 0
 
   # parameters for validation samples that are written to disk
   output : {
     # number of samples that are written
-    num_samples: 8,
+    num_samples: 0,
     # write samples in normalized model space
     normalized_samples: True,
     # output streams to write; default all


### PR DESCRIPTION
## Description

Updating the config/config_physical_jepa.yml to disable the val before training as it currently yields an error:
```
  File "/users/walmikae/weathergen/WeatherGenerator/src/weathergen/run_train.py", line 185, in train_with_args
    trainer.run(cf, devices)
  File "/users/walmikae/weathergen/WeatherGenerator/src/weathergen/train/trainer.py", line 358, in run
    self.validate_before_training()
  File "/users/walmikae/weathergen/WeatherGenerator/src/weathergen/train/trainer.py", line 396, in validate_before_training
    self.validate(-1, cfg, batch_size)
  File "/users/walmikae/weathergen/WeatherGenerator/src/weathergen/train/trainer.py", line 584, in validate
    write_output(
  File "/users/walmikae/weathergen/WeatherGenerator/src/weathergen/utils/validation_io.py", line 63, in write_output
    for i_batch, (pred, target) in enumerate(zip(preds, targets, strict=True)):
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: zip() argument 2 is shorter than argument 1
[4] > /users/walmikae/weathergen/WeatherGenerator/src/weathergen/utils/validation_io.py(63)write_output()
-> for i_batch, (pred, target) in enumerate(zip(preds, targets, strict=True)):
```

Closes #1753 

## Checklist before asking for review

-   [X] I have performed a self-review of my code
-   [X] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [X] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
