### PR TITLE
Reenable max_num_targets and add shuffle_source and shuffle_target stream config options

### DIFF
--- a/src/weathergen/datasets/data_reader_base.py
+++ b/src/weathergen/datasets/data_reader_base.py
@@ -208,6 +208,42 @@ class ReaderData:
             self.datetimes[idx_valid],
         )
 
+    def shuffle(self, rng, shuffle: bool, num_subset: int) -> "ReaderData":
+        """
+        Drop a random subset of points as specified by num_subset
+        num_subset = -1 indicates no points to be dropped
+
+        Returns
+        -------
+        self
+        """
+
+        # nothing to be done
+        if num_subset < 0 and shuffle is False:
+            return self
+
+        num_datapoints = self.coords.shape[0]
+        if (num_datapoints == 0) or (num_datapoints < num_subset and shuffle is False):
+            return self
+
+        # only shuffling
+        if num_subset == -1 and shuffle is True:
+            num_subset = num_datapoints
+
+        # ensure num_subset <= num_datapoints
+        num_subset = min(num_subset, num_datapoints)
+
+        idxs_subset = rng.choice(num_datapoints, num_subset, replace=False)
+        if shuffle is False:
+            idxs_subset = np.sort(idxs_subset)
+
+        self.coords = self.coords[idxs_subset]
+        self.geoinfos = self.geoinfos[idxs_subset]
+        self.data = self.data[idxs_subset]
+        self.datetimes = self.datetimes[idxs_subset]
+
+        return self
+
 
 def check_reader_data(rdata: ReaderData, dtr: DTRange) -> None:
     """

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -50,10 +50,10 @@ def collect_datasources(stream_datasets: list, idx: int, type: str, rng) -> IORe
 
     rdatas = []
 
-    # number of points to sub-sample
-    num_subset = -1
-
     for ds in stream_datasets:
+        # number of points to sub-sample
+        num_subset = -1
+
         if type == "source":
             get_reader_data = ds.get_source
             normalize_channels = ds.normalize_source_channels

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -41,25 +41,33 @@ type StreamName = str
 logger = logging.getLogger(__name__)
 
 
-def collect_datasources(stream_datasets: list, idx: int, type: str) -> IOReaderData:
+def collect_datasources(stream_datasets: list, idx: int, type: str, rng) -> IOReaderData:
     """
     Utility function to collect all sources / targets from streams list
+
+    rng and num_subset are used to drop data
     """
 
     rdatas = []
+
+    # number of points to sub-sample
+    num_subset = -1
 
     for ds in stream_datasets:
         if type == "source":
             get_reader_data = ds.get_source
             normalize_channels = ds.normalize_source_channels
+            shuffle = ds.stream_info.get("shuffle_source", False)
         elif type == "target":
             get_reader_data = ds.get_target
             normalize_channels = ds.normalize_target_channels
+            num_subset = ds.stream_info.get("max_num_targets", -1)
+            shuffle = ds.stream_info.get("shuffle_target", False)
         else:
             assert False, "invalid value for argument `type`"
 
         # get source (of potentially multi-step length)
-        rdata = get_reader_data(idx).remove_nan_coords()
+        rdata = get_reader_data(idx).shuffle(rng, shuffle, num_subset).remove_nan_coords()
         rdata.data = normalize_channels(rdata.data)
         rdata.geoinfos = ds.normalize_geoinfos(rdata.geoinfos)
         rdatas += [rdata]
@@ -528,7 +536,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         for idx in range(base_idx - num_steps_input_max, base_idx + 1):
             # TODO: check that we are not out of bounds when we go back in time
 
-            rdata = collect_datasources(stream_ds, idx, "source")
+            rdata = collect_datasources(stream_ds, idx, "source", self.rng)
 
             if rdata.is_empty():
                 # work around for https://github.com/pytorch/pytorch/issues/158719
@@ -550,7 +558,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         for timestep_idx in range(self.output_offset, num_output_steps):
             step_forecast_dt = base_idx + (self.time_step * timestep_idx) // self.step_timedelta
 
-            rdata = collect_datasources(stream_ds, step_forecast_dt, "target")
+            rdata = collect_datasources(stream_ds, step_forecast_dt, "target", self.rng)
 
             if rdata.is_empty():
                 # work around for https://github.com/pytorch/pytorch/issues/158719

--- a/src/weathergen/datasets/tokenizer_masking.py
+++ b/src/weathergen/datasets/tokenizer_masking.py
@@ -151,49 +151,6 @@ class TokenizerMasking(Tokenizer):
 
         return (source_tokens_cells, source_tokens_lens)
 
-    # batchify_target_for_view now unified into batchify_target via optional mask_state
-
-    def get_target(
-        self,
-        stream_info: dict,
-        sampling_rate_target: float,
-        rdata: IOReaderData,
-        token_data,
-        time_win: tuple,
-        mask_state: dict | None = None,
-    ):
-        # TODO: remove
-
-        # create tokenization index
-        (idxs_cells, idxs_cells_lens) = token_data
-
-        # Apply per-view mask state if provided
-        if mask_state is not None:
-            self.masker.current_strategy = mask_state.get("strategy", self.masker.masking_strategy)
-            self.masker.mask_tokens = mask_state.get("mask_tokens")
-            self.masker.mask_channels = mask_state.get("mask_channels")
-
-        (mask_tokens, mask_channels, idxs_ord_inv) = self.masker.mask_targets_idxs(
-            idxs_cells,
-            idxs_cells_lens,
-        )
-
-        data, datetimes, coords, coords_local, coords_per_cell = tokenize_apply_mask_target(
-            self.hl_target,
-            idxs_cells,
-            idxs_cells_lens,
-            mask_tokens,
-            mask_channels,
-            rdata,
-            time_win,
-            self.hpy_verts_rots_target,
-            self.hpy_verts_local_target,
-            self.hpy_nctrs_target,
-            encode_times_target,
-        )
-
-        return (data, datetimes, coords, coords_local, coords_per_cell, idxs_ord_inv)
-
     def get_target_coords(
         self,
         stream_info: dict,
@@ -201,7 +158,6 @@ class TokenizerMasking(Tokenizer):
         token_data,
         time_win: tuple,
         cell_mask,
-        # mask_state: dict | None = None,
     ):
         # create tokenization index
         (idxs_cells, idxs_cells_lens) = token_data
@@ -225,31 +181,6 @@ class TokenizerMasking(Tokenizer):
             encode_times_target,
         )
 
-        # selection = self._select_target_subset(stream_info, coords_local.shape[0])
-
-        # if selection is not None and coords_local.numel() > 0:
-        #     # use nice index_select method
-        #     coords_local = coords_local.index_select(0, selection.to(coords_local.device))
-
-        # # coords_per_cell is trickier
-        # if selection is not None and coords_per_cell.numel() > 0:
-        #     total_points = int(coords_per_cell.sum().item())
-        #     if total_points == 0:
-        #         coords_per_cell = torch.zeros_like(coords_per_cell)
-        #     else:
-        #         cell_ids = torch.repeat_interleave(
-        #             torch.arange(coords_per_cell.shape[0], dtype=torch.long),
-        #             coords_per_cell.to(torch.long),
-        #         )
-        #         if cell_ids.numel() == 0:
-        #             coords_per_cell = torch.zeros_like(coords_per_cell)
-        #         else:
-        #             new_counts = torch.bincount(
-        #                 cell_ids[selection.to(cell_ids.device)],
-        #                 minlength=coords_per_cell.shape[0],
-        #             )
-        #             coords_per_cell = new_counts.to(dtype=coords_per_cell.dtype)
-
         # pass the selection back for use in get_target_values
         return (coords_local, coords_per_cell)
 
@@ -260,8 +191,6 @@ class TokenizerMasking(Tokenizer):
         token_data,
         time_win: tuple,
         cell_mask,
-        # mask_state: dict | None = None,
-        # selection: torch.Tensor | None = None,
     ):
         # create tokenization index
         (idxs_cells, idxs_cells_lens) = token_data
@@ -284,9 +213,6 @@ class TokenizerMasking(Tokenizer):
             encode_times_target,
         )
 
-        # if selection is None:
-        #     selection = self._select_target_subset(stream_info, data.shape[0])
-
         # if selection is not None and data.numel() > 0:
         #     device_sel = selection.to(data.device)
         #     data = data.index_select(0, device_sel)
@@ -298,32 +224,11 @@ class TokenizerMasking(Tokenizer):
         #     np_sel = selection.cpu().numpy()
         #     datetimes = datetimes[np_sel]
 
-        # TODO: shuffling
-
         # TODO: idxs_ord_inv
         idxs_ord_inv = None
 
         # selection not passed on, we call get_target_coords first
         return (data, datetimes, coords, idxs_ord_inv)
-
-    def _select_target_subset(
-        self,
-        stream_info: dict,
-        num_points: int,
-    ) -> torch.Tensor | None:
-        max_num_targets = stream_info.get("max_num_targets", -1)
-
-        if max_num_targets is None or max_num_targets <= 0 or num_points <= max_num_targets:
-            return None
-
-        rng = getattr(self, "rng", None)
-        if rng is None:
-            rng = np.random.default_rng()
-            self.rng = rng
-
-        selected = np.sort(rng.choice(num_points, max_num_targets, replace=False))
-
-        return torch.from_numpy(selected).to(torch.long)
 
     def sample_tensors_uniform_vectorized(
         self, tensor_list: list, lengths: list, max_total_points: int

--- a/src/weathergen/datasets/tokenizer_masking.py
+++ b/src/weathergen/datasets/tokenizer_masking.py
@@ -229,39 +229,3 @@ class TokenizerMasking(Tokenizer):
 
         # selection not passed on, we call get_target_coords first
         return (data, datetimes, coords, idxs_ord_inv)
-
-    def sample_tensors_uniform_vectorized(
-        self, tensor_list: list, lengths: list, max_total_points: int
-    ):
-        """
-        This function randomly selects tensors up to a maximum number of total points
-
-        tensor_list: List[torch.tensor] the list to select from
-        lengths: List[int] the length of each tensor in tensor_list
-        max_total_points: the maximum number of total points to sample from
-        """
-        if not tensor_list:
-            return [], 0
-
-        # Create random permutation
-        perm = self.rng.permutation(len(tensor_list))
-
-        # Vectorized cumulative sum
-        cumsum = torch.cumsum(lengths[perm], dim=0)
-
-        # Find cutoff point
-        valid_mask = cumsum <= max_total_points
-        if not valid_mask.any():
-            return [], 0
-
-        num_selected = valid_mask.sum().item()
-        perm = torch.tensor(perm)
-        selected_indices = perm[:num_selected]
-        selected_indices = torch.zeros_like(perm).scatter(0, selected_indices, 1)
-
-        selected_tensors = [
-            t if mask.item() == 1 else t[:0]
-            for t, mask in zip(tensor_list, selected_indices, strict=False)
-        ]
-
-        return selected_tensors


### PR DESCRIPTION
## Description

Re-introduce max_num_target stream config option, but at a more appropriate place. Also addding shuffle_source and shuffle_target stream config options.

## Issue Number

Closes #1751 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
