### PR TITLE
Sgrasse/develop/435 unify dataset access

### DIFF
--- a/integration_tests/small_multi_stream.yaml
+++ b/integration_tests/small_multi_stream.yaml
@@ -186,6 +186,7 @@ training_config:
       time_step: 06:00:00
       num_steps: 2
       policy: "fixed" 
+      offset: 1
 
 
 # validation config; full validation config is merge of training and validation config

--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -312,7 +312,7 @@ def _check_datasets(config: Config) -> Config:
     config = config.copy()
     if config.get("data_paths") is None:  # TODO remove this for next version
         legacy_keys = [
-            "data_path_anmoi",
+            "data_path_anemoi",
             "data_path_obs",
             "data_path_eobs",
             "data_path_fesom",

--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -307,10 +307,10 @@ def _apply_fixes(config: Config) -> Config:
 
 def _check_datasets(config: Config) -> Config:
     """
-    Collect dataset pathes under legacy keys.
+    Collect dataset paths under legacy keys.
     """
     config = config.copy()
-    if config.get("data_pathes") is None:  # TODO remove this for next version
+    if config.get("data_paths") is None:  # TODO remove this for next version
         legacy_keys = [
             "data_path_anmoi",
             "data_path_obs",
@@ -318,8 +318,8 @@ def _check_datasets(config: Config) -> Config:
             "data_path_fesom",
             "data_path_icon",
         ]
-        pathes = [config.get(key) for key in legacy_keys]
-        config.data_pathes = [path for path in pathes if path is not None]
+        paths = [config.get(key) for key in legacy_keys]
+        config.data_paths = [path for path in paths if path is not None]
 
     return config
 

--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -310,17 +310,17 @@ def _check_datasets(config: Config) -> Config:
     Collect dataset pathes under legacy keys.
     """
     config = config.copy()
-    if config.get("data_pathes") is None: # TODO remove this for next version
+    if config.get("data_pathes") is None:  # TODO remove this for next version
         legacy_keys = [
             "data_path_anmoi",
             "data_path_obs",
             "data_path_eobs",
             "data_path_fesom",
-            "data_path_icon"
+            "data_path_icon",
         ]
         pathes = [config.get(key) for key in legacy_keys]
         config.data_pathes = [path for path in pathes if path is not None]
-    
+
     return config
 
 
@@ -545,8 +545,8 @@ def _load_private_conf(private_home: Path | None = None) -> DictConfig:
 
     if "secrets" in private_cf:
         del private_cf["secrets"]
-    
-    private_cf = _check_datasets(private_cf) # TODO: remove temp backward compatibility fix
+
+    private_cf = _check_datasets(private_cf)  # TODO: remove temp backward compatibility fix
 
     assert isinstance(private_cf, DictConfig)
     return private_cf

--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -301,6 +301,26 @@ def _apply_fixes(config: Config) -> Config:
     eventually removed.
     """
     config = _check_logging(config)
+    config = _check_datasets(config)
+    return config
+
+
+def _check_datasets(config: Config) -> Config:
+    """
+    Collect dataset pathes under legacy keys.
+    """
+    config = config.copy()
+    if config.get("data_pathes") is None: # TODO remove this for next version
+        legacy_keys = [
+            "data_path_anmoi",
+            "data_path_obs",
+            "data_path_eobs",
+            "data_path_fesom",
+            "data_path_icon"
+        ]
+        pathes = [config.get(key) for key in legacy_keys]
+        config.data_pathes = [path for path in pathes if path is not None]
+    
     return config
 
 
@@ -525,6 +545,8 @@ def _load_private_conf(private_home: Path | None = None) -> DictConfig:
 
     if "secrets" in private_cf:
         del private_cf["secrets"]
+    
+    private_cf = _check_datasets(private_cf) # TODO: remove temp backward compatibility fix
 
     assert isinstance(private_cf, DictConfig)
     return private_cf

--- a/packages/readers_extra/src/weathergen/readers_extra/registry.py
+++ b/packages/readers_extra/src/weathergen/readers_extra/registry.py
@@ -1,9 +1,3 @@
-from collections.abc import Callable
-from dataclasses import dataclass
-
-from weathergen.common.config import Config
-
-
 def get_extra_reader(stream_type: str) -> object | None:
     """Get an extra reader by stream_type name."""
     # Uses lazy imports to avoid circular dependencies and to not load all the readers at start.

--- a/packages/readers_extra/src/weathergen/readers_extra/registry.py
+++ b/packages/readers_extra/src/weathergen/readers_extra/registry.py
@@ -4,33 +4,27 @@ from dataclasses import dataclass
 from weathergen.common.config import Config
 
 
-@dataclass
-class ReaderEntry:
-    data_path: str | None
-    constructor: Callable
-
-
-def get_extra_reader(name: str, cf: Config) -> object | None:
-    """Get an extra reader by name."""
+def get_extra_reader(stream_type: str) -> object | None:
+    """Get an extra reader by stream_type name."""
     # Uses lazy imports to avoid circular dependencies and to not load all the readers at start.
     # There is no sanity check on them, so they may fail at runtime during imports
 
-    match name:
+    match stream_type:
         case "iconart":
             from weathergen.readers_extra.data_reader_iconart import DataReaderIconArt
 
-            return ReaderEntry(cf.data_path_icon, DataReaderIconArt)
+            return DataReaderIconArt
         case "eobs":
             from weathergen.readers_extra.data_reader_eobs import DataReaderEObs
 
-            return ReaderEntry(cf.data_path_eobs, DataReaderEObs)
+            return DataReaderEObs
         case "iconesm":
             from weathergen.readers_extra.data_reader_icon_esm import DataReaderIconEsm
 
-            return ReaderEntry(cf.data_path_icon_esm, DataReaderIconEsm)
+            return DataReaderIconEsm
         case "cams":
             from weathergen.readers_extra.data_reader_cams import DataReaderCams
 
-            return ReaderEntry(cf.data_path_cams, DataReaderCams)
+            return DataReaderCams
         case _:
             return None

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -177,7 +177,9 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                         )
                         raise FileNotFoundError(msg)
 
-                    filename = filenames[0]  # arbitrarly choose first existing path
+                    # The same dataset can exist on different locations in the filesystem,
+                    # so we need to choose here.
+                    filename = filenames[0]
 
                 ds_type = stream_info["type"]
                 if is_root():

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -168,8 +168,8 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                             f"stream '{stream_info['name']}': {filenames}."
                         )
                         raise FileNotFoundError(msg)
-                    
-                    filename = filenames[0] # arbitrarly choose first existing path
+
+                    filename = filenames[0]  # arbitrarly choose first existing path
 
                 ds_type = stream_info["type"]
                 if is_root():

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -160,7 +160,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                     # check if fname is a valid path to allow for simple overwriting
                     filename = fname
                 else:
-                    filenames = [pathlib.Path(path) / fname for path in cf.data_pathes]
+                    filenames = [pathlib.Path(path) / fname for path in cf.data_paths]
 
                     if not any(filename.exists() for filename in filenames):  # see above
                         msg = (

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -143,39 +143,33 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                 match stream_info["type"]:
                     case "obs":
                         dataset = DataReaderObs
-                        datapath = cf.data_path_obs
-                        # kwargs["end"] = end_date_padded # TODO: implement the padding
                     case "anemoi":
                         dataset = DataReaderAnemoi
-                        datapath = cf.data_path_anemoi
                     case "fesom":
                         dataset = DataReaderFesom
-                        datapath = cf.data_path_fesom
                     case type_name:
-                        reader_entry = get_extra_reader(type_name, cf)
-                        if reader_entry is not None:
-                            dataset = reader_entry.constructor
-                            datapath = reader_entry.data_path
-                        else:
+                        dataset = get_extra_reader(type_name)
+                        if dataset is None:
                             msg = f"Unsupported stream type {stream_info['type']}"
                             f"for stream name '{stream_info['name']}'."
                             raise ValueError(msg)
 
-                datapath = pathlib.Path(datapath)
                 fname = pathlib.Path(fname)
                 # dont check if file exists since zarr stores might be directories
                 if fname.exists():
                     # check if fname is a valid path to allow for simple overwriting
                     filename = fname
                 else:
-                    filename = pathlib.Path(datapath) / fname
+                    filenames = [pathlib.Path(path) / fname for path in cf.data_pathes]
 
-                    if not filename.exists():  # see above
+                    if not any(filename.exists() for filename in filenames):  # see above
                         msg = (
                             f"Did not find input data for {stream_info['type']} "
-                            f"stream '{stream_info['name']}': {filename}."
+                            f"stream '{stream_info['name']}': {filenames}."
                         )
                         raise FileNotFoundError(msg)
+                    
+                    filename = filenames[0] # arbitrarly choose first existing path
 
                 ds_type = stream_info["type"]
                 if is_root():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,8 +9,7 @@ import weathergen.common.config as config
 TEST_RUN_ID = "test123"
 SECRET_COMPONENT = "53CR3T"
 DUMMY_PRIVATE_CONF = {
-    "data_path_anemoi": "/path/to/anmoi/data",
-    "data_path_obs": "/path/to/observation/data",
+    "data_paths": ["/path/to/anmoi/data", "/path/to/observation/data"]
     "secrets": {
         "my_big_secret": {
             "my_secret_id": f"{SECRET_COMPONENT}01234",


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->
closes #435 
goes together with [!120](https://gitlab.jsc.fz-juelich.de/esde/WeatherGenerator-private/-/merge_requests/120)

First part of revised usage of pathes, has backward compatiblity. Once the new `data_pathes` option has been introduced in all private configs a grace period should be given before old options eg `data_path_anemoi ...` are removed from private configs.

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
