### PR TITLE
Fix typo in logger warning for unused keys in model loading

### DIFF
--- a/src/weathergen/model/model_interface.py
+++ b/src/weathergen/model/model_interface.py
@@ -234,7 +234,7 @@ def load_model(cf, model, device, run_id: str, mini_epoch=-1):
     if len(mkeys) > 0:
         logger.warning(f"Missing keys when loading model: {mkeys}")
     if len(ukeys) > 0:
-        logger.warning(f"Unused keys when loading model: {mkeys}")
+        logger.warning(f"Unused keys when loading model: {ukeys}")
 
     return model
 


### PR DESCRIPTION
Logging ukeys rather than incorrect mkeys in model_inferface

## Description

Fixing mkeys -> ukeys typo in model_interface.


## Issue Number

Closes #1768 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
