### PR TITLE
Skip empty variables when eval plotting instead of raising assert error

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -393,7 +393,7 @@ class Plotter:
                             f"dropping NAs. Skipping this plot."
                         )
                         continue
-                        
+
                     name = self.scatter_plot(
                         da_t,
                         map_output_dir,

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -387,8 +387,13 @@ class Plotter:
                         _logger.debug(f"Plotting map for {var} at valid_time {valid_time}")
 
                     da_t = da_t.dropna(dim="ipoint")
-                    assert da_t.size > 0, "Data array must not be empty or contain only NAs"
-
+                    if da_t.size == 0:
+                        _logger.warning(
+                            f"Data array for {var} at valid_time {valid_time} is empty after "
+                            f"dropping NAs. Skipping this plot."
+                        )
+                        continue
+                        
                     name = self.scatter_plot(
                         da_t,
                         map_output_dir,


### PR DESCRIPTION
## Description

Instead of raising assert and stopping when trying to plot a variable with no data in eval, skip that particular variable and raise a warning. If all variables are empty, warnings are logged so it should be clear to the user.


## Issue Number

Closes #1786 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
