### PR TITLE
Fix animation frame ordering (ERA5 1h): sort frames by valid_time the…

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/plotting/image_sort.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/image_sort.py
@@ -1,0 +1,36 @@
+import datetime
+import os
+import re
+
+
+def _extract_valid_time_and_fstep_from_filename(fname: str):
+    """Extract valid_time and fstep from a plot filename.
+
+    The filename format includes an ISO-like valid time fragment like
+    YYYY-MM-DDTHHMM and a forecast step fragment like fstep_XXX.
+
+    Returns a tuple (valid_time: datetime | None, fstep: int | None).
+    """
+    basename = os.path.basename(fname)
+
+    dt_match = re.search(r"\d{4}-\d{2}-\d{2}T\d{4}", basename)
+    if dt_match:
+        try:
+            dt = datetime.datetime.strptime(dt_match.group(), "%Y-%m-%dT%H%M")
+        except Exception:
+            dt = None
+    else:
+        dt = None
+
+    fstep_match = re.search(r"fstep_(\d{3})", basename)
+    fstep = int(fstep_match.group(1)) if fstep_match else None
+
+    return dt, fstep
+
+
+def _image_sort_key(path: str):
+    """Sort key for image file paths: by valid_time (if present), then fstep, then filename."""
+    dt, fstep = _extract_valid_time_and_fstep_from_filename(path)
+    dt_key = dt if dt is not None else datetime.datetime.min
+    fstep_key = fstep if fstep is not None else -1
+    return (dt_key, fstep_key, os.path.basename(path))

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -39,6 +39,12 @@ _logger.setLevel(logging.INFO)
 _logger.debug(f"Taking cartopy paths from {work_dir}")
 
 
+from weathergen.evaluate.plotting.image_sort import (
+    _extract_valid_time_and_fstep_from_filename,
+    _image_sort_key,
+)
+
+
 class Plotter:
     """
     Contains all basic plotting functions.
@@ -575,6 +581,9 @@ class Plotter:
         # Convert FPS to duration in milliseconds
         duration_ms = int(1000 / self.fps) if self.fps > 0 else 400
 
+        # Collected created animation filenames to return
+        created_animations: list[str] = []
+
         for region in self.regions:
             for _, sa in enumerate(samples):
                 for _, var in enumerate(variables):
@@ -602,19 +611,27 @@ class Plotter:
                         image_paths += names
 
                     if image_paths:
+                        # Ensure deterministic ordering of frames. For ERA5 1h there can be
+                        # multiple valid_time stamps; sort by valid_time (if present),
+                        # then by fstep number to guarantee chronological order.
+                        image_paths = sorted(image_paths, key=_image_sort_key)
+
                         images = [Image.open(path) for path in image_paths]
+                        anim_fname = f"{map_output_dir}/animation_{self.run_id}_{tag}_{sa}_{self.stream}_{region}_{var}.gif"
                         images[0].save(
-                            f"{map_output_dir}/animation_{self.run_id}_{tag}_{sa}_{self.stream}_{region}_{var}.gif",
+                            anim_fname,
                             save_all=True,
                             append_images=images[1:],
                             duration=duration_ms,
                             loop=0,
                         )
 
+                        created_animations.append(anim_fname)
+
                     else:
                         _logger.warning(f"No images found for animation {var} sample {sa}")
 
-        return image_paths
+        return created_animations
 
     def get_map_output_dir(self, tag):
         return self.out_plot_basedir / self.stream / "maps" / tag

--- a/packages/evaluate/tests/test_plotter_animation.py
+++ b/packages/evaluate/tests/test_plotter_animation.py
@@ -1,0 +1,40 @@
+import datetime
+import os
+import sys
+
+# Make the local package importable for tests without installing the package
+tests_dir = os.path.dirname(__file__)
+src_dir = os.path.abspath(os.path.join(tests_dir, os.pardir, "src"))
+if src_dir not in sys.path:
+    sys.path.insert(0, src_dir)
+
+from weathergen.evaluate.plotting.image_sort import _extract_valid_time_and_fstep_from_filename, _image_sort_key
+
+
+def test_extract_valid_time_and_fstep_from_filename():
+    fname = "map_run_tag_0_2023-01-01T0100_ERA5_region_var_fstep_006.png"
+    dt, fstep = _extract_valid_time_and_fstep_from_filename(fname)
+    assert dt == datetime.datetime(2023, 1, 1, 1, 0)
+    assert fstep == 6
+
+
+def test_image_sort_key_orders_by_valid_time_then_fstep():
+    base = "map_run_tag_0"
+    a = f"{base}_2023-01-01T0100_ERA5_region_var_fstep_006.png"
+    b = f"{base}_2023-01-01T0000_ERA5_region_var_fstep_000.png"
+    c = f"{base}_2023-01-01T0200_ERA5_region_var_fstep_012.png"
+
+    shuffled = [a, c, b]
+    sorted_paths = sorted(shuffled, key=_image_sort_key)
+    assert sorted_paths == [b, a, c]
+
+
+def test_image_sort_key_fallbacks_to_fstep_when_no_valid_time():
+    base = "map_run_tag_0"
+    a = f"{base}_ERA5_region_var_fstep_012.png"
+    b = f"{base}_ERA5_region_var_fstep_000.png"
+    c = f"{base}_ERA5_region_var_fstep_006.png"
+
+    shuffled = [a, c, b]
+    sorted_paths = sorted(shuffled, key=_image_sort_key)
+    assert sorted_paths == [b, c, a]

--- a/packages/evaluate/tests/test_plotter_animation.py
+++ b/packages/evaluate/tests/test_plotter_animation.py
@@ -8,7 +8,10 @@ src_dir = os.path.abspath(os.path.join(tests_dir, os.pardir, "src"))
 if src_dir not in sys.path:
     sys.path.insert(0, src_dir)
 
-from weathergen.evaluate.plotting.image_sort import _extract_valid_time_and_fstep_from_filename, _image_sort_key
+from weathergen.evaluate.plotting.image_sort import (
+    _extract_valid_time_and_fstep_from_filename,
+    _image_sort_key,
+)
 
 
 def test_extract_valid_time_and_fstep_from_filename():


### PR DESCRIPTION
## Description

Fix animation frame ordering for ERA5 1h (issue #1781).

- Ensure images are sorted deterministically before building GIFs by parsing valid_time (YYYY-MM-DDTHHMM) and fstep (fstep_XXX).
- animation() now returns the list of created GIF filenames.
- Add unit tests for the filename parsing and ordering.

Closes #1781

## Is this PR a draft?

Yes — please mark as draft while CI and integration tests are completed.

## Checklist before asking for review

- [x] I have performed a self-review of my code
- [x] My changes comply with basic sanity checks:
  - [x] I have fixed formatting issues with `./scripts/actions.sh lint` (ran `ruff format` on modified files)
  - [x] I have run unit tests for the added tests (`pytest packages/evaluate/tests/test_plotter_animation.py`)
  - [x] I have documented my code and updated docstrings where relevant (see `image_sort.py`)
  - [x] I have added unit tests
- What I ran locally
Unit tests: pytest packages/evaluate/tests/test_plotter_animation.py — passed 
Lightweight integration-style test (temporary PNGs -> GIF -> assert order) — run locally and passed (test not committed).
- [x] I have tried my changes with data and code:
- kindly Run the full integration tests , please run on CI / Linux runner
@SavvasMel (please review / confirm integration behavior)

## Additional notes

- I propose an integration test that actually writes temporary PNG frames and asserts the produced GIF ordering,I can add that as a follow-up.
