### PR TITLE
Fix get_2x2_event_counts and remove duplicate code in score.py

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -438,7 +438,7 @@ class Scores:
         """
 
         a = self._sum((p >= thresh) & (gt >= thresh))
-        b = self._sum((p >= thresh) & (gt >= thresh))
+        b = self._sum((p >= thresh) & (gt < thresh))
         c = self._sum((p < thresh) & (gt >= thresh))
         d = self._sum((p < thresh) & (gt < thresh))
 
@@ -1151,7 +1151,7 @@ class Scores:
             seeps_weights = seeps_weights.stack({"xy": spatial_dims})
             t3 = t3.stack({"xy": spatial_dims})
             lstack = True
-        elif self.prediction.ndim == 2:
+        elif p.ndim == 2:
             prediction, ground_truth = p, gt
             lstack = False
         else:
@@ -1377,13 +1377,6 @@ class Scores:
             bins=np.arange(len(fcst_stacked[self._ens_dim]) + 2),
             block_size=None if rank.chunks is None else "auto",
         )
-
-        # Reattach preserved coordinates by broadcasting
-        for coord_name, coord_values in preserved_coords.items():
-            # Only keep unique values along npoints if necessary
-            if coord_name in rank_counts.coords:
-                continue
-            rank_counts = rank_counts.assign_coords({coord_name: coord_values})
 
         # Reattach preserved coordinates by broadcasting
         for coord_name, coord_values in preserved_coords.items():


### PR DESCRIPTION
## Description

Fixing several smaller mistakes. Affected scores are ETS, FBI and PSS (unused so far I guess).

## Issue Number

Closes #1805

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
