### PR TITLE
Enable model checkpoint loading from config

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -82,6 +82,7 @@ latent_noise_use_additive_noise: False
 latent_noise_deterministic_latents: True
 
 freeze_modules: ""
+load_chkpt: {}
 
 norm_type: "LayerNorm"
 


### PR DESCRIPTION
## Description

This PR introduces `load_chkpt` config parameter which takes a dictionary of following structure:

```
load_chkpt: { 
        run_id: <run_id>, 
        mini_epoch: <mini_epoch>
}
```

If the dictionary is empty, no checkpoint is loaded.
If mini_epoch is not specified, by default `-1` will be used (i.e. `_latest`).

The dict-structure can hopefully be expanded in the future to specify specific modules to be loaded from checkpoint.

## Issue Number

Closes #1809 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
