### PR TITLE
Fixes FSDP error on develop when running with forecast engine

### DIFF
--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -473,7 +473,7 @@ class ForecastingEngine(torch.nn.Module):
             if isinstance(block, torch.nn.modules.normalization.LayerNorm):
                 tokens = block(tokens)
             else:
-                tokens = block(tokens, aux_info)
+                tokens = checkpoint(block, tokens, aux_info, use_reentrant=False)
         return tokens
 
 

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -18,7 +18,6 @@ import astropy_healpix.healpy
 import numpy as np
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 
 from weathergen.common.config import Config
 from weathergen.datasets.batch import ModelBatch
@@ -589,7 +588,7 @@ class Model(torch.nn.Module):
         for step in batch.get_output_idxs():
             # apply forecasting engine (if present)
             if self.forecast_engine:
-                tokens = checkpoint(self.forecast_engine, tokens, step, use_reentrant=False)
+                tokens = self.forecast_engine(tokens, step)
 
             # decoder predictions
             output = self.predict_decoders(model_params, step, tokens, batch, output)


### PR DESCRIPTION
## Description

Fixes the error when running with forecast engine blocks > 0 by removing checkpoint around forecast engine.
Moving the checkpoint around each block of forecast engine instead.

## Issue Number

Closes #1811 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
