### PR TITLE
Enable gradient checkpointing in forward_channels

### DIFF
--- a/src/weathergen/model/embeddings.py
+++ b/src/weathergen/model/embeddings.py
@@ -9,6 +9,7 @@
 
 import numpy as np
 import torch
+from torch.utils.checkpoint import checkpoint
 
 from weathergen.model.attention import MultiSelfAttentionHead
 from weathergen.model.layers import MLP
@@ -141,7 +142,7 @@ class StreamEmbedTransformer(torch.nn.Module):
         x = peh(self.embed(x_in.transpose(-2, -1)))
 
         for layer in self.layers:
-            x = layer(x)
+            x = checkpoint(layer,x, use_reentrant=False)
 
         # read out
         if self.unembed_mode == "full":


### PR DESCRIPTION
## Description
According to issue #1844, `forward_channels` consumes a lot of memory. In this PR, gradient checkpointing has been enabled for the forward_channels method. Here is the memory usage before enabling gradient checkpointing (**22.4 GB** peak memory):

<img width="1820" height="438" alt="Screenshot from 2026-02-17 09-14-29" src="https://github.com/user-attachments/assets/e1be9835-cc4c-49a0-bba9-fb1ce5d09853" />

After enabling gradient checkpointing (around **11.3 GB** peak memeory)

<img width="1820" height="438" alt="Screenshot from 2026-02-17 09-29-08" src="https://github.com/user-attachments/assets/edebb5f1-c42a-4dc4-ba10-2aef2d8ac265" />

Since enabling gradient checkpointing can degrade training performance, the CPU time for one iteration after warm-up was measured. Before gradient checkpointing, the CPU time was `4.768 s`; after enabling it, it was `5.024 s`.

This is about a **5%** performance drop, but the memory footprint decreases by around **50%**.

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number
Closes #1844
<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
