### PR TITLE
Add the possibility the ensemble members to be given as str

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/io/io_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/io_reader.py
@@ -305,6 +305,11 @@ class Reader:
                 "String format for sample in config must be 'digit-digit' or 'all'"
             )
             samples = list(range(int(samples.split("-")[0]), int(samples.split("-")[1]) + 1))
+        if isinstance(ensemble, str) and ensemble not in {"all", "mean"}:
+            assert re.match(r"^\d+-\d+$", ensemble), (
+                "String format for sample in config must be 'digit-digit' or 'all'"
+            )
+            ensemble = list(range(int(ensemble.split("-")[0]), int(ensemble.split("-")[1]) + 1))
 
         return DataAvailability(
             score_availability=True,


### PR DESCRIPTION
## Description

This is a minor PR to allow ensemble members to be given as str of the form `"1-3"`

## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/1852

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [X] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
