### PR TITLE
Fixing lead time dimension

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
@@ -529,7 +529,7 @@ class WeatherGenZarrReader(WeatherGenReader):
         vt = da["valid_time"]
         sis = da["source_interval_start"]
 
-        vt_reduced = vt.min(dim=[d for d in vt.dims if d != sample_dim])
+        vt_reduced = vt.min(dim=[d for d in vt.dims])
 
         lead_time = vt_reduced - sis
 

--- a/packages/evaluate/src/weathergen/evaluate/utils/utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils/utils.py
@@ -25,7 +25,6 @@ from weathergen.evaluate.plotting.plot_utils import (
     bar_plot_metric_region,
     heat_maps_metric_region,
     plot_metric_region,
-    quantile_plot_metric_region,
     ratio_plot_metric_region,
     score_card_metric_region,
 )
@@ -33,7 +32,6 @@ from weathergen.evaluate.plotting.plotter import (
     BarPlots,
     LinePlots,
     Plotter,
-    QuantilePlots,
     ScoreCards,
 )
 from weathergen.evaluate.scores.score import VerifiedData, get_score
@@ -596,7 +594,7 @@ def plot_summary(cfg: dict, scores_dict: dict, summary_dir: Path):
     plotter = LinePlots(plot_cfg, summary_dir)
     sc_plotter = ScoreCards(plot_cfg, summary_dir)
     br_plotter = BarPlots(plot_cfg, summary_dir)
-    quantile_plotter = QuantilePlots(plot_cfg, summary_dir)
+    # quantile_plotter = QuantilePlots(plot_cfg, summary_dir)
     plotting_log_emitted = False
     for region in regions:
         for metric in metrics:


### PR DESCRIPTION
## Description

There is an issue with `lead_time` having "sample" as dimension.


## Issue Number

-

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [X] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [X] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
