### PR TITLE
Update stream check to allow ERA5_...

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
@@ -548,7 +548,7 @@ class WeatherGenZarrReader(WeatherGenReader):
         -------
             Returns a Dataset where channels have been scaled if needed
         """
-        if stream not in ["ERA5"]:
+        if stream is None or not str(stream).startswith("ERA5"):
             return data
 
         channels_z = [ch for ch in np.atleast_1d(data.channel.values) if str(ch).startswith("z_")]


### PR DESCRIPTION
I want to do the z rescaling, even when I have ERA5 streams that are slightly renamed. For example if we split streams, we might have ERA5_uv, ERA5_v, ERA5_t etc., and I want the rescaling to catch these.

## Description

Check if stream name startswith "ERA5"

## Issue Number

Closes #1922 

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
