### PR TITLE
Fix left over train_log_freq, now train_logging

### DIFF
--- a/config/config_dinov2.yml
+++ b/config/config_dinov2.yml
@@ -107,7 +107,7 @@ general:
   run_history: []
 
 # logging frequency in the training loop (in number of batches)
-train_log_freq:
+train_logging:
   terminal: 10
   metrics: 20
   checkpoint: 250

--- a/config/config_forecasting.yml
+++ b/config/config_forecasting.yml
@@ -117,7 +117,7 @@ general:
   run_history: []
 
 # logging frequency in the training loop (in number of batches)
-train_log_freq:
+train_logging:
   terminal: 10
   metrics: 20
   checkpoint: 250

--- a/config/config_forecasting_finetuning.yml
+++ b/config/config_forecasting_finetuning.yml
@@ -117,7 +117,7 @@ general:
   run_history: []
 
 # logging frequency in the training loop (in number of batches)
-train_log_freq:
+train_logging:
   terminal: 10
   metrics: 20
   checkpoint: 250

--- a/config/config_jepa_finetuning.yml
+++ b/config/config_jepa_finetuning.yml
@@ -116,7 +116,7 @@ general:
   run_history: []
 
 # logging frequency in the training loop (in number of batches)
-train_log_freq:
+train_logging:
   terminal: 10
   metrics: 20
   checkpoint: 250

--- a/integration_tests/small1.yaml
+++ b/integration_tests/small1.yaml
@@ -26,5 +26,5 @@ impute_latent_noise_std: 0.0
 healpix_level: 4
 training_mode: "forecast"
 
-train_log:
+train_logging:
   log_interval: 1

--- a/integration_tests/small_multi_stream.yaml
+++ b/integration_tests/small_multi_stream.yaml
@@ -113,7 +113,7 @@ general:
   run_id: ???
   run_history: []
 
-train_log_freq:
+train_logging:
   terminal: 10
   metrics: 20
   checkpoint: 250

--- a/integration_tests/small_multi_stream_test.py
+++ b/integration_tests/small_multi_stream_test.py
@@ -68,7 +68,7 @@ def test_train_multi_stream(setup, test_run_id):
     )
    
     infer_multi_stream(test_run_id)
-    # evaluate_multi_stream_results(test_run_id)
+    evaluate_multi_stream_results(test_run_id)
     assert_metrics_file_exists(test_run_id)
     assert_stream_losses_below_threshold(test_run_id, stage="train")
     assert_stream_losses_below_threshold(test_run_id, stage="val")

--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -329,7 +329,7 @@ def _check_logging(config: Config) -> Config:
     Apply fixes to log frequency config.
     """
     config = config.copy()
-    if config.get("train_log_freq") is None:  # TODO remove this for next version
+    if config.get("train_logging") is None:  # TODO remove this for next version
         config.train_log_freq = OmegaConf.create(
             {"checkpoint": 250, "terminal": 10, "metrics": config.train_log.log_interval}
         )

--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -330,8 +330,8 @@ def _check_logging(config: Config) -> Config:
     """
     config = config.copy()
     if config.get("train_logging") is None:  # TODO remove this for next version
-        config.train_log_freq = OmegaConf.create(
-            {"checkpoint": 250, "terminal": 10, "metrics": config.train_log.log_interval}
+        config.train_logging = OmegaConf.create(
+            {"checkpoint": 250, "terminal": 10, "metrics": config.train_logging.log_interval}
         )
 
     return config

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -55,10 +55,10 @@ logger = logging.getLogger(__name__)
 
 
 class Trainer(TrainerBase):
-    def __init__(self, train_log_freq: Config):
+    def __init__(self, train_logging: Config):
         TrainerBase.__init__(self)
 
-        self.train_log_freq = train_log_freq
+        self.train_logging = train_logging
 
         self.data_loader: torch.utils.data.DataLoader | None = None
         self.data_loader_validation: torch.utils.data.DataLoader | None = None
@@ -488,9 +488,9 @@ class Trainer(TrainerBase):
 
             # log gradient norms
             if self.log_grad_norms:
-                if bidx % self.train_log_freq.terminal == 0:
+                if bidx % self.train_logging.terminal == 0:
                     self.last_grad_norm = self._get_tensor_item(total_norm)
-                if bidx % self.train_log_freq.metrics == 0:
+                if bidx % self.train_logging.metrics == 0:
                     self._log_instant_grad_norms(TRAIN)
 
             # optimizer step
@@ -527,14 +527,14 @@ class Trainer(TrainerBase):
                 )
 
             self._log_terminal(bidx, mini_epoch, TRAIN)
-            if bidx % self.train_log_freq.metrics == 0:
+            if bidx % self.train_logging.metrics == 0:
                 self._log(TRAIN)
                 # Log collapse metrics
                 if self.collapse_monitor.should_log(self.cf.general.istep):
                     self._log_collapse_metrics(TRAIN)
 
             # save model checkpoint (with designation _latest)
-            if bidx % self.train_log_freq.checkpoint == 0 and bidx > 0:
+            if bidx % self.train_logging.checkpoint == 0 and bidx > 0:
                 self.save_model(-1)
 
             self.cf.general.istep += 1
@@ -763,7 +763,7 @@ class Trainer(TrainerBase):
             self.train_logger.log_metrics(stage, grad_norms)
 
     def _log_terminal(self, bidx: int, mini_epoch: int, stage: Stage):
-        print_freq = self.train_log_freq.terminal
+        print_freq = self.train_logging.terminal
         if bidx % print_freq == 0 and bidx > 0 or stage == VAL:
             # compute from last iteration
             loss_calculator = self.loss_calculator_val if stage == VAL else self.loss_calculator


### PR DESCRIPTION
## Description

Replace left over train_log_freqs

Integration tests run except for known, separate issue of none type datetime in evaluation.

## Issue Number

Closes #1926 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
