### PR TITLE
Fix valid_time bug

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -401,7 +401,7 @@ class Plotter:
                         region,
                         tag=tag,
                         map_kwargs=dict(map_kwargs.get(var, {})) | map_kwargs_global,
-                        title=self.get_map_title(var, valid_time),
+                        title=self.get_map_title(var, valid_time, da_t),
                     )
                     plot_names.append(name)
 

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -503,7 +503,7 @@ class Plotter:
         )
 
         plt.colorbar(scatter_plt, ax=ax, orientation="horizontal", label=f"Variable: {varname}")
-        plt.title(title)
+        plt.title(title, fontsize=9.5)
         if regionname == "global":
             ax.set_global()
         else:
@@ -630,8 +630,8 @@ class Plotter:
         if valid_time is not None:
             title += f" ({format_datetime(valid_time)})"
         elif "valid_time" in data.coords:
-            valid_time_start = data["valid_time"][0].values
-            valid_time_end = data["valid_time"][-1].values
+            valid_time_start = data["valid_time"].values.min()
+            valid_time_end = data["valid_time"].values.max()
             if valid_time_start != valid_time_end:
                 title += (
                     f" ({format_datetime(valid_time_start)} - {format_datetime(valid_time_end)})"

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -16,8 +16,8 @@ import xarray as xr
 from matplotlib.lines import Line2D
 from PIL import Image
 from scipy.stats import wilcoxon
-
 from weathergen.common.config import _load_private_conf
+
 from weathergen.evaluate.plotting.plot_utils import (
     DefaultMarkerSize,
 )
@@ -401,10 +401,7 @@ class Plotter:
                         region,
                         tag=tag,
                         map_kwargs=dict(map_kwargs.get(var, {})) | map_kwargs_global,
-                        title=(
-                            f"{self.stream}, {var} : fstep = {self.fstep:03} "
-                            f"({format_datetime(valid_time)})"
-                        ),
+                        title=self.get_map_title(var, valid_time),
                     )
                     plot_names.append(name)
 
@@ -627,6 +624,22 @@ class Plotter:
 
     def get_map_output_dir(self, tag):
         return self.out_plot_basedir / self.stream / "maps" / tag
+
+    def get_map_title(self, var, valid_time, data):
+        title = f"{self.stream}, {var} : fstep = {self.fstep:03}"
+        if valid_time is not None:
+            title += f" ({format_datetime(valid_time)})"
+        elif "valid_time" in data.coords:
+            valid_time_start = data["valid_time"][0].values
+            valid_time_end = data["valid_time"][-1].values
+            if valid_time_start != valid_time_end:
+                title += (
+                    f" ({format_datetime(valid_time_start)} - {format_datetime(valid_time_end)})"
+                )
+            else:
+                title += f" ({format_datetime(valid_time_start)})"
+
+        return title
 
 
 class LinePlots:

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -16,8 +16,8 @@ import xarray as xr
 from matplotlib.lines import Line2D
 from PIL import Image
 from scipy.stats import wilcoxon
-from weathergen.common.config import _load_private_conf
 
+from weathergen.common.config import _load_private_conf
 from weathergen.evaluate.plotting.plot_utils import (
     DefaultMarkerSize,
 )

--- a/packages/evaluate/src/weathergen/evaluate/utils/utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils/utils.py
@@ -430,7 +430,8 @@ def plot_data(reader: Reader, stream: str, global_plotting_opts: dict) -> None:
         "fig_size": global_plotting_opts.get("fig_size", (8, 10)),
         "fps": global_plotting_opts.get("fps", 2),
         "regions": global_plotting_opts.get("regions", ["global"]),
-        "plot_subtimesteps": reader.get_inference_stream_attr(stream, "tokenize_spacetime", False),
+        "plot_subtimesteps": reader.get_inference_stream_attr(stream, "tokenize_spacetime", False)
+        | plot_settings.get("plot_subtimesteps", False),
     }
     plotter = Plotter(plotter_cfg, reader.runplot_dir)
 

--- a/src/weathergen/model/embeddings.py
+++ b/src/weathergen/model/embeddings.py
@@ -142,7 +142,7 @@ class StreamEmbedTransformer(torch.nn.Module):
         x = peh(self.embed(x_in.transpose(-2, -1)))
 
         for layer in self.layers:
-            x = checkpoint(layer,x, use_reentrant=False)
+            x = checkpoint(layer, x, use_reentrant=False)
 
         # read out
         if self.unembed_mode == "full":


### PR DESCRIPTION
## Description

With this PR, we distinguish cases in valid_times for the global maps, and we adapt the titles accordingly.

## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/1913

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [X] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
