### PR TITLE
[1918] Use exclude-newer in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ cpu = [
 ]
 
 gpu = [
-  'torch==2.6.0',
+  "torch==2.6.0; sys_platform == 'linux'",
   # flash-attn also has a torch dependency.
   "flash-attn",
 ]
@@ -162,7 +162,7 @@ link-mode = "symlink"
 # by future releases of dependencies or sub-dependencies. 
 # See https://docs.astral.sh/uv/reference/settings/#exclude-newer
 # TODO: pytorch does not publish valid release timestamps, so sadly it does not work.
-# exclude-newer = "2025-03-14T00:00:00Z"
+exclude-newer = "2026-02-27T00:00:00Z"
 
 # The minimum version of uv required.
 # It is tightly controlled because the format of uv.lock has changed 
@@ -242,9 +242,10 @@ torch = [
 # Explicit pin for GPU
   { url = "https://download.pytorch.org/whl/cu126/torch-2.6.0%2Bcu126-cp312-cp312-linux_aarch64.whl", marker = 'sys_platform == "linux" and platform_machine == "aarch64"', extra="gpu" },
   { url = "https://download.pytorch.org/whl/cu126/torch-2.6.0%2Bcu126-cp312-cp312-manylinux_2_28_x86_64.whl", marker = 'sys_platform == "linux"  and platform_machine == "x86_64"', extra="gpu" },
-# Use the public repo for CPU versions.
-  { index = "pytorch-cpu", marker = "sys_platform == 'linux'", extra="cpu"},
-  { index = "pytorch-cpu", marker = "sys_platform == 'darwin'", extra="cpu"},
+# Explicit pin for CPU.
+  { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-linux_x86_64.whl",marker = "sys_platform == 'linux' and platform_machine == 'x86_64'",extra = "cpu" },
+  { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl",marker = "sys_platform == 'linux' and platform_machine == 'aarch64'",extra = "cpu" },
+  { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0-cp312-none-macosx_11_0_arm64.whl",marker = "sys_platform == 'darwin'", extra="cpu" },
   # No acceleration for now.
   # TODO: explore pytorch + metal backend
   { index = "pytorch-cpu", marker = "sys_platform == 'darwin'", extra="gpu"},


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->

- Added `exclude-newer` flag in `pyproject.toml`
- Does not work for `Pytorch` because it does not publish valid release timestamps -> added wheels for torch CPU 
- Works for the other packages and sub-packages


## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Closes #1918 


## Checklist before asking for review

-   [X] I have performed a self-review of my code
-   [X] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [X] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
