### PR TITLE
Update jepa finetuning:

### DIFF
--- a/config/config_jepa_finetuning.yml
+++ b/config/config_jepa_finetuning.yml
@@ -7,51 +7,11 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-embed_orientation: "channels"
-embed_unembed_mode: "block"
-embed_dropout_rate: 0.1
-
-ae_local_dim_embed: 1024
-ae_local_num_blocks: 4
-ae_local_num_heads: 16
-ae_local_dropout_rate: 0.1
-ae_local_with_qk_lnorm: True
-
-ae_local_num_queries: 1
-ae_local_queries_per_cell: False
-ae_adapter_num_heads: 16
-ae_adapter_embed: 128
-ae_adapter_with_qk_lnorm: True
-ae_adapter_with_residual: True
-ae_adapter_dropout_rate: 0.1
-
-ae_global_dim_embed: 2048
-ae_global_num_blocks: 2
-ae_global_num_heads: 32
-ae_global_dropout_rate: 0.1
-ae_global_with_qk_lnorm: True
-# TODO: switching to < 1 triggers triton-related issues.
-# See https://github.com/ecmwf/WeatherGenerator/issues/1050
-ae_global_att_dense_rate: 1.0
-ae_global_block_factor: 64
-ae_global_mlp_hidden_factor: 2
-ae_global_trailing_layer_norm: False
-
-ae_aggregation_num_blocks: 8
-ae_aggregation_num_heads: 32
-ae_aggregation_dropout_rate: 0.1
-ae_aggregation_with_qk_lnorm: True
-ae_aggregation_att_dense_rate: 1.0
-ae_aggregation_block_factor: 64
-ae_aggregation_mlp_hidden_factor: 2
-
 decoder_type: PerceiverIOCoordConditioning # CrossAttentionAdaNormConditioning
 pred_adapter_kv: False
 pred_self_attention: True
 pred_dyadic_dims: False
 pred_mlp_adaln: True
-num_class_tokens: 1
-num_register_tokens: 7
 
 # number of steps offset applied to first target window; if set to zero and forecast_steps=0 then
 # one is training an auto-encoder
@@ -65,8 +25,6 @@ fe_impute_latent_noise_std: 0.0  # 1e-4
 forecast_att_dense_rate: 1.0
 with_step_conditioning: True # False
 
-healpix_level: 5
-
 # performance
 with_mixed_precision: True
 with_flash_attention: True
@@ -78,12 +36,6 @@ mixed_precision_dtype: bf16
 mlp_norm_eps: 1e-5
 norm_eps: 1e-4
 
-latent_noise_kl_weight: 0.0 # 1e-5
-latent_noise_gamma: 2.0
-latent_noise_saturate_encodings: 5 
-latent_noise_use_additive_noise: False
-latent_noise_deterministic_latents: True
-
 freeze_modules: ".*encoder.*|.*latent_pre_norm.*|.*latent_heads.*"
 
 # type of zarr_store
@@ -91,8 +43,7 @@ zarr_store: "zip" # "zarr" for LocalStore, "zip" for ZipStore
 
 #####################################
 
-# streams_directory: "./config/streams/era5_1deg/"
-streams_directory: "./config/streams/era5_synop_finetuning/"
+streams_directory: "./config/streams/era5_iasi_finetuning/"
 streams: ???
 
 general:
@@ -139,8 +90,8 @@ training_config:
   samples_per_mini_epoch: 4096
   shuffle: True
 
-  start_date: 1979-01-01T00:00
-  end_date: 2022-12-31T00:00
+  start_date: 2012-01-01T00:00
+  end_date: 2022-08-31T00:00
 
   time_window_step: 06:00:00
   time_window_len: 06:00:00
@@ -172,7 +123,7 @@ training_config:
   losses : {
     "student-teacher": {
         enabled: False,
-        type: LossLatentSSLStudentTeacher,
+        type: Disabled,
         weight: 1.0,
         loss_fcts : {
           "JEPA": {
@@ -210,7 +161,7 @@ training_config:
       # masking strategy: "random", "forecast"
       enabled: False,
       masking_strategy: "random",
-      num_samples: 1,
+      num_samples: 0,
       num_steps_input: 1,
       masking_strategy_config : { 
         diffusion_rn : True, 
@@ -271,7 +222,7 @@ validation_config:
     # write samples in normalized model space
     normalized_samples: False,
     # output streams to write; default all
-    streams: ["SurfaceCombined"],
+    # streams: ["SurfaceCombined"],
   }
 
   # run validation before training starts (mainly for model development)

--- a/config/config_jepa_finetuning.yml
+++ b/config/config_jepa_finetuning.yml
@@ -91,7 +91,7 @@ training_config:
   shuffle: True
 
   start_date: 2012-01-01T00:00
-  end_date: 2022-09-31T00:00
+  end_date: 2022-08-31T00:00
 
   time_window_step: 06:00:00
   time_window_len: 06:00:00

--- a/config/config_jepa_finetuning.yml
+++ b/config/config_jepa_finetuning.yml
@@ -91,7 +91,7 @@ training_config:
   shuffle: True
 
   start_date: 2012-01-01T00:00
-  end_date: 2022-08-31T00:00
+  end_date: 2022-09-31T00:00
 
   time_window_step: 06:00:00
   time_window_len: 06:00:00

--- a/config/streams/era5_iasi_finetuning/era5.yml
+++ b/config/streams/era5_iasi_finetuning/era5.yml
@@ -1,0 +1,40 @@
+# (C) Copyright 2024 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+ERA5 :
+  type : anemoi
+  filenames : ['aifs-ea-an-oper-0001-mars-o96-1979-2023-6h-v8.zarr']
+  stream_id : 0
+  source_exclude : ['w_', 'skt', 'tcw', 'cp', 'tp']
+  target : [ ]
+  forcing: True
+  loss_weight : 1.
+  location_weight : cosine_latitude
+  masking_rate : 0.6
+  masking_rate_none : 0.05
+  token_size : 8
+  tokenize_spacetime : True
+  max_num_targets: -1 
+  embed : 
+    net : transformer
+    num_tokens : 1
+    num_heads : 8
+    dim_embed : 256
+    num_blocks : 2
+  embed_target_coords :
+    net : linear
+    dim_embed : 256
+  target_readout :
+    num_layers : 2
+    num_heads : 4
+    # sampling_rate : 0.2
+  pred_head :
+    ens_size : 1
+    num_layers : 1
+

--- a/config/streams/era5_iasi_finetuning/iasi.yml
+++ b/config/streams/era5_iasi_finetuning/iasi.yml
@@ -5,7 +5,7 @@
 
 METOPBIASI :
   type : obs
-  stream_id : 3
+  stream_id : 1
   filenames : ['observations-ea-ofb-0001-2013-2023-metop-b-iasi-radiances-v1.zarr']
   loss_weight : 1.
   diagnostic : True

--- a/config/streams/era5_iasi_finetuning/iasi.yml
+++ b/config/streams/era5_iasi_finetuning/iasi.yml
@@ -1,0 +1,30 @@
+# obs_types
+# 0 : polar orbiting satellites
+# 1 : geostationay satellites
+# 2 : conventional observations
+
+METOPBIASI :
+  type : obs
+  stream_id : 3
+  filenames : ['observations-ea-ofb-0001-2013-2023-metop-b-iasi-radiances-v1.zarr']
+  loss_weight : 1.
+  diagnostic : True
+  masking_rate : 0.6
+  masking_rate_none : 0.05
+  token_size : 512
+  embed : 
+    net : transformer
+    num_tokens : 1
+    num_heads : 2
+    dim_embed : 256
+    num_blocks : 2
+  embed_target_coords :
+    net : linear
+    dim_embed : 256
+  target_readout :
+    num_layers : 2
+    num_heads : 4
+  pred_head :
+    ens_size : 1
+    num_layers : 1
+


### PR DESCRIPTION
## Description

Update the jepa finetuning configs to use IASI by default


## Issue Number

Closes #1956

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
