### PR TITLE
[1974][model] Add fallback to config loading

### DIFF
--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -234,12 +234,25 @@ def load_run_config(run_id: str, mini_epoch: int | None, model_path: str | None)
         else:
             path = Path(model_path) / run_id
 
-        fname = path / _get_model_config_file_read_name(run_id, mini_epoch)
-        assert fname.exists(), (
-            "The fallback path to the model does not exist. Please provide a `model_path`.",
-            fname,
-        )
-        _logger.info(f"Loading config from specified run_id and mini_epoch: {fname}")
+        config_path_with_epoch = path / _get_model_config_file_read_name(run_id, mini_epoch)
+        config_path_without_epoch = path / _get_model_config_file_read_name(run_id, None)
+
+        if config_path_with_epoch.exists():
+            fname = config_path_with_epoch
+            _logger.info(f"Loading config from specified run_id and mini_epoch: {fname}")
+        elif config_path_without_epoch.exists():
+            fname = config_path_without_epoch
+            _logger.info(
+                f"Config for mini_epoch {mini_epoch} not found. "
+                f"Falling back to config without mini_epoch: {fname}"
+            )
+        else:
+            raise FileNotFoundError(
+                f"Could not find model config for run_id '{run_id}' "
+                f"(mini_epoch={mini_epoch}) in '{path}'. "
+                f"Tried: '{config_path_with_epoch.name}' and '{config_path_without_epoch.name}'. "
+                f"Please provide a valid `model_path`."
+            )
 
     with fname.open() as f:
         json_str = f.read()

--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -251,7 +251,7 @@ def load_run_config(run_id: str, mini_epoch: int | None, model_path: str | None)
                 f"Could not find model config for run_id '{run_id}' "
                 f"(mini_epoch={mini_epoch}) in '{path}'. "
                 f"Tried: '{config_path_with_epoch.name}' and '{config_path_without_epoch.name}'. "
-                f"Please provide a valid `model_path`."
+                f"Please check run-id and mini_epoch."
             )
 
     with fname.open() as f:

--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -251,7 +251,7 @@ def load_run_config(run_id: str, mini_epoch: int | None, model_path: str | None)
                 f"Could not find model config for run_id '{run_id}' "
                 f"(mini_epoch={mini_epoch}) in '{path}'. "
                 f"Tried: '{config_path_with_epoch.name}' and '{config_path_without_epoch.name}'. "
-                f"Please check run-id and mini_epoch."
+                f"Please check run_id and mini_epoch."
             )
 
     with fname.open() as f:


### PR DESCRIPTION
## Description

When loading the config `.json` file with the provided `mini_epoch` fails, we now fall back to using the `.json` file without `mini_epoch` suffix.

## Issue Number

Closes #1974 

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
