### PR TITLE
Introduce "plot_bias" in evaluation configuration

### DIFF
--- a/config/evaluate/eval_config.yml
+++ b/config/evaluate/eval_config.yml
@@ -47,6 +47,7 @@ default_streams:
       forecast_step: [1,3, 2] #supported: "all", [1,2,3,...], "1-50" (equivalent of [1,2,3,...50])
       ensemble: [0,2,5] #supported: "all", "mean", [0,1,2]
       plot_maps: true
+      plot_bias: false
       plot_target: false
       plot_histograms: true
       plot_animations: true
@@ -59,6 +60,7 @@ default_streams:
       sample: [2, 3, 0]
       forecast_step: [1,3, 4, 5]
       plot_maps: true
+      plot_bias: false
       plot_target: false
       plot_histograms: true
       plot_animations: true
@@ -96,6 +98,7 @@ run_ids :
           forecast_step: [1,3, 2]
           ensemble: "mean" 
           plot_maps: true
+          plot_bias: false
           plot_target: false
           plot_histograms: true
           plot_animations: true


### PR DESCRIPTION
## Description

Update evaluation config.

Closes https://github.com/ecmwf/WeatherGenerator/issues/1772

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
