### PR TITLE
Fixing flash attn in ddp diffusion model

### DIFF
--- a/config/config_diffusion.yml
+++ b/config/config_diffusion.yml
@@ -95,7 +95,7 @@ latent_noise_deterministic_latents: True
 
 
 freeze_modules: ".*latent_pre_norm.*|.*latent_heads.*|.*pred_heads.*|.*target_token_engines.*|.*embed_target_coords.*|.*encoder.*|.*StreamEmbedder_ERA5.*|.*embed_engine.*|.*embed_engine.*|.*ae_local_engine.*|.*ae_local_global_engine.*|.*ae_global_engine.*"
-load_chkpt: {'run_id': 't0bdz7qn', 'epoch': -1}
+# load_chkpt: {'run_id': 't0bdz7qn', 'epoch': -1}
 
 norm_type: "LayerNorm"
 
@@ -244,7 +244,7 @@ validation_config:
     }
 
   # run validation before training starts (mainly for model development)
-  validate_before_training: True
+  validate_before_training: False
 
 
 # test config; full test config is merge of validation and test config

--- a/src/weathergen/model/attention.py
+++ b/src/weathergen/model/attention.py
@@ -87,9 +87,9 @@ class MultiSelfAttentionHeadVarlen(torch.nn.Module):
         # project onto heads and q,k,v and
         # ensure these are 4D tensors as required for flash attention
         s = [x.shape[0], self.num_heads, x.shape[-1] // self.num_heads]
-        qs = self.lnorm_q(self.proj_heads_q(x).reshape(s)).to(self.dtype)
-        ks = self.lnorm_k(self.proj_heads_k(x).reshape(s)).to(self.dtype)
-        vs = self.proj_heads_v(x).reshape(s)
+        qs = self.lnorm_q(self.proj_heads_q(x).reshape(s)).to(self.dtype).contiguous()
+        ks = self.lnorm_k(self.proj_heads_k(x).reshape(s)).to(self.dtype).contiguous()
+        vs = self.proj_heads_v(x).reshape(s).contiguous()
 
         if self.with_2d_rope:
             if coords is None:
@@ -183,9 +183,9 @@ class MultiSelfAttentionHeadVarlenFlex(torch.nn.Module):
         # project onto heads and q,k,v and
         # ensure these are 4D tensors as required for flash attention
         s = [x.shape[0], 1, self.num_heads, -1]
-        qs = self.lnorm_q(self.proj_heads_q(x).reshape(s)).to(self.dtype).permute([1, 2, 0, 3])
-        ks = self.lnorm_k(self.proj_heads_k(x).reshape(s)).to(self.dtype).permute([1, 2, 0, 3])
-        vs = self.proj_heads_v(x).reshape(s).permute([1, 2, 0, 3])
+        qs = self.lnorm_q(self.proj_heads_q(x).reshape(s)).to(self.dtype).permute([1, 2, 0, 3]).contiguous()
+        ks = self.lnorm_k(self.proj_heads_k(x).reshape(s)).to(self.dtype).permute([1, 2, 0, 3]).contiguous()
+        vs = self.proj_heads_v(x).reshape(s).permute([1, 2, 0, 3]).contiguous()
 
         outs = self.compiled_flex_attention(qs, ks, vs).transpose(1, 2).squeeze()
 
@@ -275,9 +275,9 @@ class MultiSelfAttentionHeadLocal(torch.nn.Module):
 
         # project onto heads
         s = [x.shape[0], x.shape[1], self.num_heads, -1]
-        qs = self.lnorm_q(self.proj_heads_q(x).reshape(s)).to(self.dtype).permute([0, 2, 1, 3])
-        ks = self.lnorm_k(self.proj_heads_k(x).reshape(s)).to(self.dtype).permute([0, 2, 1, 3])
-        vs = self.proj_heads_v(x).reshape(s).permute([0, 2, 1, 3])
+        qs = self.lnorm_q(self.proj_heads_q(x).reshape(s)).to(self.dtype).permute([0, 2, 1, 3]).contiguous()
+        ks = self.lnorm_k(self.proj_heads_k(x).reshape(s)).to(self.dtype).permute([0, 2, 1, 3]).contiguous()
+        vs = self.proj_heads_v(x).reshape(s).permute([0, 2, 1, 3]).contiguous()
 
         if self.with_2d_rope:
             if coords is None:
@@ -360,10 +360,10 @@ class MultiCrossAttentionHeadVarlen(torch.nn.Module):
         # project onto heads and q,k,v and
         # ensure these are 4D tensors as required for flash attention
         s = [x_q.shape[0], self.num_heads, self.dim_head_proj]
-        qs = self.lnorm_q(self.proj_heads_q(x_q).reshape(s)).to(self.dtype)
+        qs = self.lnorm_q(self.proj_heads_q(x_q).reshape(s)).to(self.dtype).contiguous()
         s = [x_kv.shape[0], self.num_heads, self.dim_head_proj]
-        ks = self.lnorm_k(self.proj_heads_k(x_kv).reshape(s)).to(self.dtype)
-        vs = self.proj_heads_v(x_kv).reshape(s)
+        ks = self.lnorm_k(self.proj_heads_k(x_kv).reshape(s)).to(self.dtype).contiguous()
+        vs = self.proj_heads_v(x_kv).reshape(s).contiguous()
 
         # set dropout rate according to training/eval mode as required by flash_attn
         dropout_rate = self.dropout_rate if self.training else 0.0
@@ -468,12 +468,12 @@ class MultiCrossAttentionHeadVarlenSlicedQ(torch.nn.Module):
         # ensure these are 4D tensors as required for flash attention
         s = [x_q.shape[0], self.num_heads, self.dim_head_proj]
         qs = [
-            self.lnorm_q(head_proj(x_q_i).reshape(s)).to(self.dtype)
+            self.lnorm_q(head_proj(x_q_i).reshape(s)).to(self.dtype).contiguous()
             for head_proj, x_q_i in zip(self.proj_heads_q, x_q.transpose(1, 0), strict=False)
         ]
         s = [x_kv.shape[0], self.num_heads, self.dim_head_proj]
-        ks = self.lnorm_k(self.proj_heads_k(x_kv).reshape(s)).to(self.dtype)
-        vs = self.proj_heads_v(x_kv).reshape(s)
+        ks = self.lnorm_k(self.proj_heads_k(x_kv).reshape(s)).to(self.dtype).contiguous()
+        vs = self.proj_heads_v(x_kv).reshape(s).contiguous()
 
         # set dropout rate according to training/eval mode as required by flash_attn
         dropout_rate = self.dropout_rate if self.training else 0.0
@@ -580,9 +580,9 @@ class MultiSelfAttentionHead(torch.nn.Module):
         # project onto heads and q,k,v and
         # ensure these are 4D tensors as required for flash attention
         s = [*([x.shape[0], 1] if len(x.shape) == 2 else x.shape[:-1]), self.num_heads, -1]
-        qs = self.lnorm_q(self.proj_heads_q(x).reshape(s)).to(self.dtype)
-        ks = self.lnorm_k(self.proj_heads_k(x).reshape(s)).to(self.dtype)
-        vs = self.proj_heads_v(x).reshape(s).to(self.dtype)
+        qs = self.lnorm_q(self.proj_heads_q(x).reshape(s)).to(self.dtype).contiguous()
+        ks = self.lnorm_k(self.proj_heads_k(x).reshape(s)).to(self.dtype).contiguous()
+        vs = self.proj_heads_v(x).reshape(s).to(self.dtype).contiguous()
 
         if self.with_2d_rope:
             if coords is None:
@@ -664,10 +664,10 @@ class MultiCrossAttentionHead(torch.nn.Module):
         # project onto heads and q,k,v and
         # ensure these are 4D tensors as required for flash attention
         s = [x_q.shape[0], -1, self.num_heads, self.dim_head_proj]
-        qs = self.lnorm_q(self.proj_heads_q(x_q).reshape(s)).to(self.dtype).transpose(-3, -2)
+        qs = self.lnorm_q(self.proj_heads_q(x_q).reshape(s)).to(self.dtype).transpose(-3, -2).contiguous()
         s = [x_kv.shape[0], -1, self.num_heads, self.dim_head_proj]
-        ks = self.lnorm_k(self.proj_heads_k(x_kv).reshape(s)).to(self.dtype).transpose(-3, -2)
-        vs = self.proj_heads_v(x_kv).reshape(s).transpose(-3, -2)
+        ks = self.lnorm_k(self.proj_heads_k(x_kv).reshape(s)).to(self.dtype).transpose(-3, -2).contiguous()
+        vs = self.proj_heads_v(x_kv).reshape(s).transpose(-3, -2).contiguous()
 
         # correct ordering of tensors with seq dimension second but last is critical
         with torch.nn.attention.sdpa_kernel(torch.nn.attention.SDPBackend.FLASH_ATTENTION):

--- a/src/weathergen/model/model_interface.py
+++ b/src/weathergen/model/model_interface.py
@@ -76,7 +76,7 @@ def init_model_and_shard(
             find_unused_parameters=cf.get("ddp_find_unused_parameters", True),
             gradient_as_bucket_view=True,
             bucket_cap_mb=512,
-            static_graph=cf.get("ddp_static_graph", True)
+            # static_graph=cf.get("ddp_static_graph", True)
         )
 
     elif with_ddp and with_fsdp:

--- a/src/weathergen/model/model_interface.py
+++ b/src/weathergen/model/model_interface.py
@@ -332,20 +332,8 @@ def get_target_aux_calculator(
         target_aux = PhysicalTargetAndAux(loss_cfg, model)
 
     elif target_and_aux_calc == "DiffusionLatentTargetEncoder":
-        model, _ = init_model_and_shard(
-            cf,
-            dataset,
-            cf.get("load_chkpt", {}).get("run_id", None),
-            cf.get("load_chkpt", {}).get("epoch", -1),
-            "student",
-            device,
-            with_ddp=False,
-            with_fsdp=False,
-            overrides=target_and_aux_calc_params.get("model_param_overrides", {}),
-        )
-        target_aux = DiffusionLatentTargetEncoder(
-            model, is_model_sharded=(cf.with_ddp and cf.with_fsdp)
-        )
+        # Uses the training model's frozen encoder directly — no separate model needed.
+        target_aux = DiffusionLatentTargetEncoder()
     elif target_and_aux_calc == "EMATeacher":
         # work around for problems with FSDP2
         assert not cf.with_fsdp, "EMATeacher not supported with FSDP(2) at the moment"

--- a/src/weathergen/train/target_and_aux_diffusion.py
+++ b/src/weathergen/train/target_and_aux_diffusion.py
@@ -11,34 +11,16 @@ from weathergen.train.target_and_aux_module_base import (
 
 
 class DiffusionLatentTargetEncoder(TargetAndAuxModuleBase):
-    def __init__(self, encoder, is_model_sharded=True):
-        # Todo: make sure this is a frozen clone or forward without gradients in compute()
-        self.encoder = encoder
+    """Computes latent diffusion targets by running the training model's frozen encoder.
 
-        self.is_model_sharded = is_model_sharded
-        # Build a name → param map once
-        self.src_params = dict(self.encoder.named_parameters())
+    No separate encoder copy is maintained. The training model's encoder is assumed to be
+    frozen (via freeze_modules config) and is used directly in compute(). This guarantees
+    that the encoder producing targets is identical to the one in the forward pass and
+    avoids illegal memory access errors from running two independent flash-attention models.
+    """
 
-        self.reset()
-
-    @torch.no_grad()
-    def reset(self):
-        """
-        This function resets the EMAModel to be the same as the Model.
-
-        It operates via the state_dict to be able to deal with sharded tensors in case
-        FSDP2 is used.
-        """
-        self.encoder.to_empty(device="cuda")
-        for p in self.encoder.parameters():
-            p.requires_grad = False
-        maybe_sharded_sd = self.encoder.state_dict()
-        mkeys, ukeys = self.encoder.load_state_dict(maybe_sharded_sd, strict=False, assign=False)
-        self.encoder.eval()
-
-    def update_state_post_opt_step(self, istep, batch, model, **kwargs) -> None:
-        if self.is_model_sharded:
-            self.encoder.reshard()
+    def __init__(self):
+        pass
 
     def compute(
         self,
@@ -53,10 +35,12 @@ class DiffusionLatentTargetEncoder(TargetAndAuxModuleBase):
             batch.samples[0].meta_info["ERA5"].params["noise_level_rn"]
         )  # TODO: adjust for multiple streams
 
-        # TODO: check if there are scenarios where the encoder needs to be set to eval
+        # The encoder is frozen (requires_grad=False via freeze_modules), so no_grad is
+        # used only to avoid unnecessary autograd bookkeeping and reduce memory usage.
+        # Unwrap DDP wrapper if present to access the encoder directly.
+        unwrapped = model.module if hasattr(model, "module") else model
         with torch.no_grad():
-            tokens, posteriors = self.encoder.encoder(model_params=model_params, batch=batch)
-        # NOTE: must not set to train afterwards unless it was already in train
+            tokens, posteriors = unwrapped.encoder(model_params=model_params, batch=batch)
 
         output_idxs = batch.get_output_idxs()
         assert len(output_idxs) > 0
@@ -64,7 +48,7 @@ class DiffusionLatentTargetEncoder(TargetAndAuxModuleBase):
         target_aux_output = TargetAuxOutput(batch.get_output_len(), output_idxs)
 
         # TODO: currently hard-coding 0
-        target_aux_output.add_latent_target(0, "diffusion_latent", tokens)
+        target_aux_output.add_latent_target(0, "diffusion_latent", tokens.detach().clone())
 
         # TODO: write function in TargetAuxOutput class
         target_aux_output.aux_outputs = {"noise_level_rn": noise_level_rn}


### PR DESCRIPTION
## Description

When running multi-gpu training with `fe_diffusion_model: True` we get illegal memory access error caused during back propagation in the varlen attention.

In this PR we tried to implement following fixes, however the issue persists.
- adding `.contiguous()` to all q/k/v tensors before they enter flash attention,
- using the training model's frozen encoder directly, no separate encoder copy is initialized,
- detaching encoded target tokens before passing it to the target aux output.

Not within this PR, we implemented Torch's SDPA as an alternative to the varlen attention. This indeed fixed the error, but it not what we want because of the memory overhead. Still, if the problem persists, we might use it as an intermediate solution to run diffusion experiments in multi-gpu setting. 

## Issue Number

Fixes #1999 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
