### PR TITLE
Reduce verbosity of output during inference and evaluation 

### DIFF
--- a/packages/common/src/weathergen/common/io.py
+++ b/packages/common/src/weathergen/common/io.py
@@ -23,7 +23,6 @@ import xarray as xr
 import zarr
 from numpy import datetime64
 from numpy.typing import NDArray
-from tqdm import tqdm
 from zarr.errors import ZarrUserWarning
 from zarr.storage import LocalStore, ZipStore
 
@@ -409,9 +408,7 @@ class ZarrIO:
     def write_zarr(self, item: OutputItem):
         """Write one output item to the zarr store."""
         group = self._get_group(item.key, create=True)
-        for dataset in tqdm(item.datasets):  # pyrefly: ignore[not-iterable]
-            # pyrefly doesn't recognize that tqdm makes item.datasets iterable
-            # until fixed, ignore the warning here
+        for dataset in item.datasets:
             if dataset is not None:
                 self._write_dataset(group, dataset)
 
@@ -530,7 +527,7 @@ class ZarrIO:
 
 class ZipZarrIO(ZarrIO):
     def __enter__(self) -> typing.Self:
-        _logger.info(f"Opening zipstore, read-only: {self.read_only}")
+        _logger.debug(f"Opening zipstore, read-only: {self.read_only}")
         self._store = ZipStore(self._store_path, mode=self._mode, read_only=self.read_only)
         if self.read_only:
             self.data_root = zarr.open_group(store=self._store, mode=self._mode)

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -555,7 +555,9 @@ class Trainer(TrainerBase):
 
         with torch.no_grad():
             # print progress bar but only in interactive mode, i.e. when without ddp
-            with tqdm.tqdm(total=mode_cfg.samples_per_mini_epoch, disable=self.cf.with_ddp) as pbar:
+            with tqdm.tqdm(
+                total=len(self.data_loader_validation), disable=self.cf.with_ddp
+            ) as pbar:
                 for bidx, batch in enumerate(dataset_val_iter):
                     if cf.data_loading.get("memory_pinning", False):
                         # pin memory for faster CPU-GPU transfer


### PR DESCRIPTION
## Description

Reduce verbosity of output during inference and evaluation to make it more reasonable.

## Issue Number

Closes #2004 

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
