### PR TITLE
Swap return order of da_pred and da_tar

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
@@ -675,7 +675,7 @@ def _select_channels(
         da_tar = da_tar.sel(channel=channels)
         da_pred = da_pred.sel(channel=channels)
 
-    return da_pred, da_tar
+    return da_tar, da_pred
 
 
 def _scale_z_channels(data: xr.DataArray, stream: str) -> xr.DataArray:


### PR DESCRIPTION
## Description

Quick fix to swap target and predictions in derived channels. 

## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/2019

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
