### PR TITLE
[2026] fix(integration-test): update samples_per_mini_epoch to pass integration-test-single

### DIFF
--- a/integration_tests/small1.yml
+++ b/integration_tests/small1.yml
@@ -138,7 +138,7 @@ training_config:
   training_mode: ["masking"]
 
   num_mini_epochs: 1
-  samples_per_mini_epoch: 48
+  samples_per_mini_epoch: 64
   shuffle: True
 
   start_date: 2014-01-01T00:00


### PR DESCRIPTION
## Description
`./scripts/actions.sh  integration-test-single` did not pass on Jupiter; the loss above the asserted threshold in [`integration_tests/small1_test.py`, line 64.](https://github.com/ecmwf/WeatherGenerator/blob/96c8169b0ea6d5806887d3a46c9eaf618a04eafa/integration_tests/small1_test.py#L64).

We increase the number of samples, which leading to a lower error beneath threshold.

## Issue Number
Closes #2026

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
