### PR TITLE
fix: sort variable lists by pressure level to match sorted pl

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/export/reshape.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/reshape.py
@@ -79,6 +79,13 @@ def find_pl(vars: list) -> tuple[dict[str, list[str]], list[int]]:
         else:
             var_dict.setdefault(var, []).append(var)
     pl = sorted(set(pl))
+    # Sort each variable list by pressure level so the order matches the sorted pl
+    for var_name in var_dict:
+        if len(var_dict[var_name]) > 1:
+            var_dict[var_name] = sorted(
+                var_dict[var_name],
+                key=lambda v: int(re.search(r"_(\d+)$", v).group(1)),
+            )
     return var_dict, pl
 
 


### PR DESCRIPTION
## Bug
https://github.com/ecmwf/WeatherGenerator/issues/2030 — `find_pl` sorts the list of unique pressure levels but does not sort the corresponding variable name lists in `var_dict`. When the caller later pairs data selected by `var_dict` entries with the sorted pressure level coordinates, the fields end up assigned to the wrong pressure levels.

## Fix
After sorting `pl`, sort each multi-entry list in `var_dict` by its pressure-level suffix so both orderings are consistent. Single-entry lists (non-pressure-level variables) are left untouched.

## Testing
Verified with a manual trace: given input `['q_850', 'q_500', 'q_200', 't_850', 't_500', 't_200']`, the returned `var_dict` now contains `{'q': ['q_200', 'q_500', 'q_850'], 't': ['t_200', 't_500', 't_850']}` matching `pl = [200, 500, 850]`. Previously the variable lists kept their original (unsorted) order, causing a data/coordinate mismatch in the downstream `_reshape_data` method.

Happy to address any feedback.

Greetings, saschabuehrle