### PR TITLE
fix tidx -> idx in _build_stream_data

### DIFF
--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -675,7 +675,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                 tidx = source_to_target[sidx].item()
                 sdata = self._build_stream_data(
                     source_select,
-                    tidx,
+                    idx,
                     num_forecast_steps,
                     stream_info,
                     source_masks.metadata[sidx].params.get("num_steps_input", 1),
@@ -695,7 +695,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                 # the inputs. Hence the target mask is also the source mask here.
                 sdata = self._build_stream_data(
                     target_select,
-                    tidx,
+                    idx,
                     num_forecast_steps,
                     stream_info,
                     target_masks.metadata[tidx].params.get("num_steps_input", 1),


### PR DESCRIPTION
## Description

Fix incorrect tidx -> correct idx in _build_stream_data for source and target in multi_stream_data_sampler. This was leading to incorrect source_interval_start and _end (always the same) when writing out, but also meant that source tokens had incorrect time embeddings, and also the target coord embeddings were also incorrect. Likely especially bad for irregular data.

After this fix we see, the source_interval_start and _end are now correct, cf. #2016.

```    
<xarray.DataArray 'prediction' (sample: 1, stream: 1, forecast_step: 1,
                                     ipoint: 40320, channel: 1, ens: 1)> Size: 161kB
     dask.array<reshape, shape=(1, 1, 1, 40320, 1, 1), dtype=float32, chunksize=(1, 1, 1, 672, 1, 1), chunktype=numpy.ndarray>
     Coordinates:
       * sample                 (sample) int64 8B 0
         source_interval_start  (sample) datetime64[ns] 8B 2021-10-10
         source_interval_end    (sample) datetime64[ns] 8B 2021-10-10T06:00:00
       * stream                 (stream) <U4 16B 'ERA5'
       * forecast_step          (forecast_step) int64 8B 1
       * ipoint                 (ipoint) int64 323kB 0 1 2 3 ... 40317 40318 40319
         valid_time             (ipoint) datetime64[ns] 323kB 2021-10-10T06:00:00 ...
         lat                    (ipoint) float32 161kB 89.28 89.28 ... -89.28 -89.28
         lon                    (ipoint) float32 161kB 0.0 18.0 36.0 ... -36.0 -18.0
       * channel                (channel) <U5 20B 't_850'
     Dimensions without coordinates: ens

     <xarray.DataArray 'prediction' (sample: 1, stream: 1, forecast_step: 1,
                                     ipoint: 40320, channel: 1, ens: 1)> Size: 161kB
     dask.array<reshape, shape=(1, 1, 1, 40320, 1, 1), dtype=float32, chunksize=(1, 1, 1, 672, 1, 1), chunktype=numpy.ndarray>
     Coordinates:
       * sample                 (sample) int64 8B 1
         source_interval_start  (sample) datetime64[ns] 8B 2021-10-10T06:00:00
         source_interval_end    (sample) datetime64[ns] 8B 2021-10-10T12:00:00
       * stream                 (stream) <U4 16B 'ERA5'
       * forecast_step          (forecast_step) int64 8B 1
       * ipoint                 (ipoint) int64 323kB 0 1 2 3 ... 40317 40318 40319
         valid_time             (ipoint) datetime64[ns] 323kB 2021-10-10T12:00:00 ...
         lat                    (ipoint) float32 161kB 89.28 89.28 ... -89.28 -89.28
         lon                    (ipoint) float32 161kB 0.0 18.0 36.0 ... -36.0 -18.0
       * channel                (channel) <U5 20B 't_850'
     Dimensions without coordinates: ens

     <xarray.DataArray 'prediction' (sample: 1, stream: 1, forecast_step: 1,
                                     ipoint: 40320, channel: 1, ens: 1)> Size: 161kB
     dask.array<reshape, shape=(1, 1, 1, 40320, 1, 1), dtype=float32, chunksize=(1, 1, 1, 672, 1, 1), chunktype=numpy.ndarray>
     Coordinates:
       * sample                 (sample) int64 8B 2
         source_interval_start  (sample) datetime64[ns] 8B 2021-10-10T12:00:00
         source_interval_end    (sample) datetime64[ns] 8B 2021-10-10T18:00:00
       * stream                 (stream) <U4 16B 'ERA5'
       * forecast_step          (forecast_step) int64 8B 1
       * ipoint                 (ipoint) int64 323kB 0 1 2 3 ... 40317 40318 40319
         valid_time             (ipoint) datetime64[ns] 323kB 2021-10-10T18:00:00 ...
         lat                    (ipoint) float32 161kB 89.28 89.28 ... -89.28 -89.28
         lon                    (ipoint) float32 161kB 0.0 18.0 36.0 ... -36.0 -18.0
       * channel                (channel) <U5 20B 't_850'
     Dimensions without coordinates: ens

     <xarray.DataArray 'prediction' (sample: 1, stream: 1, forecast_step: 1,
                                     ipoint: 40320, channel: 1, ens: 1)> Size: 161kB
     dask.array<reshape, shape=(1, 1, 1, 40320, 1, 1), dtype=float32, chunksize=(1, 1, 1, 672, 1, 1), chunktype=numpy.ndarray>
     Coordinates:
       * sample                 (sample) int64 8B 3
         source_interval_start  (sample) datetime64[ns] 8B 2021-10-10T18:00:00
         source_interval_end    (sample) datetime64[ns] 8B 2021-10-11
       * stream                 (stream) <U4 16B 'ERA5'
       * forecast_step          (forecast_step) int64 8B 1
       * ipoint                 (ipoint) int64 323kB 0 1 2 3 ... 40317 40318 40319
         valid_time             (ipoint) datetime64[ns] 323kB 2021-10-11 ... 2021-...
         lat                    (ipoint) float32 161kB 89.28 89.28 ... -89.28 -89.28
         lon                    (ipoint) float32 161kB 0.0 18.0 36.0 ... -36.0 -18.0
       * channel                (channel) <U5 20B 't_850'
     Dimensions without coordinates: ens
```

## Issue Number

Closes #2016 
Hopefully also addresses #2024 failure

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
