### PR TITLE
Check plot_training names length

### DIFF
--- a/src/weathergen/utils/plot_training.py
+++ b/src/weathergen/utils/plot_training.py
@@ -26,6 +26,7 @@ from weathergen.utils.train_logger import Metrics, TrainLogger
 _logger = logging.getLogger(__name__)
 
 DEFAULT_RUN_FILE = Path("./config/runs_plot_train.yml")
+MAX_FILENAME_LEN = 255
 
 
 ####################################################################################################
@@ -237,6 +238,9 @@ def plot_lr(
     plt.tight_layout()
     rstr = "".join([f"{r}_" for r in runs_ids])
 
+    if len(rstr) + 6 > MAX_FILENAME_LEN:
+        rstr = rstr[:MAX_FILENAME_LEN - 6] 
+
     # save the plot
     plt_fname = plot_dir / f"{rstr}lr.png"
     _logger.info(f"Saving learning rate plot to '{plt_fname}'")
@@ -442,13 +446,18 @@ def plot_loss_per_stream(
             rstr = "".join([f"{r}_" for r in runs_ids])
 
             # save the plot
-            plt_fname = plot_dir / "{}{}fs_{}{}_{}.png".format(
+            fname = "{}{}fs_{}{}_{}.png".format(
                 rstr,
                 "".join([f"{m}_" for m in modes]),
                 "".join([f"{fs}_" for fs in forecast_steps]),
                 stream_name,
                 channel,
             )
+            if len(fname) + 4 > MAX_FILENAME_LEN:
+                fname = fname[:MAX_FILENAME_LEN - 4] + ".png"
+
+            plt_fname = plot_dir / fname
+
             _logger.info(f"Saving loss per stream plot to '{plt_fname}'")
             plt.savefig(plt_fname)
             plt.close()
@@ -568,7 +577,13 @@ def plot_loss_per_run(
     )
 
     # save the plot
-    plt_fname = plot_dir / "{}_{}{}.png".format(run_id, "".join([f"{m}_" for m in modes]), sstr)
+    fname = "{}_{}{}.png".format(run_id, "".join([f"{m}_" for m in modes]), sstr)
+
+    if len(fname) + 4 > MAX_FILENAME_LEN:
+        fname = fname[:MAX_FILENAME_LEN - 4] + ".png"  # keep extension
+
+    plt_fname = plot_dir / fname
+
     _logger.info(f"Saving loss plot for {run_id}-run to '{plt_fname}'")
     plt.savefig(plt_fname)
     plt.close()


### PR DESCRIPTION
## Description

Adds checks for length of file names created by plot_training.  When it's exceeded, crops them to prevent crash. 


## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/1732

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
