### PR TITLE
[2062] Adds more time to the CI single time

### DIFF
--- a/ci/cscs.yaml
+++ b/ci/cscs.yaml
@@ -27,5 +27,5 @@ test_job:
   variables:
     SLURM_JOB_NUM_NODES: 1
     WITH_UENV_VIEW: 'modules'
-    SLURM_TIMELIMIT: '00:10:00'
+    SLURM_TIMELIMIT: '00:20:00'
     UV_CACHE_DIR: /iopsstor/scratch/cscs/thunter/uv_cache_shared


### PR DESCRIPTION
## Description

Allows the run for 20 minutes, to account for possible instability on the CSCS data plane side. There is no point for longer, it is likely hanging on an connection.

## Issue Number

Closes #2062 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
