### PR TITLE
Fix metric recomputation bugs

### DIFF
--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -311,7 +311,6 @@ def _apply_fixes(config: Config) -> Config:
     "outdatet" run configurations. The fixes in this function should be
     eventually removed.
     """
-    #config = _check_logging(config)
     config = _check_datasets(config)
     return config
 
@@ -331,19 +330,6 @@ def _check_datasets(config: Config) -> Config:
         ]
         paths = [config.get(key) for key in legacy_keys]
         config.data_paths = [path for path in paths if path is not None]
-
-    return config
-
-
-def _check_logging(config: Config) -> Config:
-    """
-    Apply fixes to log frequency config.
-    """
-    config = config.copy()
-    if config.get("train_logging") is None:  # TODO remove this for next version
-        config.train_logging = OmegaConf.create(
-            {"checkpoint": 250, "terminal": 10, "metrics": config.train_logging.log_interval}
-        )
 
     return config
 

--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -311,7 +311,7 @@ def _apply_fixes(config: Config) -> Config:
     "outdatet" run configurations. The fixes in this function should be
     eventually removed.
     """
-    config = _check_logging(config)
+    #config = _check_logging(config)
     config = _check_datasets(config)
     return config
 

--- a/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
@@ -240,20 +240,22 @@ def _process_stream(
 
     stream_loaded_scores, recomputable_metrics = reader.load_scores(stream, regions, metrics)
     scores_dict = stream_loaded_scores
+    if recomputable_metrics:
+        metrics_to_compute = recomputable_metrics
+        regions_to_compute = list(set(recomputable_metrics.keys()))
+    elif plot_score_maps and type_ == "zarr":
+        metrics_to_compute = {r: metrics for r in regions}
+        regions_to_compute = regions
+    else:
+        return run_id, stream, scores_dict
 
-    if recomputable_metrics or (plot_score_maps and type_ == "zarr"):
-        regions_to_compute = (
-            list(set(recomputable_metrics.keys())) if recomputable_metrics else regions
-        )
-        metrics_to_compute = recomputable_metrics if recomputable_metrics else metrics
-
-        stream_computed_scores = calc_scores_per_stream(
-            reader, stream, regions_to_compute, metrics_to_compute, plot_score_maps
-        )
-        metric_list_to_json(reader, stream, stream_computed_scores, regions)
-        scores_dict = merge(stream_loaded_scores, stream_computed_scores)
-
-    return run_id, stream, scores_dict
+    stream_computed_scores = calc_scores_per_stream(
+        reader, stream, regions_to_compute, metrics_to_compute, plot_score_maps
+    )
+    metric_list_to_json(reader, stream, stream_computed_scores, regions_to_compute)
+    scores_dict = merge(stream_loaded_scores, stream_computed_scores)
+    return run_id, stream, scores_dict 
+    
 
 
 # except Exception as e:


### PR DESCRIPTION
## Description

The evaluation package was crashing when some scores were loaded from json but recomputation was still needed. As far as I know there are two scenarios where this would happen:

1. scores are present in json and `plot_score_maps: true`
2. scores are present for one region and we request the same score for that region plus another region for which scores are not yet present (for example, run with `regions: ["nhem"]` and then rerun with `regions: ["nhem","shem"]`).

To fix 1, the logic for `metrics_to_compute` was changed in `_process_stream`. For 2, `metric_list_to_json` is now given the list of `regions_to_compute` instead of all regions originally requested.

To be able to test this on any of the runs I had, I had to disable `_check_logging` in `config.py`, see [here](https://github.com/ecmwf/WeatherGenerator/issues/1934). 
*Update*: `_check_logging` is deleted, closing that issue as well. 


## Issue Number

Closes #1880 
Closes #1934 

