### PR TITLE
Translate `mini_epoch` to `istep`

### DIFF
--- a/config/config_dinov2.yml
+++ b/config/config_dinov2.yml
@@ -125,7 +125,7 @@ training_config:
   # training_mode: "masking", "student_teacher", "latent_loss"
   training_mode: ["student_teacher"]
 
-  num_mini_epochs: 32
+  num_isteps: 131072 # 32 * 4096 = 131072
   samples_per_mini_epoch: 4096
   shuffle: True
 

--- a/config/config_forecasting.yml
+++ b/config/config_forecasting.yml
@@ -136,7 +136,7 @@ training_config:
   # training_mode: "masking", "student_teacher", "latent_loss"
   training_mode: ["masking"]
 
-  num_mini_epochs: 64
+  num_isteps: 262144 # 64 * 4096 = 262144
   samples_per_mini_epoch: 4096
   shuffle: True
 

--- a/config/config_forecasting_finetuning.yml
+++ b/config/config_forecasting_finetuning.yml
@@ -136,7 +136,7 @@ training_config:
   # training_mode: "masking", "student_teacher", "latent_loss"
   training_mode: ["masking"]
 
-  num_mini_epochs: 32
+  num_isteps: 131072 # 32 * 4096 = 131072
   samples_per_mini_epoch: 4096
   shuffle: True
 

--- a/config/config_jepa.yml
+++ b/config/config_jepa.yml
@@ -197,7 +197,7 @@ training_config:
       ema_beta:
         enabled: true
 
-  num_mini_epochs: 32
+  num_isteps: 131072 # 32 * 4096 = 131072
   samples_per_mini_epoch: 4096
   shuffle: True
 

--- a/config/config_jepa_finetuning.yml
+++ b/config/config_jepa_finetuning.yml
@@ -86,7 +86,7 @@ training_config:
   # training_mode: ["student_teacher"]
   training_mode: ["masking"]
 
-  num_mini_epochs: 32
+  num_isteps: 131072 # 32 * 4096 = 131072
   samples_per_mini_epoch: 4096
   shuffle: True
 

--- a/config/config_physical_jepa.yml
+++ b/config/config_physical_jepa.yml
@@ -139,7 +139,7 @@ training_config:
   # training_mode: "masking", "student_teacher", "latent_loss"
   training_mode: ["masking", "student_teacher"]
 
-  num_mini_epochs: 32
+  num_isteps: 131072 # 32 * 4096 = 131072
   samples_per_mini_epoch: 4096
   shuffle: True
 

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -174,7 +174,7 @@ training_config:
       ema_beta:
         enabled: false  # only relevant for SSL with EMA teacher
 
-  num_mini_epochs: 32
+  num_isteps: 131072 # 32 * 4096 = 131072
   samples_per_mini_epoch: 4096
   shuffle: True
 

--- a/integration_tests/jepa1.yaml
+++ b/integration_tests/jepa1.yaml
@@ -3,7 +3,7 @@ run_path: "./results"
 model_path: "./models"
 loss_fcts: [["mse", 1.0]]
 loss_fcts_val: [["mse", 1.0]]
-num_mini_epochs: 1
+num_isteps: 100
 samples_per_mini_epoch: 100
 samples_per_validation: 5
 lr_steps: 4

--- a/integration_tests/small1.yml
+++ b/integration_tests/small1.yml
@@ -137,7 +137,7 @@ training_config:
   
   training_mode: ["masking"]
 
-  num_mini_epochs: 1
+  num_isteps: 64
   samples_per_mini_epoch: 64
   shuffle: True
 

--- a/integration_tests/small1_test.py
+++ b/integration_tests/small1_test.py
@@ -77,7 +77,7 @@ def infer(run_id):
             "2022-10-11",
             "--samples",
             "10",
-            "--mini-epoch",
+            "--istep",
             "0",
             "--from-run-id",
             run_id,
@@ -122,7 +122,7 @@ def evaluate_results(run_id):
                         }
                     },
                     "label": "MTM ERA5",
-                    "mini_epoch": 0,
+                    "istep": 0,
                     "rank": 0,
                 }
             },
@@ -164,7 +164,7 @@ def assert_train_loss_below_threshold(run_id):
         None,
     )
     assert loss_metric is not None, f"'{loss_avg_name}' metric is missing in metrics file"
-    # Check that the loss does not explode in a single mini_epoch
+    # Check that the loss does not explode in a single chkpt
     # This is meant to be a quick test, not a convergence test
     target = 0.25
     assert loss_metric < target, (
@@ -185,6 +185,6 @@ def assert_val_loss_below_threshold(run_id):
         None,
     )
     assert loss_metric is not None, f"'{loss_avg_name}' metric is missing in metrics file"
-    # Check that the loss does not explode in a single mini_epoch
+    # Check that the loss does not explode in a single chkpt
     # This is meant to be a quick test, not a convergence test
     assert loss_metric < 0.2, f"'{loss_avg_name}' is {loss_metric}, expected to be below 0.2"

--- a/integration_tests/small_multi_stream.yaml
+++ b/integration_tests/small_multi_stream.yaml
@@ -135,7 +135,7 @@ training_config:
   
   training_mode: ["masking"]
 
-  num_mini_epochs: 1
+  num_isteps: 512 #128 #256
   samples_per_mini_epoch: 512 #128 #256
   shuffle: True
 

--- a/integration_tests/small_multi_stream_test.py
+++ b/integration_tests/small_multi_stream_test.py
@@ -87,7 +87,7 @@ def infer_multi_stream(run_id):
             "2022-10-11",
             "--samples",
             "10",
-            "--mini-epoch",
+            "--istep",
             "0",
             "--from-run-id",
             run_id,
@@ -158,7 +158,7 @@ def evaluate_multi_stream_results(run_id):
                         },
                     },
                     "label": "Multi-Stream Test",
-                    "mini_epoch": 0,
+                    "istep": 0,
                     "rank": 0,
                 }
             },

--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -195,31 +195,31 @@ def format_cf(config: Config) -> str:
     return stream.getvalue()
 
 
-def save(config: Config, mini_epoch: int | None):
+def save(config: Config, istep: int | None):
     """Save current config into the current runs model directory."""
     # save in directory with model files
     dirname = get_path_model(config)
     dirname.mkdir(exist_ok=True, parents=True)
 
-    fname = _get_model_config_file_write_name(get_run_id_from_config(config), mini_epoch)
+    fname = _get_model_config_file_write_name(get_run_id_from_config(config), istep)
 
     json_str = json.dumps(OmegaConf.to_container(_strip_interpolation(config)))
     with (dirname / fname).open("w") as f:
         f.write(json_str)
 
 
-def load_run_config(run_id: str, mini_epoch: int | None, model_path: str | None) -> Config:
+def load_run_config(run_id: str, istep: int | None, model_path: str | None) -> Config:
     """
-    Load a configuration file from a given run_id and mini_epoch.
+    Load a configuration file from a given run_id and istep.
     If run_id is a full path, loads it from the full path.
 
     Args:
         run_id: Run ID of the pretrained WeatherGenerator model
-        mini_epoch: Mini_epoch of the checkpoint to load. -1 indicates last checkpoint available.
+        istep: istep of the checkpoint to load. -1 indicates last checkpoint available.
         model_path: Path to the model directory. If None, uses the model_path from private config.
 
     Returns:
-        Configuration object loaded from the specified run and mini_epoch.
+        Configuration object loaded from the specified run and istep.
     """
     # Loading path
     if Path(run_id).exists():  # load from the full path if a full path is provided
@@ -232,24 +232,24 @@ def load_run_config(run_id: str, mini_epoch: int | None, model_path: str | None)
         else:
             path = Path(model_path) / run_id
 
-        config_path_with_epoch = path / _get_model_config_file_read_name(run_id, mini_epoch)
-        config_path_without_epoch = path / _get_model_config_file_read_name(run_id, None)
+        config_path_with_istep = path / _get_model_config_file_read_name(run_id, istep)
+        config_path_without_istep = path / _get_model_config_file_read_name(run_id, None)
 
-        if config_path_with_epoch.exists():
-            fname = config_path_with_epoch
-            _logger.info(f"Loading config from specified run_id and mini_epoch: {fname}")
-        elif config_path_without_epoch.exists():
-            fname = config_path_without_epoch
+        if config_path_with_istep.exists():
+            fname = config_path_with_istep
+            _logger.info(f"Loading config from specified run_id and istep: {fname}")
+        elif config_path_without_istep.exists():
+            fname = config_path_without_istep
             _logger.info(
-                f"Config for mini_epoch {mini_epoch} not found. "
-                f"Falling back to config without mini_epoch: {fname}"
+                f"Config for istep {istep} not found. "
+                f"Falling back to config without istep: {fname}"
             )
         else:
             raise FileNotFoundError(
                 f"Could not find model config for run_id '{run_id}' "
-                f"(mini_epoch={mini_epoch}) in '{path}'. "
-                f"Tried: '{config_path_with_epoch.name}' and '{config_path_without_epoch.name}'. "
-                f"Please check run_id and mini_epoch."
+                f"(istep={istep}) in '{path}'. "
+                f"Tried: '{config_path_with_istep.name}' and '{config_path_without_istep.name}'. "
+                f"Please check run_id and istep."
             )
 
     with fname.open() as f:
@@ -261,43 +261,43 @@ def load_run_config(run_id: str, mini_epoch: int | None, model_path: str | None)
     return _apply_fixes(config)
 
 
-def _get_model_config_file_write_name(run_id: str, mini_epoch: int | None):
+def _get_model_config_file_write_name(run_id: str, istep: int | None):
     """Generate the filename for writing a model config file."""
-    if mini_epoch is None:
-        mini_epoch_str = ""
-    elif mini_epoch == -1:
-        mini_epoch_str = "_latest"
+    if istep is None:
+        istep_str = ""
+    elif istep == -1:
+        istep_str = "_latest"
     else:
-        mini_epoch_str = f"_chkpt{mini_epoch:05d}"
+        istep_str = f"_chkpt{istep:06d}"
 
-    return f"model_{run_id}{mini_epoch_str}.json"
+    return f"model_{run_id}{istep_str}.json"
 
 
-def _get_model_config_file_read_name(run_id: str, mini_epoch: int | None):
+def _get_model_config_file_read_name(run_id: str, istep: int | None):
     """Generate the filename for reading a model config file."""
-    if mini_epoch is None:
-        mini_epoch_str = ""
-    elif mini_epoch == -1:
-        mini_epoch_str = "_latest"
+    if istep is None:
+        istep_str = ""
+    elif istep == -1:
+        istep_str = "_latest"
     else:
-        mini_epoch_str = f"_chkpt{mini_epoch:05d}"
+        istep_str = f"_chkpt{istep:06d}"
 
-    return f"model_{run_id}{mini_epoch_str}.json"
+    return f"model_{run_id}{istep_str}.json"
 
 
-def get_model_results(run_id: str, mini_epoch: int, rank: int) -> Path:
+def get_model_results(run_id: str, istep: int, rank: int) -> Path:
     """
-    Get the path to the model results zarr store from a given run_id and mini_epoch.
+    Get the path to the model results zarr store from a given run_id and istep.
     """
     run_results = Path(_load_private_conf(None)["path_shared_working_dir"]) / f"results/{run_id}"
 
     for ext in StoreType.extensions():
-        zarr_path = run_results / f"validation_chkpt{mini_epoch:05d}_rank{rank:04d}.{ext}"
+        zarr_path = run_results / f"validation_chkpt{istep:06d}_rank{rank:04d}.{ext}"
 
         if zarr_path.exists() or zarr_path.is_dir():
             return zarr_path
     raise FileNotFoundError(
-        f"Zarr file with run_id {run_id}, mini_epoch {mini_epoch} and rank {rank} does not "
+        f"Zarr file with run_id {run_id}, istep {istep} and rank {rank} does not "
         f"exist or is not a directory."
     )
 
@@ -358,7 +358,7 @@ def merge_configs(base_config: Config, update_config: Config):
 def load_merge_configs(
     private_home: Path | None = None,
     from_run_id: str | None = None,
-    mini_epoch: int | None = None,
+    istep: int | None = None,
     base: Path | Config | None = None,
     *overwrites: Path | dict | Config,
 ) -> Config:
@@ -370,7 +370,7 @@ def load_merge_configs(
         private_home: Configuration file containing platform dependent information and secrets
         from_run_id: Run id of the pretrained WeatherGenerator model
         to continue training or inference
-        mini_epoch: Mini_epoch of the checkpoint to load. -1 indicates last checkpoint available.
+        istep: istep of the checkpoint to load. -1 indicates last checkpoint available.
         base: Path to the base configuration file. Uses default configuration if None.
         *overwrites: Additional overwrites from different sources
 
@@ -402,7 +402,7 @@ def load_merge_configs(
     if from_run_id is None:
         base_config = _load_base_conf(base)
     else:
-        base_config = load_run_config(from_run_id, mini_epoch, None)
+        base_config = load_run_config(from_run_id, istep, None)
         from_run_id = get_run_id_from_config(base_config)
     with open_dict(base_config):
         base_config.from_run_id = from_run_id
@@ -660,11 +660,11 @@ def get_path_model(config: Config | None = None, run_id: str | None = None) -> P
     return _get_shared_wg_path() / "models" / run_id
 
 
-def get_path_results(config: Config, mini_epoch: int) -> Path:
-    """Get the path to validation results for a specific mini_epoch and rank."""
+def get_path_results(config: Config, istep: int) -> Path:
+    """Get the path to validation results for a specific istep and rank."""
     ext = StoreType(config.zarr_store).value  # validate extension
     base_path = get_path_run(config)
-    fname = f"validation_chkpt{mini_epoch:05d}_rank{config.rank:04d}.{ext}"
+    fname = f"validation_chkpt{istep:06d}_rank{config.rank:04d}.{ext}"
 
     return base_path / fname
 
@@ -716,7 +716,7 @@ def validate_forecast_policy_and_steps(forecast_cfg: OmegaConf, mode: str):
     valid_forecast_policies = (
         "Valid values for '{mode}.forecast.policy' are, e.g., 'fixed' when using constant number "
         "of forecast steps throughout the training, or 'sequential' when varying the number of "
-        "forecast steps over mini_epochs, such as, e.g., 'forecast.num_steps: [2, 2, 4, 4]'. "
+        "forecast steps over data chunks, such as, e.g., 'forecast.num_steps: [2, 2, 4, 4]'. "
     )
     valid_forecast_offset = f"'{mode}.forecast.offset' must be an integer of either value 0 or 1. "
     valid_forecast_steps_offset0 = (

--- a/packages/evaluate/src/weathergen/evaluate/export/export_core.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/export_core.py
@@ -27,8 +27,8 @@ def get_data_worker(args: tuple) -> xr.DataArray:
     -------
         xarray DataArray for the specified sample and forecast step.
     """
-    sample, fstep, run_id, stream, dtype, epoch, rank = args
-    fname_zarr = get_model_results(run_id, epoch, rank)
+    sample, fstep, run_id, stream, dtype, istep, rank = args
+    fname_zarr = get_model_results(run_id, istep, rank)
     with zarrio_reader(fname_zarr) as zio:
         out = zio.get_data(sample, stream, fstep)
         if dtype == "target":
@@ -200,8 +200,8 @@ def export_model_outputs(data_type: str, config: OmegaConf, **kwargs) -> None:
             List of channels to retrieve. If None, retrieves all available channels.
         n_processes : list
             Number of parallel processes to use for data retrieval.
-        ecpoch : int
-            Epoch number to identify the Zarr store.
+        istep : int
+            istep number to identify the Zarr store.
         rank : int
             Rank number to identify the Zarr store.
         regrid_degree : float
@@ -220,14 +220,14 @@ def export_model_outputs(data_type: str, config: OmegaConf, **kwargs) -> None:
     stream = kwargs.stream
     channels = kwargs.channels
     n_processes = kwargs.n_processes
-    epoch = kwargs.epoch
+    istep = kwargs.istep
     rank = kwargs.rank
     fstep_hours = np.timedelta64(kwargs.fstep_hours, "h")
 
     if data_type not in ["target", "prediction"]:
         raise ValueError(f"Invalid type: {data_type}. Must be 'target' or 'prediction'.")
 
-    fname_zarr = get_model_results(run_id, epoch, rank)
+    fname_zarr = get_model_results(run_id, istep, rank)
     fsteps = get_fsteps(fsteps, fname_zarr)
     samples = get_samples(samples, fname_zarr)
     grid_type = get_grid_type(data_type, stream, fname_zarr)
@@ -245,7 +245,7 @@ def export_model_outputs(data_type: str, config: OmegaConf, **kwargs) -> None:
             ref_time = ref_times[s_idx]
 
             step_tasks = [
-                (sample, fstep, run_id, stream, data_type, epoch, rank) for fstep in fsteps
+                (sample, fstep, run_id, stream, data_type, istep, rank) for fstep in fsteps
             ]
 
             results_iterator = pool.imap_unordered(get_data_worker, step_tasks, chunksize=1)

--- a/packages/evaluate/src/weathergen/evaluate/export/export_inference.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/export_inference.py
@@ -129,10 +129,10 @@ def parse_args(args: list) -> argparse.Namespace:
     )
 
     parser.add_argument(
-        "--epoch",
+        "--istep",
         type=int,
         default=0,
-        help="Epoch number to identify the Zarr store",
+        help="istep to identify the Zarr store",
     )
 
     parser.add_argument(

--- a/packages/evaluate/src/weathergen/evaluate/export/io_utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/io_utils.py
@@ -59,8 +59,8 @@ def get_data_worker(args: tuple) -> xr.DataArray:
     -------
         xarray DataArray for the specified sample and forecast step.
     """
-    sample, fstep, run_id, stream, dtype, epoch, rank = args
-    fname_zarr = get_model_results(run_id, epoch, rank)
+    sample, fstep, run_id, stream, dtype, istep, rank = args
+    fname_zarr = get_model_results(run_id, istep, rank)
     with zarrio_reader(fname_zarr) as zio:
         out = zio.get_data(sample, stream, fstep)
         if dtype == "target":

--- a/packages/evaluate/src/weathergen/evaluate/io/csv_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/csv_reader.py
@@ -83,7 +83,7 @@ class CsvReader(Reader):
         )
         self.samples = [0]
         self.forecast_steps = sorted(self.data["step"].dropna().unique().tolist())
-        self.epoch = [0]
+        self.istep = [0]
 
     def get_samples(self) -> set[int]:
         """

--- a/packages/evaluate/src/weathergen/evaluate/io/merge_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/merge_reader.py
@@ -55,7 +55,7 @@ class WeatherGenMergeReader(Reader):
         super().__init__(eval_cfg, run_id, private_paths)
         self.run_ids = eval_cfg.get("merge_run_ids", [])
         self.metrics_dir = Path(eval_cfg.get("merge_metrics_dir"))
-        self.mini_epoch = eval_cfg.get("mini_epoch", 0)
+        self.istep = eval_cfg.get("istep", 0)
 
         assert self.run_ids, (
             f"'merge_run_ids' must be non-empty in eval_cfg, but got: {self.run_ids}"
@@ -191,7 +191,7 @@ class WeatherGenMergeReader(Reader):
         self, stream: str, regions: list[str], metrics: list[str]
     ) -> xr.DataArray | None:
         """
-        Load the pre-computed scores for a given run, stream and metric and epoch.
+        Load the pre-computed scores for a given run, stream and metric and istep.
 
         Parameters
         ----------

--- a/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
@@ -38,8 +38,7 @@ class WeatherGenReader(Reader):
     def __init__(self, eval_cfg: dict, run_id: str, private_paths: dict | None = None):
         super().__init__(eval_cfg, run_id, private_paths)
 
-        # TODO: remove backwards compatibility to "epoch" in Feb. 2026
-        self.mini_epoch = eval_cfg.get("mini_epoch", 0)
+        self.istep = eval_cfg.get("istep", 0)
         self.rank = eval_cfg.get("rank", 0)
 
         # Load model configuration and set (run-id specific) directories
@@ -84,12 +83,12 @@ class WeatherGenReader(Reader):
             _logger.info(
                 f"Loading config for run {self.run_id} from private paths: {self.private_paths}"
             )
-            config = load_merge_configs(self.private_paths, self.run_id, self.mini_epoch)
+            config = load_merge_configs(self.private_paths, self.run_id, self.istep)
         else:
             _logger.info(
                 f"Loading config for run {self.run_id} from model directory: {self.model_base_dir}"
             )
-            config = load_run_config(self.run_id, self.mini_epoch, self.model_base_dir)
+            config = load_run_config(self.run_id, self.istep, self.model_base_dir)
 
         if not isinstance(config, dict | oc.DictConfig):
             _logger.warning("Model config not found. inference config will be empty.")
@@ -159,7 +158,7 @@ class WeatherGenReader(Reader):
     ) -> tuple[dict, dict]:
         """
         Load multiple pre-computed scores for a given run, stream and metric
-        and epoch.
+        and istep.
 
         Parameters
         ----------
@@ -215,7 +214,7 @@ class WeatherGenReader(Reader):
             parameters = {}
         score_path = (
             Path(self.metrics_dir)
-            / f"{self.run_id}_{stream}_{region}_{metric}_chkpt{self.mini_epoch:05d}.json"
+            / f"{self.run_id}_{stream}_{region}_{metric}_chkpt{self.istep:06d}.json"
         )
         _logger.debug(f"Looking for: {score_path}")
 
@@ -345,7 +344,7 @@ class WeatherGenZarrReader(WeatherGenReader):
         # For backwards compatibility, assume zarr store is local (.zarr format).
 
         fname_zarr = self.results_dir.joinpath(
-            f"validation_chkpt{self.mini_epoch:05d}_rank{self.rank:04d}.{zarr_ext}"
+            f"validation_chkpt{self.istep:06d}_rank{self.rank:04d}.{zarr_ext}"
         )
 
         assert fname_zarr.exists(), f"Zarr file {fname_zarr} does not exist."

--- a/packages/evaluate/src/weathergen/evaluate/utils/utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils/utils.py
@@ -564,7 +564,7 @@ def metric_list_to_json(
                 # Match the expected filename pattern
                 save_path = (
                     reader.metrics_dir
-                    / f"{run_id}_{stream}_{region}_{metric}_chkpt{reader.mini_epoch:05d}.json"
+                    / f"{run_id}_{stream}_{region}_{metric}_chkpt{reader.istep:06d}.json"
                 )
                 metric_data_dict = metric_data.to_dict()
 
@@ -596,7 +596,7 @@ def metric_list_to_json(
                     json.dump(data_dict, f, indent=4)
 
     _logger.info(
-        f"Saved all results of inference run {reader.run_id} - mini_epoch {reader.mini_epoch:d} "
+        f"Saved all results of inference run {reader.run_id} - istep {reader.istep:d} "
         f"successfully to {reader.metrics_dir}."
     )
 

--- a/src/weathergen/model/model_interface.py
+++ b/src/weathergen/model/model_interface.py
@@ -48,7 +48,7 @@ def init_model_and_shard(
     cf,
     dataset,
     run_id_contd,
-    mini_epoch_contd,
+    istep_contd,
     training_mode,
     device,
     with_ddp,
@@ -149,14 +149,14 @@ def init_model_and_shard(
     # complete initalization and load model if inference/continuing a run
     if run_id_contd is not None:
         if is_root():
-            logger.info(f"Continuing run with id={run_id_contd} at mini_epoch {mini_epoch_contd}.")
-        model = load_model(cf, model, device, run_id_contd, mini_epoch_contd)
+            logger.info(f"Continuing run with id={run_id_contd} at istep {istep_contd}.")
+        model = load_model(cf, model, device, run_id_contd, istep_contd)
     elif cf.get("load_chkpt", {}).get("run_id", None):
         run_id = cf.load_chkpt.run_id
-        mini_epoch = cf.load_chkpt.get("mini_epoch", -1)
+        istep = cf.load_chkpt.get("istep", -1)
         if is_root():
-            logger.info(f"Loading checkpoint from id={run_id} at mini_epoch {mini_epoch}.")
-        model = load_model(cf, model, device, run_id, mini_epoch)
+            logger.info(f"Loading checkpoint from id={run_id} at istep {istep}.")
+        model = load_model(cf, model, device, run_id, istep)
     else:
         if with_ddp and with_fsdp:
             model.to_empty(device="cuda")
@@ -171,18 +171,18 @@ def init_model_and_shard(
     return model, model_params
 
 
-def load_model(cf, model, device, run_id: str, mini_epoch=-1):
+def load_model(cf, model, device, run_id: str, istep=-1):
     """Loads model state from checkpoint and checks for missing and unused keys.
     Args:
         run_id : model_id of the trained model
-        mini_epoch : The mini_epoch to load. Default (-1) is the latest mini_epoch
+        istep : The istep to load. Default (-1) is the latest istep
     """
 
     path_run = get_path_model(run_id=run_id)
-    mini_epoch_id = (
-        f"chkpt{mini_epoch:05d}" if mini_epoch != -1 and mini_epoch is not None else "latest"
+    istep_id = (
+        f"chkpt{istep:06d}" if istep != -1 and istep is not None else "latest"
     )
-    filename = f"{run_id}_{mini_epoch_id}.chkpt"
+    filename = f"{run_id}_{istep_id}.chkpt"
 
     params = torch.load(
         path_run / filename, map_location=torch.device("cpu"), mmap=True, weights_only=True

--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -99,7 +99,7 @@ def run_inference(args):
     cf = config.load_merge_configs(
         args.private_config,
         args.from_run_id,
-        args.mini_epoch,
+        args.istep,
         args.base_config,
         *args.config,
         inference_overwrite,
@@ -118,7 +118,7 @@ def run_inference(args):
 
     trainer = Trainer(cf.train_logging)
     try:
-        trainer.inference(cf, devices, args.from_run_id, args.mini_epoch)
+        trainer.inference(cf, devices, args.from_run_id, args.istep)
     except Exception:
         extype, value, tb = sys.exc_info()
         traceback.print_exc()
@@ -137,7 +137,7 @@ def run_continue(args):
     cf = config.load_merge_configs(
         args.private_config,
         args.from_run_id,
-        args.mini_epoch,
+        args.istep,
         args.base_config,
         *args.config,
         {},
@@ -157,7 +157,7 @@ def run_continue(args):
     trainer = Trainer(cf.train_logging)
 
     try:
-        trainer.run(cf, devices, args.from_run_id, args.mini_epoch)
+        trainer.run(cf, devices, args.from_run_id, args.istep)
     except Exception:
         extype, value, tb = sys.exc_info()
         traceback.print_exc()

--- a/src/weathergen/train/lr_scheduler.py
+++ b/src/weathergen/train/lr_scheduler.py
@@ -248,8 +248,7 @@ class LearningRateScheduler:
         Use as LearningRateScheduler.plot()
         """
 
-        num_mini_epochs = 42
-        num_samples_per_mini_epoch = 4096
+        num_isteps = 42 * 4096
 
         lr_start = 0.000001
         lr_max = 0.000015
@@ -275,7 +274,7 @@ class LearningRateScheduler:
             lr_final_decay,
             lr_final,
             lr_steps_warmup,
-            num_mini_epochs * num_samples_per_mini_epoch,
+            num_isteps,
             lr_steps_cooldown,
             lr_policy_warmup,
             lr_policy_decay,
@@ -284,7 +283,7 @@ class LearningRateScheduler:
         lrs = []
 
         for _ in range(
-            num_mini_epochs * num_samples_per_mini_epoch
+            num_isteps
             + lr_steps_warmup
             + lr_steps_cooldown
             + 1023
@@ -312,7 +311,7 @@ class LearningRateScheduler:
             lr_final_decay,
             lr_final,
             lr_steps_warmup,
-            num_mini_epochs * num_samples_per_mini_epoch,
+            num_isteps,
             lr_steps_cooldown,
             lr_policy_warmup,
             lr_policy_decay,
@@ -321,7 +320,7 @@ class LearningRateScheduler:
         lrs = []
 
         for _ in range(
-            num_mini_epochs * num_samples_per_mini_epoch
+            num_isteps
             + lr_steps_warmup
             + lr_steps_cooldown
             + 1023

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -176,7 +176,7 @@ class Trainer(TrainerBase):
 
         return target_and_aux_calculators
 
-    def inference(self, cf, devices, run_id_contd, mini_epoch_contd):
+    def inference(self, cf, devices, run_id_contd, istep_contd):
         # general initalization
         self.init(cf, devices)
 
@@ -210,7 +210,7 @@ class Trainer(TrainerBase):
             cf,
             self.dataset,
             run_id_contd,
-            mini_epoch_contd,
+            istep_contd,
             self.test_cfg.training_mode,
             devices[0],
             cf.with_ddp,
@@ -223,7 +223,7 @@ class Trainer(TrainerBase):
         self.loss_calculator_val = LossCalculator(cf, self.test_cfg, VAL, device=self.devices[0])
 
         if is_root():
-            config.save(self.cf, mini_epoch=0)
+            config.save(self.cf, istep=0)
 
         logger.info(f"Starting inference with id={self.cf.general.run_id}.")
 
@@ -231,7 +231,7 @@ class Trainer(TrainerBase):
         self.validate(0, self.test_cfg, self.batch_size_test_per_gpu)
         logger.info(f"Finished inference run with id: {cf.general.run_id}")
 
-    def run(self, cf, devices, run_id_contd=None, mini_epoch_contd=None):
+    def run(self, cf, devices, run_id_contd=None, istep_contd=None):
         # general initalization
         self.init(cf, devices)
         cf = self.cf
@@ -261,7 +261,7 @@ class Trainer(TrainerBase):
             cf,
             self.dataset,
             run_id_contd,
-            mini_epoch_contd,
+            istep_contd,
             self.training_cfg.training_mode,
             devices[0],
             cf.with_ddp,
@@ -280,7 +280,7 @@ class Trainer(TrainerBase):
                 cf,
                 self.dataset,
                 run_id_contd,
-                mini_epoch_contd,
+                istep_contd,
                 cf.training_config.training_mode,
                 devices[0],
                 cf.with_ddp,
@@ -328,7 +328,7 @@ class Trainer(TrainerBase):
         # lr is updated after each batch so account for this
         # TODO: conf should be read-only, do not modify the conf in flight
         len_ds = len(self.dataset)
-        lr_steps = int((len_ds * self.training_cfg.num_mini_epochs) / self.batch_size_per_gpu)
+        lr_steps = self.training_cfg.num_isteps
         self.lr_scheduler = LearningRateScheduler(
             self.optimizer,
             self.batch_size_per_gpu,
@@ -348,21 +348,6 @@ class Trainer(TrainerBase):
         val_cfg = self.validation_cfg
         self.loss_calculator_val = LossCalculator(cf, val_cfg, VAL, device=self.device)
 
-        # recover mini_epoch when continuing run
-        if self.world_size_original is None:
-            mini_epoch_base = int(self.cf.general.istep / len(self.data_loader))
-        else:
-            len_per_rank = (
-                len(self.dataset) // (self.world_size_original * self.batch_size_per_gpu)
-            ) * self.batch_size_per_gpu
-            mini_epoch_base = int(
-                self.cf.general.istep
-                / (
-                    min(len_per_rank, self.training_cfg.samples_per_mini_epoch)
-                    * self.world_size_original
-                )
-            )
-
         if is_root():
             config.save(self.cf, None)
             logger.info(config.format_cf(self.cf))
@@ -372,22 +357,22 @@ class Trainer(TrainerBase):
 
         # training loop
 
-        for mini_epoch in range(mini_epoch_base, self.training_cfg.num_mini_epochs):
-            logger.info(f"Mini_epoch {mini_epoch} of {self.training_cfg.num_mini_epochs}: train.")
-            self.train(mini_epoch)
+        while self.cf.general.istep < self.training_cfg.num_isteps:
+            logger.info(f"Training chunk starting at step {self.cf.general.istep} of {self.training_cfg.num_isteps}.")
+            self.train(self.cf.general.istep)
 
             logger.info(
-                f"Mini_epoch {mini_epoch} of {self.training_cfg.num_mini_epochs}: validate."
+                f"Validation at step {self.cf.general.istep} of {self.training_cfg.num_isteps}."
             )
-            self.validate(mini_epoch, self.validation_cfg, self.batch_size_validation_per_gpu)
+            self.validate(self.cf.general.istep, self.validation_cfg, self.batch_size_validation_per_gpu)
 
             logger.info(
-                f"Mini_epoch {mini_epoch} of {self.training_cfg.num_mini_epochs}: save_model."
+                f"Saving model at step {self.cf.general.istep} of {self.training_cfg.num_isteps}."
             )
-            self.save_model(mini_epoch)
+            self.save_model(self.cf.general.istep)
 
         # log final model
-        self.save_model(self.training_cfg.num_mini_epochs)
+        self.save_model(self.training_cfg.num_isteps)
 
     def validate_before_training(self):
         """
@@ -410,9 +395,9 @@ class Trainer(TrainerBase):
             else:
                 assert False, "validate_before_training must be integer or boolean."
 
-    def train(self, mini_epoch):
+    def train(self, istep):
         """
-        Perform training for one epoch
+        Perform training for one data chunk
         """
 
         cf = self.cf
@@ -427,6 +412,9 @@ class Trainer(TrainerBase):
         # training loop
         self.t_start = time.time()
         for bidx, batch in enumerate(dataset_iter):
+            if self.cf.general.istep >= self.training_cfg.num_isteps:
+                break
+
             if cf.data_loading.get("memory_pinning", False):
                 # pin memory for faster CPU-GPU transfer
                 batch = batch.pin_memory()
@@ -526,7 +514,7 @@ class Trainer(TrainerBase):
                     targets_and_auxs,
                 )
 
-            self._log_terminal(bidx, mini_epoch, TRAIN)
+            self._log_terminal(bidx, istep, TRAIN)
             if bidx % self.train_logging.metrics == 0:
                 self._log(TRAIN)
                 # Log collapse metrics
@@ -541,7 +529,7 @@ class Trainer(TrainerBase):
 
         self.dataset.advance()
 
-    def validate(self, mini_epoch, mode_cfg, batch_size):
+    def validate(self, istep, mode_cfg, batch_size):
         """
         Perform validation / test computation as specified by mode_cfg
         """
@@ -611,7 +599,7 @@ class Trainer(TrainerBase):
                             self.cf,
                             mode_cfg,
                             batch_size,
-                            mini_epoch,
+                            istep,
                             bidx,
                             denormalize_data_fct,
                             batch,
@@ -621,10 +609,7 @@ class Trainer(TrainerBase):
 
                     pbar.update(batch_size)
 
-                    if (bidx * batch_size) > mode_cfg.samples_per_mini_epoch:
-                        break
-
-                self._log_terminal(0, mini_epoch, VAL)
+                self._log_terminal(0, istep, VAL)
                 self._log(VAL)
 
         # avoid that there is a systematic bias in the validation subset
@@ -676,10 +661,10 @@ class Trainer(TrainerBase):
         else:
             return {}
 
-    def save_model(self, mini_epoch: int, name=None):
-        # Saving at mini_epoch == max_mini_epoch means that we are saving the latest checkpoint.
-        max_mini_epoch = self.training_cfg.num_mini_epochs
-        assert mini_epoch <= max_mini_epoch, (mini_epoch, max_mini_epoch)
+    def save_model(self, istep: int, name=None):
+        # Saving at istep == max_istep means that we are saving the latest checkpoint.
+        max_istep = self.training_cfg.num_isteps
+        assert istep <= max_istep, (istep, max_istep)
         model_state_dict = self._get_full_model_state_dict()
 
         if is_root():
@@ -687,7 +672,7 @@ class Trainer(TrainerBase):
                 [
                     self.cf.general.run_id,
                     "_",
-                    "latest" if mini_epoch == -1 else f"chkpt{mini_epoch:05d}",
+                    "latest" if istep == -1 else f"chkpt{istep:06d}",
                     ("_" + name) if name is not None else "",
                 ]
             )
@@ -702,7 +687,7 @@ class Trainer(TrainerBase):
                 logger.info(f"Saved model to {file_out}")
 
             # save config
-            config.save(self.cf, mini_epoch)
+            config.save(self.cf, istep)
 
     def _log(self, stage: Stage):
         """
@@ -764,7 +749,7 @@ class Trainer(TrainerBase):
         if is_root():
             self.train_logger.log_metrics(stage, grad_norms)
 
-    def _log_terminal(self, bidx: int, mini_epoch: int, stage: Stage):
+    def _log_terminal(self, bidx: int, istep: int, stage: Stage):
         print_freq = self.train_logging.terminal
         if bidx % print_freq == 0 and bidx > 0 or stage == VAL:
             # compute from last iteration
@@ -778,7 +763,7 @@ class Trainer(TrainerBase):
             if is_root():
                 if stage == VAL:
                     logger.info(
-                        f"""validation ({self.cf.general.run_id}) : {mini_epoch:03d} : 
+                        f"""validation ({self.cf.general.run_id}) : {istep:04d} : 
                         {np.nanmean(avg_loss)}"""
                     )
 
@@ -787,7 +772,7 @@ class Trainer(TrainerBase):
                     dt = time.time() - self.t_start
                     len_dataset = len(self.data_loader) // self.batch_size_per_gpu
                     pstr = (
-                        f"{mini_epoch:03d} : {bidx:05d}/{len_dataset:05d} : "
+                        f"{istep:04d} : {bidx:05d}/{len_dataset:05d} : "
                         + f"{self.cf.general.istep:06d} : loss = {np.nanmean(avg_loss):.4E} "
                         + f"(lr={self.lr_scheduler.get_lr():.2E}, "
                     )

--- a/src/weathergen/utils/cli.py
+++ b/src/weathergen/utils/cli.py
@@ -176,12 +176,12 @@ def _add_model_loading_params(parser: argparse.ArgumentParser):
         ),
     )
     parser.add_argument(
-        "-e",
-        "--mini-epoch",
+        "-i",
+        "--istep",
         type=int,
         default=-1,
         help=(
-            "Mini-epoch of pretrained WeatherGenerator model used"
+            "istep of pretrained WeatherGenerator model used"
             " (Default -1 corresponds to the last checkpoint)."
         ),
     )

--- a/src/weathergen/utils/compare_run_configs.py
+++ b/src/weathergen/utils/compare_run_configs.py
@@ -217,13 +217,13 @@ def main():
 
         logger.info(f"Loading config for run_id: {run_id} from {path}")
         try:
-            cfg = load_run_config(run_id=run_id, mini_epoch=None, model_path=path)
+            cfg = load_run_config(run_id=run_id, istep=None, model_path=path)
         except Exception:
             logger.warning(
                 f"Failed to load config for run_id: {run_id} from {path}",
-                "Assuming mini_epoch=0 and retrying.",
+                "Assuming istep=0 and retrying.",
             )
-            cfg = load_run_config(run_id=run_id, mini_epoch=0, model_path=path)
+            cfg = load_run_config(run_id=run_id, istep=0, model_path=path)
         actual_run_id = cfg.get("run_id", run_id)
 
         # Process streams and flatten

--- a/src/weathergen/utils/plot_training.py
+++ b/src/weathergen/utils/plot_training.py
@@ -727,13 +727,13 @@ def plot_train(args=None):
             # Load config from given model_path if provided, otherwise use path from private config
             if model_base_dir:
                 cf = config.load_run_config(
-                    run_id=run_id, mini_epoch=None, model_path=model_base_dir
+                    run_id=run_id, istep=None, model_path=model_base_dir
                 )
             else:
                 cf = config.load_merge_configs(
                     private_home=None,
                     from_run_id=run_id,
-                    mini_epoch=None,
+                    istep=None,
                 )
             for stream_info in cf.streams:
                 streams += [stream_info["name"]]

--- a/src/weathergen/utils/train_logger.py
+++ b/src/weathergen/utils/train_logger.py
@@ -130,7 +130,7 @@ class TrainLogger:
     def read(
         run_id: str,
         model_path: str = None,
-        mini_epoch: int | None = None,
+        istep: int | None = None,
         cols_patterns: list[str] | None = None,
     ) -> Metrics:
         """
@@ -139,10 +139,10 @@ class TrainLogger:
 
         # Load config from given model_path if provided, otherwise use path from private config
         if model_path:
-            cf = config.load_run_config(run_id=run_id, mini_epoch=mini_epoch, model_path=model_path)
+            cf = config.load_run_config(run_id=run_id, istep=istep, model_path=model_path)
         else:
             cf = config.load_merge_configs(
-                private_home=None, from_run_id=run_id, mini_epoch=mini_epoch
+                private_home=None, from_run_id=run_id, istep=istep
             )
         run_id = cf.general.run_id
 

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -21,7 +21,7 @@ _logger = logging.getLogger(__name__)
 
 
 def write_output(
-    cf, val_cfg, batch_size, mini_epoch, batch_idx, dn_data, batch, model_output, target_aux_out
+    cf, val_cfg, batch_size, istep, batch_idx, dn_data, batch, model_output, target_aux_out
 ):
     """
     Interface for writing model output
@@ -171,6 +171,6 @@ def write_output(
         sample_start,
         forecast_offset,
     )
-    with zarrio_writer(config.get_path_results(cf, mini_epoch)) as zio:
+    with zarrio_writer(config.get_path_results(cf, istep)) as zio:
         for subset in data.items():
             zio.write_zarr(subset)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ import weathergen.utils.cli as cli
 
 DATE_FORMATS = ["2022-12-01T00:00:00", "20221201", "2022-12-01", "12.01.2022"]
 EXPECTED_DATE_STR = "202212010000"
-MODEL_LOADING_ARGS = ["from-run-id", "mini-epoch", "reuse-run-id"]
+MODEL_LOADING_ARGS = ["from-run-id", "istep", "reuse-run-id"]
 GENERAL_ARGS = ["config", "private-config", "options", "run-id"]
 MODEL_LOADING_PARSERS = [cli.get_continue_parser(), cli.get_inference_parser()]
 BASIC_ARGLIST = ["--from-run-id", "test123"]
@@ -80,7 +80,7 @@ def test_inference_defaults(inference_parser):
         "end-date",
         "samples",
         "streams-output",
-        "mini-epoch",
+        "istep",
         "private-config",
     ]
     default_values = [inference_parser.get_default(arg) for arg in default_args]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,7 @@ import weathergen.common.config as config
 TEST_RUN_ID = "test123"
 SECRET_COMPONENT = "53CR3T"
 DUMMY_PRIVATE_CONF = {
-    "data_paths": ["/path/to/anmoi/data", "/path/to/observation/data"]
+    "data_paths": ["/path/to/anmoi/data", "/path/to/observation/data"],
     "secrets": {
         "my_big_secret": {
             "my_secret_id": f"{SECRET_COMPONENT}01234",
@@ -18,7 +18,7 @@ DUMMY_PRIVATE_CONF = {
     },
 }
 
-DUMMY_OVERWRITES = [("num_mini_epochs", 42), ("healpix_level", 42)]
+DUMMY_OVERWRITES = [("num_isteps", 42 * 1024), ("healpix_level", 42)]
 
 DUMMY_STREAM_CONF = {
     "ERA5": {
@@ -232,16 +232,16 @@ def test_load_multiple_overwrites(private_config_file):
     assert contains(cf, expected)
 
 
-@pytest.mark.parametrize("mini_epoch", [None, 0, 1, 2, -1])
-def test_load_existing_config(mini_epoch, private_config_file, config_fresh):
-    test_num_mini_epochs = 3000
+@pytest.mark.parametrize("istep", [None, 0, 1, 2, -1])
+def test_load_existing_config(istep, private_config_file, config_fresh):
+    test_num_isteps = 3000 * 1024
 
-    config_fresh.num_mini_epochs = test_num_mini_epochs  # some specific change
-    config.save(config_fresh, mini_epoch)
+    config_fresh.num_isteps = test_num_isteps  # some specific change
+    config.save(config_fresh, istep)
 
-    cf = config.load_merge_configs(private_config_file, config_fresh.run_id, mini_epoch)
+    cf = config.load_merge_configs(private_config_file, config_fresh.run_id, istep)
 
-    assert cf.num_mini_epochs == test_num_mini_epochs
+    assert cf.num_isteps == test_num_isteps
 
 
 @pytest.mark.parametrize("options,cf", [(["foo=1", "bar=2"], {"foo": 1, "bar": 2}), ([], {})])
@@ -344,9 +344,9 @@ def test_load_duplicate_streams_same_file(streams_dir):
         config.load_streams(streams_dir)
 
 
-@pytest.mark.parametrize("mini_epoch", [None, 0, 1, 2, -1])  # maybe add -5 as test case
-def test_save(mini_epoch, config_fresh):
-    config.save(config_fresh, mini_epoch)
+@pytest.mark.parametrize("istep", [None, 0, 1, 2, -1])  # maybe add -5 as test case
+def test_save(istep, config_fresh):
+    config.save(config_fresh, istep)
 
-    cf = config.load_run_config(config_fresh.run_id, mini_epoch, config_fresh.model_path)
+    cf = config.load_run_config(config_fresh.run_id, istep, config_fresh.model_path)
     assert is_equal(cf, config_fresh)


### PR DESCRIPTION
## Description

With this PR we will remove `mini_epoch` entirely from the repository and only rely on istep to measure training progress.


CC @clessig @MatKbauer 

## Issue Number

Closes #1676 
Closes #2219 2219

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
