### PR TITLE
Ensure _latest.chkpt and _latest.json exist and are up to date

### DIFF
--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -10,6 +10,7 @@
 # nor does it submit to any jurisdiction.
 import copy
 import logging
+import shutil
 import time
 
 import numpy as np
@@ -703,6 +704,19 @@ class Trainer(TrainerBase):
 
             # save config
             config.save(self.cf, mini_epoch)
+
+            # keep _latest always pointing to the most recent checkpoint
+            if mini_epoch != -1:
+                run_id = self.cf.general.run_id
+                latest_chkpt = base_path / (run_id + "_latest.chkpt")
+                shutil.copy2(file_out, latest_chkpt)
+
+                config_name = config._get_model_config_file_write_name(run_id, mini_epoch)
+                latest_config_name = config._get_model_config_file_write_name(run_id, -1)
+                config_file = base_path / config_name
+                latest_config_file = base_path / latest_config_name
+                if config_file.exists():
+                    shutil.copy2(config_file, latest_config_file)
 
     def _log(self, stage: Stage):
         """


### PR DESCRIPTION
## Description

Always update _latest entries after saving checkpoint after completing epoch.


## Issue Number

Closes #2084 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
