### PR TITLE
fix: default inference args overwrite start_date and end_date

### DIFF
--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -98,8 +98,8 @@ def run_inference(args):
         args.mini_epoch,
         args.base_config,
         *args.config,
-        inference_overwrite,
         cli_overwrite,
+        inference_overwrite,
     )
     cf = config.set_run_id(cf, args.run_id, args.reuse_run_id)
 

--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -103,7 +103,6 @@ def run_inference(args):
     )
     cf = config.set_run_id(cf, args.run_id, args.reuse_run_id)
 
-    logger.info(f"Running inference with config: {cf}")
     devices = Trainer.init_torch()
     cf = Trainer.init_ddp(cf)
 

--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -103,6 +103,7 @@ def run_inference(args):
     )
     cf = config.set_run_id(cf, args.run_id, args.reuse_run_id)
 
+    logger.info(f"Running inference with config: {cf}")
     devices = Trainer.init_torch()
     cf = Trainer.init_ddp(cf)
 

--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -87,10 +87,6 @@ def run_inference(args):
     inference_overwrite = {
         "test_config": dict(
             shuffle=False,
-            start_date=args.start_date,
-            end_date=args.end_date,
-            samples_per_mini_epoch=args.samples,
-            output=dict(num_samples=args.samples if args.save_samples else 0),
             streams_output=args.streams_output,
         )
     }


### PR DESCRIPTION
## Description

- part of #1925

## Issue Number

- closes #2087

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
