### PR TITLE
Fixed default args for inference

### DIFF
--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -84,16 +84,6 @@ def run_inference(args):
 
     Note: Additional configuration for inference (`test_config`) is set in the function.
     """
-    inference_overwrite = {
-        "test_config": dict(
-            shuffle=False,
-            start_date=args.start_date,
-            end_date=args.end_date,
-            samples_per_mini_epoch=args.samples,
-            output=dict(num_samples=args.samples if args.save_samples else 0),
-            streams_output=args.streams_output,
-        )
-    }
 
     cli_overwrite = config.from_cli_arglist(args.options)
     cf = config.load_merge_configs(
@@ -102,7 +92,7 @@ def run_inference(args):
         args.mini_epoch,
         args.base_config,
         *args.config,
-        inference_overwrite,
+        {},
         cli_overwrite,
     )
     cf = config.set_run_id(cf, args.run_id, args.reuse_run_id)

--- a/src/weathergen/utils/cli.py
+++ b/src/weathergen/utils/cli.py
@@ -77,35 +77,6 @@ def _add_inference_args(parser: argparse.ArgumentParser):
     _add_model_loading_params(parser)
     _add_general_arguments(parser)
 
-    parser.add_argument(
-        "--start-date",
-        "-start",
-        type=_format_date,
-        default="2022-10-01",
-        help="Start date for inference. Format must be parsable with pd.to_datetime.",
-    )
-    parser.add_argument(
-        "--end-date",
-        "-end",
-        type=_format_date,
-        default="2022-12-01",
-        help="End date for inference. Format must be parsable with pd.to_datetime.",
-    )
-    parser.add_argument(
-        "--samples", type=int, default=10000000, help="Number of inference samples."
-    )
-    parser.add_argument(  # behaviour changed => implies default=False
-        "--save-samples",
-        type=bool,
-        default=True,
-        help="Toggle saving of samples from inference. Default True",
-    )
-    parser.add_argument(
-        "--streams-output",
-        nargs="+",
-        help="Output streams during inference.",
-    )
-
 
 def _format_date(date: str) -> str:
     try:


### PR DESCRIPTION
## Description

Fixed default args for inference; removing and needs to be specified in config

## Issue Number

Closes #2097 

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
