### PR TITLE
Handle cartopy assets when they cannot be found

### DIFF
--- a/config/evaluate/eval_config.yml
+++ b/config/evaluate/eval_config.yml
@@ -1,7 +1,5 @@
 #optional: if commented out all is taken care of by the default settings
 # NB. global options apply to all run_ids 
-global_plotting_options:
-  cartopy_offline: true # set true to force local Cartopy data only (no auto-download)
 
 #global_plotting_options:
 #  regions: ["europe", "global"]
@@ -19,6 +17,7 @@ global_plotting_options:
 #    10u:
 #      vmin: -40
 #      vmax: 40
+#  cartopy_offline: true # set true to force local Cartopy data only (no auto-download)
 
 evaluation:
   metrics  : ["rmse", "mae"]

--- a/config/evaluate/eval_config.yml
+++ b/config/evaluate/eval_config.yml
@@ -1,5 +1,8 @@
 #optional: if commented out all is taken care of by the default settings
 # NB. global options apply to all run_ids 
+global_plotting_options:
+  cartopy_offline: true # set true to force local Cartopy data only (no auto-download)
+
 #global_plotting_options:
 #  regions: ["europe", "global"]
 #  image_format : "png" #options: "png", "pdf", "svg", "eps", "jpg" ..

--- a/config/evaluate/eval_config.yml
+++ b/config/evaluate/eval_config.yml
@@ -19,7 +19,6 @@
 #    10u:
 #      vmin: -40
 #      vmax: 40
-#  cartopy_offline: true # set true to force local Cartopy data only (no auto-download)
 
 evaluation:
   metrics  : ["rmse", "mae"]

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -8,13 +8,13 @@ from pathlib import Path
 
 import cartopy
 import cartopy.crs as ccrs
-from cartopy.io import DownloadWarning
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import omegaconf as oc
 import seaborn as sns
 import xarray as xr
+from cartopy.io import DownloadWarning
 from matplotlib.lines import Line2D
 from PIL import Image
 from scipy.stats import wilcoxon

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -14,17 +14,15 @@ import numpy as np
 import omegaconf as oc
 import seaborn as sns
 import xarray as xr
-from cartopy.io import DownloadWarning
 from astropy_healpix import HEALPix as HEALPixGrid
+from cartopy.io import DownloadWarning
 from matplotlib.collections import LineCollection
 from matplotlib.lines import Line2D
 from PIL import Image
 from scipy.stats import wilcoxon
 
 from weathergen.common.config import _load_private_conf
-from weathergen.evaluate.plotting.plot_utils import (
-    DefaultMarkerSize,
-)
+from weathergen.evaluate.plotting.plot_utils import DefaultMarkerSize
 from weathergen.evaluate.utils.regions import RegionBoundingBox
 
 _logger = logging.getLogger(__name__)

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -44,8 +44,7 @@ def _download_cartopy_off(enabled: bool) -> None:
     if enabled:
         warnings.filterwarnings("error", category=DownloadWarning)
         _logger.info(
-            "Cartopy offline mode enabled from plotting config. "
-            "Auto-downloads are blocked; only local cartopy data will be used."
+            "Auto-downloads are blocked for cartopy; only local cartopy data will be used."
         )
     else:
         warnings.filterwarnings("default", category=DownloadWarning)
@@ -509,12 +508,10 @@ class Plotter:
             proj = ccrs.Robinson()
 
         ax = fig.add_subplot(1, 1, 1, projection=proj)
-        if self.cartopy_offline:
-            _logger.info(
-                "Skipping coastlines in Cartopy offline mode to avoid triggering downloads."
-            )
-        else:
+        try:
             ax.coastlines()
+        except Exception:
+            _logger.warning("Could not add coastlines to plot; continuing without them.")
 
         assert data["lon"].shape == data["lat"].shape == data.shape, (
             f"Scatter plot:: Data shape do not match. Shapes: "

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -3,10 +3,12 @@ import glob
 import logging
 import os
 import re
+import warnings
 from pathlib import Path
 
 import cartopy
 import cartopy.crs as ccrs
+from cartopy.io import DownloadWarning
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
@@ -23,18 +25,55 @@ from weathergen.evaluate.plotting.plot_utils import (
 )
 from weathergen.evaluate.utils.regions import RegionBoundingBox
 
+_logger = logging.getLogger(__name__)
+_logger.setLevel(logging.INFO)
+
+_CARTOPY_WARNING_HOOK_INSTALLED = False
+_ORIGINAL_SHOWWARNING = warnings.showwarning
+
 work_dir = Path(_load_private_conf(None)["path_shared_working_dir"]) / "assets/cartopy"
 
 cartopy.config["data_dir"] = str(work_dir)
 cartopy.config["pre_existing_data_dir"] = str(work_dir)
 os.environ["CARTOPY_DATA_DIR"] = str(work_dir)
 
+def _install_cartopy_download_warning_hook() -> None:
+    """Log Cartopy download attempts when Cartopy emits DownloadWarning."""
+
+    global _CARTOPY_WARNING_HOOK_INSTALLED
+    if _CARTOPY_WARNING_HOOK_INSTALLED:
+        return
+
+    def _showwarning(message, category, filename, lineno, file=None, line=None):
+        if issubclass(category, DownloadWarning):
+            msg = (
+                "Cartopy attempted to download external map data. "
+                f"Details: {message}"
+            )
+            _logger.warning(msg)
+            return
+        _ORIGINAL_SHOWWARNING(message, category, filename, lineno, file=file, line=line)
+
+    warnings.showwarning = _showwarning
+    _CARTOPY_WARNING_HOOK_INSTALLED = True
+
+
+def _set_cartopy_offline_mode(enabled: bool) -> None:
+    """Enable/disable blocking Cartopy downloads by elevating DownloadWarning to error."""
+    if enabled:
+        warnings.filterwarnings("error", category=DownloadWarning)
+        _logger.info(
+            "Cartopy offline mode enabled from plotting config. "
+            "Auto-downloads are blocked; only local cartopy data will be used."
+        )
+    else:
+        warnings.filterwarnings("default", category=DownloadWarning)
+
+_install_cartopy_download_warning_hook()
+
 np.seterr(divide="ignore", invalid="ignore")
 
 logging.getLogger("matplotlib.category").setLevel(logging.ERROR)
-
-_logger = logging.getLogger(__name__)
-_logger.setLevel(logging.INFO)
 
 _logger.debug(f"Taking cartopy paths from {work_dir}")
 
@@ -72,6 +111,8 @@ class Plotter:
         self.fig_size = plotter_cfg.get("fig_size")
         self.fps = plotter_cfg.get("fps")
         self.regions = plotter_cfg.get("regions")
+        self.cartopy_offline = bool(plotter_cfg.get("cartopy_offline", False))
+        _set_cartopy_offline_mode(self.cartopy_offline)
         self.plot_subtimesteps = plotter_cfg.get(
             "plot_subtimesteps", False
         )  # True if plots are created for each valid time separately
@@ -482,7 +523,12 @@ class Plotter:
             proj = ccrs.Robinson()
 
         ax = fig.add_subplot(1, 1, 1, projection=proj)
-        ax.coastlines()
+        if self.cartopy_offline:
+            _logger.info(
+                "Skipping coastlines in Cartopy offline mode to avoid triggering downloads."
+            )
+        else:
+            ax.coastlines()
 
         assert data["lon"].shape == data["lat"].shape == data.shape, (
             f"Scatter plot:: Data shape do not match. Shapes: "

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -28,34 +28,15 @@ from weathergen.evaluate.utils.regions import RegionBoundingBox
 _logger = logging.getLogger(__name__)
 _logger.setLevel(logging.INFO)
 
-_CARTOPY_WARNING_HOOK_INSTALLED = False
-_ORIGINAL_SHOWWARNING = warnings.showwarning
-
 work_dir = Path(_load_private_conf(None)["path_shared_working_dir"]) / "assets/cartopy"
 
 cartopy.config["data_dir"] = str(work_dir)
 cartopy.config["pre_existing_data_dir"] = str(work_dir)
 os.environ["CARTOPY_DATA_DIR"] = str(work_dir)
 
-def _install_cartopy_download_warning_hook() -> None:
-    """Log Cartopy download attempts when Cartopy emits DownloadWarning."""
-
-    global _CARTOPY_WARNING_HOOK_INSTALLED
-    if _CARTOPY_WARNING_HOOK_INSTALLED:
-        return
-
-    def _showwarning(message, category, filename, lineno, file=None, line=None):
-        if issubclass(category, DownloadWarning):
-            msg = (
-                "Cartopy attempted to download external map data. "
-                f"Details: {message}"
-            )
-            _logger.warning(msg)
-            return
-        _ORIGINAL_SHOWWARNING(message, category, filename, lineno, file=file, line=line)
-
-    warnings.showwarning = _showwarning
-    _CARTOPY_WARNING_HOOK_INSTALLED = True
+# Route Cartopy DownloadWarnings through the logging system so they are visible in logs.
+logging.captureWarnings(True)
+warnings.filterwarnings("always", category=DownloadWarning)
 
 
 def _set_cartopy_offline_mode(enabled: bool) -> None:
@@ -68,8 +49,6 @@ def _set_cartopy_offline_mode(enabled: bool) -> None:
         )
     else:
         warnings.filterwarnings("default", category=DownloadWarning)
-
-_install_cartopy_download_warning_hook()
 
 np.seterr(divide="ignore", invalid="ignore")
 

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -39,7 +39,7 @@ logging.captureWarnings(True)
 warnings.filterwarnings("always", category=DownloadWarning)
 
 
-def _set_cartopy_offline_mode(enabled: bool) -> None:
+def _download_cartopy_off(enabled: bool) -> None:
     """Enable/disable blocking Cartopy downloads by elevating DownloadWarning to error."""
     if enabled:
         warnings.filterwarnings("error", category=DownloadWarning)
@@ -90,8 +90,7 @@ class Plotter:
         self.fig_size = plotter_cfg.get("fig_size")
         self.fps = plotter_cfg.get("fps")
         self.regions = plotter_cfg.get("regions")
-        self.cartopy_offline = bool(plotter_cfg.get("cartopy_offline", False))
-        _set_cartopy_offline_mode(self.cartopy_offline)
+        _download_cartopy_off(enabled=True)
         self.plot_subtimesteps = plotter_cfg.get(
             "plot_subtimesteps", False
         )  # True if plots are created for each valid time separately

--- a/packages/evaluate/src/weathergen/evaluate/utils/utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils/utils.py
@@ -348,7 +348,6 @@ def _plot_score_maps_per_stream(
             "image_format": cfg.get("image_format", "png"),
             "dpi_val": cfg.get("dpi_val", 300),
             "fig_size": cfg.get("fig_size", (8, 10)),
-            "cartopy_offline": cfg.get("cartopy_offline", True),
         },
         reader.runplot_dir,
         stream,
@@ -430,7 +429,6 @@ def plot_data(reader: Reader, stream: str, global_plotting_opts: dict) -> None:
         "fig_size": global_plotting_opts.get("fig_size", (8, 10)),
         "fps": global_plotting_opts.get("fps", 2),
         "regions": global_plotting_opts.get("regions", ["global"]),
-        "cartopy_offline": global_plotting_opts.get("cartopy_offline", True),
         "plot_subtimesteps": reader.get_inference_stream_attr(stream, "tokenize_spacetime", False)
         | plot_settings.get("plot_subtimesteps", False),
     }

--- a/packages/evaluate/src/weathergen/evaluate/utils/utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils/utils.py
@@ -348,6 +348,7 @@ def _plot_score_maps_per_stream(
             "image_format": cfg.get("image_format", "png"),
             "dpi_val": cfg.get("dpi_val", 300),
             "fig_size": cfg.get("fig_size", (8, 10)),
+            "cartopy_offline": cfg.get("cartopy_offline", True),
         },
         reader.runplot_dir,
         stream,
@@ -429,6 +430,7 @@ def plot_data(reader: Reader, stream: str, global_plotting_opts: dict) -> None:
         "fig_size": global_plotting_opts.get("fig_size", (8, 10)),
         "fps": global_plotting_opts.get("fps", 2),
         "regions": global_plotting_opts.get("regions", ["global"]),
+        "cartopy_offline": global_plotting_opts.get("cartopy_offline", True),
         "plot_subtimesteps": reader.get_inference_stream_attr(stream, "tokenize_spacetime", False)
         | plot_settings.get("plot_subtimesteps", False),
     }


### PR DESCRIPTION
## Description

A script was added to `packages/evaluate/src/weathergen/evaluate/plotting/plotter.py` to catch when cartopy tries to download missing asset.

If cartopy is not found, global plots will look like this:

<img width="1920" height="1440" alt="image" src="https://github.com/user-attachments/assets/d309b2db-00fd-45a6-aab5-039cf6c9c89f" />


## Issue Number

 Closes #2071 


Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
