### PR TITLE
Add early initialization for channels in DataReaderFesom

### DIFF
--- a/src/weathergen/datasets/data_reader_fesom.py
+++ b/src/weathergen/datasets/data_reader_fesom.py
@@ -94,7 +94,54 @@ class DataReaderFesom(DataReaderTimestep):
 
         # This flag ensures initialization happens only once per worker
         self._initialized = False
-        # print(f"checking stream info {list(stream_info.keys())}")
+        if len(self.filenames) > 0 and len(self.target_files) > 0:
+            # We need to initialize the channels in __init__ so that the
+            # MultiStreamDataSampler can correctly identify if a stream is forcing or not.
+            s_group = zarr.open_group(self.filenames[0], mode="r")
+            t_group = zarr.open_group(self.target_files[0], mode="r")
+
+            self.source_mesh_size = self._get_mesh_size(s_group)
+            self.target_mesh_size = self._get_mesh_size(t_group)
+
+            source_colnames: list[str] = list(s_group["data"].attrs["colnames"])
+            target_colnames: list[str] = list(t_group["data"].attrs["colnames"])
+
+            source_cols_idx = list(np.arange(len(source_colnames), dtype=int))
+            target_cols_idx = list(np.arange(len(target_colnames), dtype=int))
+
+            src_lat_index: int = source_colnames.index("lat")
+            src_lon_index: int = source_colnames.index("lon")
+            trg_lat_index: int = target_colnames.index("lat")
+            trg_lon_index: int = target_colnames.index("lon")
+
+            source_colnames = self._remove_lonlat(source_colnames)
+            target_colnames = self._remove_lonlat(target_colnames)
+
+            source_cols_idx.remove(src_lat_index)
+            source_cols_idx.remove(src_lon_index)
+            source_cols_idx = np.array(source_cols_idx)
+
+            target_cols_idx.remove(trg_lat_index)
+            target_cols_idx.remove(trg_lon_index)
+            target_cols_idx = np.array(target_cols_idx)
+
+            source_channels = self._stream_info.get("source")
+            source_excl = self._stream_info.get("source_exclude")
+            self.source_channels, self.source_idx = (
+                self.select(source_colnames, source_cols_idx, source_channels, source_excl)
+                if source_channels or source_excl
+                else (source_colnames, source_cols_idx)
+            )
+
+            target_channels = self._stream_info.get("target")
+            target_excl = self._stream_info.get("target_exclude")
+            self.target_channels, self.target_idx = (
+                self.select(target_colnames, target_cols_idx, target_channels, target_excl)
+                if target_channels or target_excl
+                else (target_colnames, target_cols_idx)
+            )
+
+            self.target_channel_weights = self.parse_target_channel_weights()
 
     def _get_mesh_size(self, group: zarr.Group) -> int:
         if "n_points" in group["data"].attrs:


### PR DESCRIPTION
## Description

Add early initialization of target and source channels in DataReaderFesom

## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/2136

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
