### PR TITLE
cli overwrite in fast eval

### DIFF
--- a/config/evaluate/eval_config_default.yml
+++ b/config/evaluate/eval_config_default.yml
@@ -9,7 +9,9 @@
 #    marker_size: 2
 #    scale_marker_size: 1
 #    marker: "o"
-#    # alpha: 0.5
+#    alpha: 0.5
+#    add_healpix_grid: false
+#    healpix_nside: 4
 #    2t: 
 #      vmin: 250
 #      vmax: 300

--- a/config/evaluate/eval_config_default.yml
+++ b/config/evaluate/eval_config_default.yml
@@ -1,0 +1,62 @@
+#optional: if commented out all is taken care of by the default settings
+# NB. global options apply to all run_ids 
+#global_plotting_options:
+#  regions: ["europe", "global"]
+#  image_format : "png" #options: "png", "pdf", "svg", "eps", "jpg" ..
+#  dpi_val : 300
+#  fps: 2
+#  ERA5:
+#    marker_size: 2
+#    scale_marker_size: 1
+#    marker: "o"
+#    # alpha: 0.5
+#    2t: 
+#      vmin: 250
+#      vmax: 300
+#    10u:
+#      vmin: -40
+#      vmax: 40
+
+evaluation:
+  metrics: ["rmse", "mae"]
+  regions: ["global", "nhem"]
+  summary_plots : true
+  ratio_plots : false
+  heat_maps : false
+  summary_dir: "./plots/"
+  plot_ensemble: "members" #supported: false, "std", "minmax", "members"
+  plot_score_maps: false #plot scores on a 2D maps. it slows down score computation 
+  print_summary: false #print out score values on screen. it can be verbose
+  log_scale: false
+  add_grid: false
+  score_cards: false
+  bar_plots: false
+
+
+default_streams:
+  ERA5:
+    channels: ["2t", "10u", "10v", "z_500", "t_850", "u_850", "v_850", "q_850"]
+    evaluation:
+      forecast_step: "all"
+      sample: "all"
+      ensemble: "all" #supported: "all", "mean", [0,1,2]
+    plotting:
+      sample: [0]
+      forecast_step: "all" #supported: "all", [1,2,3,...], "1-50" (equivalent of [1,2,3,...50])
+      plot_maps: true
+      plot_histograms: false
+      plot_animations: true
+  CERRA:
+    channels: ["z_500", "t_850", "u_850"] #, "blah"]
+    evaluation:
+      forecast_step: "all"
+      sample: "all"
+    plotting:
+      sample: [0]
+      forecast_step: "all"
+      plot_maps: true
+      plot_bias: false
+      plot_target: false
+      plot_histograms: true
+      plot_animations: true
+      

--- a/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
@@ -134,6 +134,25 @@ def evaluate_from_args(argl: list[str], log_queue: mp.Queue) -> None:
         action="store_true",
         help="(optional) Upload scores to MLFlow.",
     )
+    parser.add_argument(
+        "--options",
+        nargs="+",
+        default=[],
+        help=(
+            "Overwrite individual config options."
+            " Individual items should be of the form: parent_obj.nested_obj=value."
+            " NOTE: cannot be used for run_ids (use --run-ids instead)."
+        ),
+    )
+    parser.add_argument(
+        "--run-ids",
+        nargs="+",
+        default=None,
+        help=(
+            "Filter run_ids from the config to only these."
+            " E.g. --run-ids wu4wy9os fy6fgscn so67dku1"
+        ),
+    )
 
     args = parser.parse_args(argl)
     if args.config:
@@ -155,6 +174,28 @@ def evaluate_from_args(argl: list[str], log_queue: mp.Queue) -> None:
 
     cf = OmegaConf.load(config)
     assert isinstance(cf, DictConfig)
+
+    # Disable struct flag so that --options and --run-ids can freely modify keys.
+    OmegaConf.set_struct(cf, False)
+
+    if args.options:
+        # Filter out any run_ids= items — those must use --run-ids instead.
+        cli_items = [item for item in args.options if not item.startswith("run_ids=")]
+        if len(cli_items) != len(args.options):
+            _logger.warning(
+                "run_ids= in --options is not supported (it's a dict, not a list). "
+                "Use --run-ids instead. Ignoring run_ids= items."
+            )
+        if cli_items:
+            cli_overwrite = OmegaConf.from_cli(cli_items)
+            cf = OmegaConf.merge(cf, cli_overwrite)
+            _logger.info(f"Applied --options overwrites: {cli_items}")
+
+    if args.run_ids:
+        existing = cf.get("run_ids", {})
+        cf.run_ids = {k: existing.get(k, {}) for k in args.run_ids}
+        _logger.info(f"Overwritten run_ids to: {args.run_ids}")
+
     evaluate_from_config(cf, mlflow_client, log_queue)
 
 


### PR DESCRIPTION
## Description

- add possibility to overwrite options in eval config
- add the list of `run_ids` directly from the terminal

 example:
```
uv run evaluate --config config/evaluate/eval_config_default.yml 
--run-ids "wu4wy9os" "fy6fgscn" "so67dku1" 
--options 
evaluation.regions=["shem"] 
default_streams.ERA5.evaluation.forecast_step=[1] 
default_streams.ERA5.evaluation.sample=[1,2]
```

NB. it's important that the config contains the selection under the `default_streams` option. 

## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/2129

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
