### PR TITLE
Add conditional layer norm to fe

### DIFF
--- a/.github/ISSUE_TEMPLATE/initiative.yml
+++ b/.github/ISSUE_TEMPLATE/initiative.yml
@@ -50,6 +50,7 @@ body:
         - label: infrastructure and engineering
         - label: evaluation, export and visualization
         - label: documentation
+        - label: performance
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -31,6 +31,7 @@ body:
         - label: infrastructure and engineering
         - label: evaluation, export and visualization
         - label: documentation
+        - label: performance
     validations:
       required: true
 

--- a/.github/workflows/issue_set_label.yml
+++ b/.github/workflows/issue_set_label.yml
@@ -21,7 +21,8 @@ jobs:
               "science": "science",
               "infrastructure and engineering": "infra",
               "evaluation, export and visualization": "eval",
-              "documentation": "documentation"
+              "documentation": "documentation",
+              "performance": "performance"
             };
 
             const issue = context.payload.issue;

--- a/config/config_forecasting.yml
+++ b/config/config_forecasting.yml
@@ -187,6 +187,7 @@ training_config:
       offset: 1
       num_steps: 3
       policy: "fixed"
+      condition: True
 
 
 # validation config; full validation config is merge of training and validation config

--- a/src/weathergen/datasets/batch.py
+++ b/src/weathergen/datasets/batch.py
@@ -152,6 +152,11 @@ class BatchSamples:
         self.output_steps = output_steps
         self.output_idxs = output_idxs
         self.device = None
+        # Forecast conditions are global to the batch (independent of streams)
+        # and will be populated by the data sampler when applicable. The
+        # structure is a list of per-output-step entries, each an iterable of
+        # [start_hour, start_day, end_hour, end_day].
+        self.forecast_conditions = [[] for _ in range(output_steps)]
 
     def __len__(self) -> int:
         return len(self.samples)
@@ -287,7 +292,7 @@ class ModelBatch:
         self.output_offset = output_offset
         self.output_steps = output_steps
         self.output_idxs = list(range(output_offset, output_steps))
-
+        
         self.source_samples = BatchSamples(
             streams, num_source_samples, output_steps, self.output_idxs
         )

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -11,6 +11,7 @@ import logging
 import pathlib
 
 import numpy as np
+import pandas as pd
 import torch
 
 from weathergen.common.config import Config
@@ -454,20 +455,6 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                 )
                 stream_data.add_target_values(timestep_idx, tt_cells, tt_c, tt_t, idxs_inv)
 
-            if "condition_forecast_engine" in mode:
-                # convert numpy.datetime64 to python datetimes
-                py_start = time_win.start.tolist()
-                py_end = time_win.end.tolist()
-
-                # extract start/end hour and day
-                start_hour = int(py_start.hour)
-                start_day = int(py_start.day)
-                end_hour = int(py_end.hour)
-                end_day = int(py_end.day)
-
-                # Option A — pass as separate args (adjust to the real method signature)
-                stream_data.add_forecast_condtions(start_hour, start_day, end_hour, end_day)
-
         return stream_data
 
     def _build_stream_data(
@@ -622,7 +609,6 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         batch.target_samples.tokens_lens = get_tokens_lens(
             self.streams, batch.target_samples, target_input_steps
         )
-
         return batch
 
     def _get_batch(self, idx: int, num_forecast_steps: int):
@@ -644,7 +630,8 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         if "student_teacher" in mode or "latent_loss" in mode:
             source_select += ["network_input"]
             target_select += ["network_input"]
-        if  mode.get("forecast", False).get("condtion",False) :
+        if  self.mode_cfg.get("forecast", False).get("condition",False) :
+            source_select += ["condition_forecasting_engine"]
             target_select += ["condition_forecasting_engine"]
         # remove duplicates
         source_select, target_select = list(set(source_select)), list(set(target_select))
@@ -659,6 +646,24 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
             self.output_offset,
             num_output_steps,
         )
+
+        # Compute forecast conditions for the whole batch (independent of streams)
+        # and attach them to the batch. Each entry corresponds to one output
+        # step and contains [start_hour, start_day, end_hour, end_day].
+        for timestep_idx in range(self.output_offset, num_output_steps):
+            step_forecast_dt = idx + (self.time_step * timestep_idx) // self.step_timedelta
+            time_win_target = self.time_window_handler.window(step_forecast_dt)
+
+            py_start = pd.to_datetime(time_win_target.start).to_pydatetime()
+            py_end = pd.to_datetime(time_win_target.end).to_pydatetime()
+
+            start_hour = int(py_start.hour)
+            start_day = int(py_start.day)
+            end_hour = int(py_end.hour)
+            end_day = int(py_end.day)
+
+            forecast_conditions = [start_hour, start_day, end_hour, end_day]
+            batch.get_source_samples().forecast_conditions[timestep_idx] += forecast_conditions
 
         # for all streams
         for stream_info, (stream_name, stream_ds) in zip(
@@ -734,7 +739,6 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         target_in_steps = np.array([tc.get("num_steps_input", 1) for _, tc in target_cfgs.items()])
         target_in_steps = 1 if len(target_in_steps) == 0 else target_in_steps.max().item()
         batch = self._preprocess_model_batch(batch, source_in_steps, target_in_steps)
-
         return batch
 
     def __iter__(self) -> ModelBatch:
@@ -766,7 +770,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                 idx_raw += 1
 
                 batch = self._get_batch(idx, num_forecast_steps)
-
+                
                 # ensure the batch is valid, i.e. not completely empty and no NaN values
                 # student teacher has no classical targets
                 mode = self.mode_cfg.get("training_mode")
@@ -778,7 +782,6 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                     logger.warning(f"Skipping empty batch with idx={idx}.")
                 else:
                     break
-
             yield batch
 
     def __len__(self):

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -454,6 +454,20 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                 )
                 stream_data.add_target_values(timestep_idx, tt_cells, tt_c, tt_t, idxs_inv)
 
+            if "condition_forecast_engine" in mode:
+                # convert numpy.datetime64 to python datetimes
+                py_start = time_win.start.tolist()
+                py_end = time_win.end.tolist()
+
+                # extract start/end hour and day
+                start_hour = int(py_start.hour)
+                start_day = int(py_start.day)
+                end_hour = int(py_end.hour)
+                end_day = int(py_end.day)
+
+                # Option A — pass as separate args (adjust to the real method signature)
+                stream_data.add_forecast_condtions(start_hour, start_day, end_hour, end_day)
+
         return stream_data
 
     def _build_stream_data(
@@ -630,6 +644,8 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         if "student_teacher" in mode or "latent_loss" in mode:
             source_select += ["network_input"]
             target_select += ["network_input"]
+        if  mode.get("forecast", False).get("condtion",False) :
+            target_select += ["condition_forecasting_engine"]
         # remove duplicates
         source_select, target_select = list(set(source_select)), list(set(target_select))
         if len(source_select) == 0 or len(target_select) == 0:

--- a/src/weathergen/datasets/stream_data.py
+++ b/src/weathergen/datasets/stream_data.py
@@ -97,6 +97,7 @@ class StreamData:
             torch.tensor([0 for _ in range(self.healpix_cells)]) for _ in range(output_steps)
         ]
         self.target_tokens = [torch.tensor([]) for _ in range(output_steps)]
+        self.forecast_conditions = [torch.tensor([]) for _ in range(output_steps)]
         self.idxs_inv = [torch.tensor([], dtype=torch.int64) for _ in range(output_steps)]
 
         # source tokens per cell
@@ -312,6 +313,10 @@ class StreamData:
 
         self.target_coords[fstep] = target_coords
         self.target_coords_lens[fstep] = target_coords_per_cell
+    
+    def add_forecast_conditions(self, fstep, start_hour, start_day, end_hour, end_day):
+        self.forecast_conditions[fstep] = [start_hour, start_day, end_hour, end_day]
+    
 
     def target_empty(self) -> bool:
         """

--- a/src/weathergen/datasets/stream_data.py
+++ b/src/weathergen/datasets/stream_data.py
@@ -97,7 +97,6 @@ class StreamData:
             torch.tensor([0 for _ in range(self.healpix_cells)]) for _ in range(output_steps)
         ]
         self.target_tokens = [torch.tensor([]) for _ in range(output_steps)]
-        self.forecast_conditions = [torch.tensor([]) for _ in range(output_steps)]
         self.idxs_inv = [torch.tensor([], dtype=torch.int64) for _ in range(output_steps)]
 
         # source tokens per cell
@@ -314,8 +313,8 @@ class StreamData:
         self.target_coords[fstep] = target_coords
         self.target_coords_lens[fstep] = target_coords_per_cell
     
-    def add_forecast_conditions(self, fstep, start_hour, start_day, end_hour, end_day):
-        self.forecast_conditions[fstep] = [start_hour, start_day, end_hour, end_day]
+    # Forecast conditions have been moved to batch-level and are no longer
+    # stored per-stream in StreamData. This method was intentionally removed.
     
 
     def target_empty(self) -> bool:

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -475,7 +475,7 @@ class ForecastingEngine(torch.nn.Module):
             if noise_std > 0.0:
                 tokens = tokens + torch.randn_like(tokens) * torch.norm(tokens) * noise_std
 
-        aux_info = None
+        aux_info = torch.Tensor(fstep).to(tokens.device)
         for _b_idx, block in enumerate(self.fe_blocks):
             if isinstance(block, torch.nn.modules.normalization.LayerNorm):
                 tokens = checkpoint(block, tokens, use_reentrant=False)

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -697,6 +697,8 @@ class Model(torch.nn.Module):
         # collapse along input step dimension
         tokens = tokens.reshape(shape).sum(axis=1)
 
+        break
+
         # roll-out in latent space, iterate and generate output over requested output steps
         for step in batch.get_output_idxs():
             # apply forecasting engine (if present)

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -372,7 +372,7 @@ class Model(torch.nn.Module):
         mode_cfg = cf.training_config
         self.forecast_engine = None
         if cf.fe_num_blocks > 0:
-            self.forecast_engine = ForecastingEngine(cf, mode_cfg, self.num_healpix_cells)
+            self.forecast_engine = ForecastingEngine(cf, mode_cfg, self.num_healpix_cells, 4)
 
         # embed coordinates yielding one query token for each target token
         dropout_rate = cf.embed_dropout_rate
@@ -697,13 +697,11 @@ class Model(torch.nn.Module):
         # collapse along input step dimension
         tokens = tokens.reshape(shape).sum(axis=1)
 
-        break
-
         # roll-out in latent space, iterate and generate output over requested output steps
         for step in batch.get_output_idxs():
             # apply forecasting engine (if present)
             if self.forecast_engine:
-                tokens = self.forecast_engine(tokens, step, coords=model_params.rope_coords)
+                tokens = self.forecast_engine(tokens, batch.forecast_conditions[step], coords=model_params.rope_coords)
 
             # decoder predictions
             output = self.predict_decoders(model_params, step, tokens, batch, output)


### PR DESCRIPTION
## Description

Closes #2153 

Added new config to the forecasting_engine.

It passes aux_info to the forecasting engine ( `time_window_handler.start.day`, `time_window_handler.start.time`, `time_window_handler.end.day`,`time_window_handler.end.time` )


Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
