### PR TITLE
Add Healpix grid to the evaluation global maps

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -18,8 +18,8 @@ from matplotlib.collections import LineCollection
 from matplotlib.lines import Line2D
 from PIL import Image
 from scipy.stats import wilcoxon
-
 from weathergen.common.config import _load_private_conf
+
 from weathergen.evaluate.plotting.plot_utils import (
     DefaultMarkerSize,
 )
@@ -519,7 +519,7 @@ class Plotter:
             )
             ax.add_collection(lc)
         else:
-            ax.gridlines(draw_labels=False, linestyle="--", color="black", linewidth=1)
+            ax.gridlines(draw_labels=False, linestyle="--", color="black", linewidth=0.2)
 
         plt.colorbar(scatter_plt, ax=ax, orientation="horizontal", label=f"Variable: {varname}")
         plt.title(title, fontsize=9.5)

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -18,8 +18,8 @@ from matplotlib.collections import LineCollection
 from matplotlib.lines import Line2D
 from PIL import Image
 from scipy.stats import wilcoxon
-from weathergen.common.config import _load_private_conf
 
+from weathergen.common.config import _load_private_conf
 from weathergen.evaluate.plotting.plot_utils import (
     DefaultMarkerSize,
 )

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -13,11 +13,13 @@ import numpy as np
 import omegaconf as oc
 import seaborn as sns
 import xarray as xr
+from astropy_healpix import HEALPix as HEALPixGrid
+from matplotlib.collections import LineCollection
 from matplotlib.lines import Line2D
 from PIL import Image
 from scipy.stats import wilcoxon
-
 from weathergen.common.config import _load_private_conf
+
 from weathergen.evaluate.plotting.plot_utils import (
     DefaultMarkerSize,
 )
@@ -454,6 +456,14 @@ class Plotter:
         vmax = map_kwargs_save.pop("vmax", None)
         cmap = plt.get_cmap(map_kwargs_save.pop("colormap", "coolwarm"))
 
+        # Healpix grid configuration
+        add_healpix_grid = map_kwargs_save.pop("add_healpix_grid", False)
+        healpix_nside = map_kwargs_save.pop("healpix_nside", 4)
+        healpix_color = map_kwargs_save.pop("healpix_color", "black")
+        healpix_linewidth = map_kwargs_save.pop("healpix_linewidth", 0.2)
+        healpix_step = map_kwargs_save.pop("healpix_step", 64)
+        healpix_linestyle = map_kwargs_save.pop("healpix_linestyle", "-")
+
         if isinstance(map_kwargs_save.get("levels", False), oc.listconfig.ListConfig):
             norm = mpl.colors.BoundaryNorm(
                 map_kwargs_save.pop("levels", None), cmap.N, extend="both"
@@ -502,6 +512,15 @@ class Plotter:
             **map_kwargs_save,
         )
 
+        # Add Healpix grid (optimized with LineCollection)
+        if add_healpix_grid:
+            lc = self.healpixlines(
+                healpix_nside, healpix_color, healpix_linewidth, healpix_step, healpix_linestyle
+            )
+            ax.add_collection(lc)
+        else:
+            ax.gridlines(draw_labels=False, linestyle="--", color="black", linewidth=1)
+
         plt.colorbar(scatter_plt, ax=ax, orientation="horizontal", label=f"Variable: {varname}")
         plt.title(title, fontsize=9.5)
         if regionname == "global":
@@ -514,7 +533,6 @@ class Plotter:
                 data["lat"].max().item(),
             ]
             ax.set_extent(region_extent, crs=ccrs.PlateCarree())
-        ax.gridlines(draw_labels=False, linestyle="--", color="black", linewidth=1)
 
         # TODO: make this nicer
         parts = ["map", self.run_id, tag]
@@ -550,6 +568,28 @@ class Plotter:
         plt.close()
 
         return name
+
+    def healpixlines(
+        self, healpix_nside, healpix_color, healpix_linewidth, healpix_step, healpix_linestyle
+    ):
+        hp_grid = HEALPixGrid(nside=healpix_nside, order="ring")
+        lon_all, lat_all = hp_grid.boundaries_lonlat(np.arange(hp_grid.npix), step=healpix_step)
+        # Ensure closure of polygons
+        lon_closed = np.concatenate([lon_all.deg, lon_all.deg[:, 0:1]], axis=1)
+        lat_closed = np.concatenate([lat_all.deg, lat_all.deg[:, 0:1]], axis=1)
+        # Stack as (N_polys, N_points, 2)
+        segments = np.stack([lon_closed, lat_closed], axis=-1)
+        # (cartopy handles transform for LineCollection via set_transform)
+        lc = LineCollection(
+            segments,
+            colors=healpix_color,
+            linewidths=healpix_linewidth,
+            linestyles=healpix_linestyle,
+            alpha=0.5,
+            zorder=10,
+        )
+        lc.set_transform(ccrs.PlateCarree())
+        return lc
 
     def animation(self, samples, fsteps, variables, select, tag) -> list[str]:
         """

--- a/packages/readers_extra/src/weathergen/readers_extra/data_reader_mesh.py
+++ b/packages/readers_extra/src/weathergen/readers_extra/data_reader_mesh.py
@@ -36,6 +36,7 @@ class DataReaderMesh(DataReaderTimestep):
     - Robust Multi-Node/Worker support (Fork-safe, Dask-safe).
     - Dynamic Patching (local) OR Global Sparse Sampling.
     """
+
     def __init__(
         self,
         tw_handler: TimeWindowHandler,
@@ -59,9 +60,9 @@ class DataReaderMesh(DataReaderTimestep):
 
         self.sampling_mode = stream_info.get("sampling_mode", "patch")
         self.patch_stability_window = stream_info.get("patch_stability_window", 1)
-        
+
         # Auto-enable staircase mode if window is defined and we are in patch mode
-        auto_use_counter = (self.sampling_mode == "patch" and "patch_stability_window" in stream_info)
+        auto_use_counter = self.sampling_mode == "patch" and "patch_stability_window" in stream_info
         self.patch_use_counter = stream_info.get("patch_use_counter", auto_use_counter)
 
         if self.filename_source != self.filename_target and self.sampling_mode != "patch":
@@ -129,7 +130,10 @@ class DataReaderMesh(DataReaderTimestep):
             self.roi_min_lon, self.roi_min_lat, self.roi_max_lon, self.roi_max_lat = self.roi
         else:
             self.roi_min_lon, self.roi_min_lat, self.roi_max_lon, self.roi_max_lat = (
-                -180.0, -90.0, 180.0, 90.0
+                -180.0,
+                -90.0,
+                180.0,
+                90.0,
             )
 
         self.available_channels = list(self.col_map.keys())
@@ -139,7 +143,7 @@ class DataReaderMesh(DataReaderTimestep):
         self.source_idx = self._select_channels("source")
         self.target_idx = self._select_channels("target")
         self.geoinfo_idx = []
-        self.geoinfo_channels =[]
+        self.geoinfo_channels = []
 
         self.source_channels = [self.available_channels[i] for i in self.source_idx]
         self.target_channels = [self.available_channels[i] for i in self.target_idx]
@@ -152,7 +156,7 @@ class DataReaderMesh(DataReaderTimestep):
             with xr.open_dataset(mapper, engine="zarr", chunks={}, consolidated=False) as ds:
                 if "time" not in ds.coords:
                     all_vars = list(ds.coords) + list(ds.data_vars)
-                    time_candidates =[v for v in all_vars if "time" in v.lower()]
+                    time_candidates = [v for v in all_vars if "time" in v.lower()]
                     if time_candidates:
                         target = time_candidates[0]
                         if target in ds.data_vars:
@@ -214,35 +218,25 @@ class DataReaderMesh(DataReaderTimestep):
         if self._initialized:
             return
 
-        self.mapper_src = fsspec.get_mapper("reference://", 
-                                            fo=str(self.filename_source), 
-                                            remote_protocol="file"
-                                            )
+        self.mapper_src = fsspec.get_mapper(
+            "reference://", fo=str(self.filename_source), remote_protocol="file"
+        )
         import warnings
+
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message=".*separate the stored chunks.*")
             self.ds_source = xr.open_dataset(
-                self.mapper_src, 
-                engine="zarr", 
-                chunks={}, 
-                decode_times=True, 
-                consolidated=False
+                self.mapper_src, engine="zarr", chunks={}, decode_times=True, consolidated=False
             )
 
         if self.filename_target != self.filename_source:
             self.mapper_trg = fsspec.get_mapper(
-                "reference://", 
-                fo=str(self.filename_target), 
-                remote_protocol="file"
+                "reference://", fo=str(self.filename_target), remote_protocol="file"
             )
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", message=".*separate the stored chunks.*")
                 self.ds_target = xr.open_dataset(
-                    self.mapper_trg, 
-                    engine="zarr", 
-                    chunks={}, 
-                    decode_times=True, 
-                    consolidated=False
+                    self.mapper_trg, engine="zarr", chunks={}, decode_times=True, consolidated=False
                 )
         else:
             self.ds_target = self.ds_source
@@ -290,10 +284,10 @@ class DataReaderMesh(DataReaderTimestep):
         if len(t_idxs) == 0 or not channels:
             return ReaderData.empty(len(channels), 0)
 
-        channel_indices =[self.available_channels.index(c) for c in channels]
+        channel_indices = [self.available_channels.index(c) for c in channels]
         start_t, end_t = t_idxs[0], t_idxs[-1] + 1
         n_steps = len(t_idxs)
-        
+
         spatial_indices_ref = self.spatial_indices_src if is_source else self.spatial_indices_trg
         coords_ref = self.coords_src if is_source else self.coords_trg
         ds_ref = self.ds_source if is_source else self.ds_target
@@ -308,9 +302,9 @@ class DataReaderMesh(DataReaderTimestep):
             # Fallback to time-based index (Warning: sampler often seeds this per-rank!)
             local_seed = int(idx) + 12345
             patch_idx = int(idx)
-        
+
         patch_rng = np.random.default_rng(local_seed)
-        
+
         # Increment counter for next fetch
         self.patch_counter += 1
 
@@ -334,21 +328,29 @@ class DataReaderMesh(DataReaderTimestep):
             lon_0 = self.roi_min_lon + patch_rng.random() * lon_range
 
             mask_src = (
-                (self.lats_src >= lat_0) & (self.lats_src < lat_0 + self.patch_size_deg) &
-                (self.lons_src >= lon_0) & (self.lons_src < lon_0 + self.patch_size_deg)
+                (self.lats_src >= lat_0)
+                & (self.lats_src < lat_0 + self.patch_size_deg)
+                & (self.lons_src >= lon_0)
+                & (self.lons_src < lon_0 + self.patch_size_deg)
             )
             mask_trg = (
-                (self.lats_trg >= lat_0) & (self.lats_trg < lat_0 + self.patch_size_deg) &
-                (self.lons_trg >= lon_0) & (self.lons_trg < lon_0 + self.patch_size_deg)
+                (self.lats_trg >= lat_0)
+                & (self.lats_trg < lat_0 + self.patch_size_deg)
+                & (self.lons_trg >= lon_0)
+                & (self.lons_trg < lon_0 + self.patch_size_deg)
             )
 
             patch_indices_local = np.where(mask_src if is_source else mask_trg)[0]
 
-            patch_coords_base = self.coords_src[patch_indices_local] if is_source else (
-                self.coords_trg[patch_indices_local]
+            patch_coords_base = (
+                self.coords_src[patch_indices_local]
+                if is_source
+                else (self.coords_trg[patch_indices_local])
             )
-            final_disk_indices = self.spatial_indices_src[patch_indices_local] if is_source else (
-                self.spatial_indices_trg[patch_indices_local]
+            final_disk_indices = (
+                self.spatial_indices_src[patch_indices_local]
+                if is_source
+                else (self.spatial_indices_trg[patch_indices_local])
             )
             use_contiguous_read = True
 
@@ -358,31 +360,34 @@ class DataReaderMesh(DataReaderTimestep):
             use_contiguous_read = True
 
         if len(final_disk_indices) == 0:
-            _logger.warning(f"[Stream {self._stream_info.get('name')}] NO POINTS FOUND for patch! Skipping.")
+            _logger.warning(
+                f"[Stream {self._stream_info.get('name')}] NO POINTS FOUND for patch! Skipping."
+            )
             return ReaderData.empty(len(channels), n_steps)
 
         if use_contiguous_read:
             disk_start, disk_stop = np.min(final_disk_indices), np.max(final_disk_indices) + 1
             rel_indices = final_disk_indices - disk_start
             data_block = self._load_block_from_ds(
-                ds_ref, 
-                arr_cache, 
-                channel_indices, 
-                start_t, 
-                end_t, 
-                n_steps, 
-                slice(disk_start, disk_stop), 
-                rel_indices
+                ds_ref,
+                arr_cache,
+                channel_indices,
+                start_t,
+                end_t,
+                n_steps,
+                slice(disk_start, disk_stop),
+                rel_indices,
             )
         else:
             data_block = self._load_block_from_ds(
-                ds_ref, 
-                arr_cache, 
-                channel_indices, 
-                start_t, end_t, 
-                n_steps, 
-                final_disk_indices, 
-                None
+                ds_ref,
+                arr_cache,
+                channel_indices,
+                start_t,
+                end_t,
+                n_steps,
+                final_disk_indices,
+                None,
             )
 
         if data_block.size > 0:
@@ -403,16 +408,8 @@ class DataReaderMesh(DataReaderTimestep):
         return rdata
 
     def _load_block_from_ds(
-            self, 
-            ds, 
-            arr_cache, 
-            indices, 
-            start_t, 
-            end_t, 
-            n_steps, 
-            disk_indices, 
-            rel_indices
-        ) -> np.typing.NDArray:
+        self, ds, arr_cache, indices, start_t, end_t, n_steps, disk_indices, rel_indices
+    ) -> np.typing.NDArray:
         if rel_indices is not None:
             num_points = len(rel_indices)
         else:
@@ -466,7 +463,7 @@ class DataReaderMesh(DataReaderTimestep):
                     if "time" in dims:
                         # Contiguous read: Apply raw disk bounds, then rel_indices
                         chunk = chunk[:, disk_indices]
-                        
+
                         # Safety check: if chunk is completely empty, fill with NaNs
                         if chunk.shape[1] == 0:
                             assert False, "Empty chunk after disk indexing with time dimension"
@@ -514,8 +511,8 @@ class DataReaderMesh(DataReaderTimestep):
 
     def _select_channels(self, type_key: str) -> list[int]:
         select = self._stream_info.get(type_key)
-        exclude = self._stream_info.get(f"{type_key}_exclude",[])
-        return[
+        exclude = self._stream_info.get(f"{type_key}_exclude", [])
+        return [
             i
             for i, ch in enumerate(self.available_channels)
             if (not select or any(s in ch for s in select)) and not any(e in ch for e in exclude)
@@ -550,21 +547,17 @@ class DataReaderMesh(DataReaderTimestep):
     def denormalize_source_channels(self, source):
         if isinstance(source, torch.Tensor):
             stdev = torch.tensor(
-                self.stdev[self.source_idx], 
-                dtype=source.dtype, 
-                device=source.device
+                self.stdev[self.source_idx], dtype=source.dtype, device=source.device
             )
             mean = torch.tensor(
-                self.mean[self.source_idx], 
-                dtype=source.dtype, 
-                device=source.device
+                self.mean[self.source_idx], dtype=source.dtype, device=source.device
             )
-            land_mask = (source == 0.0)
+            land_mask = source == 0.0
             denorm = (source * stdev) + mean
             denorm[land_mask] = torch.nan
             return denorm
-            
-        land_mask = (source == 0.0)
+
+        land_mask = source == 0.0
         denorm = (source * self.stdev[self.source_idx]) + self.mean[self.source_idx]
         denorm[land_mask] = np.nan
         return denorm


### PR DESCRIPTION
## Description

This PR add the possibility to plot healpix grid on the global maps.

This is a small PR. It should be noted that the plot can be very slow for healpix levels above 4 or 5.

The plotting code is optimized as much as possible.

**Example use:**

```
global_plotting_options:
  image_format: "png"
  dpi_val: 300
  ERA5:
    add_healpix_grid: true
```
    
## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/1935

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [X] I have performed a self-review of my code
-   [X] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [X] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
