### PR TITLE
Revert streams_directory to era5_1deg for jepa forecasting ft

### DIFF
--- a/config/config_jepa_forecasting_finetuning.yml
+++ b/config/config_jepa_forecasting_finetuning.yml
@@ -46,7 +46,7 @@ zarr_store: "zip" # "zarr" for LocalStore, "zip" for ZipStore
 
 #####################################
 
-streams_directory: "./config/streams/era5_1deg_forecasting/"
+streams_directory: "./config/streams/era5_1deg/"
 # streams_directory: "./config/streams/era5_synop_finetuning/"
 streams: ???
 


### PR DESCRIPTION
## Description

Using era5_1deg_forecasting significant degrades JEPA era5 forecast ft performance, due to weighting or to max_num_targets. See #2159 


## Issue Number

Closes #2159 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
