### PR TITLE
[readers_extra][GREP][AP13/14]: handle empty channels_idx

### DIFF
--- a/packages/readers_extra/src/weathergen/readers_extra/data_reader_grep.py
+++ b/packages/readers_extra/src/weathergen/readers_extra/data_reader_grep.py
@@ -380,7 +380,8 @@ class DataReaderGREP(DataReaderTimestep):
                 continue
 
             # (n_points, n_channels)
-            # TODO remove try/except: should be able to just use time or time_centered depending on dataset, without needing to guess per-timestep.
+            # TODO remove try/except: should be able to just use time or time_centered
+            # depending on dataset, without needing to guess per-timestep.
             try:
                 timestep_data = np.stack(
                     [

--- a/packages/readers_extra/src/weathergen/readers_extra/data_reader_grep.py
+++ b/packages/readers_extra/src/weathergen/readers_extra/data_reader_grep.py
@@ -332,6 +332,12 @@ class DataReaderGREP(DataReaderTimestep):
         """
         self._lazy_init()
 
+        if not channels_idx:
+            return ReaderData.empty(
+                num_data_fields=0,
+                num_geo_fields=0,
+            )
+
         (t_idxs, dtr) = self._get_dataset_idxs(idx)
 
         if self.ds is None or self.len == 0 or len(t_idxs) == 0:
@@ -374,6 +380,7 @@ class DataReaderGREP(DataReaderTimestep):
                 continue
 
             # (n_points, n_channels)
+            # TODO remove try/except: should be able to just use time or time_centered depending on dataset, without needing to guess per-timestep.
             try:
                 timestep_data = np.stack(
                     [


### PR DESCRIPTION
## Description
Added check for empty `channels_idx`

## Issue Number
- Closes #2131

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
