### PR TITLE
optimize positional encoding

### DIFF
--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -117,7 +117,10 @@ class EmbeddingEngine(torch.nn.Module):
 
         # per cell indices into positional encoding
         tok_counts = batch.tokens_lens.permute([2, 0, 1, 3]).sum(0).flatten()
-        pe_idxs = torch.cat([torch.arange(c) for c in tok_counts])
+        max_len = tok_counts.max()                                                    # 1 sync, unavoidable
+        rows = torch.arange(max_len, device=tok_counts.device)                        # [max_len]
+        mask = rows.unsqueeze(0) < tok_counts.unsqueeze(1)                            # [N, max_len]
+        pe_idxs = rows.unsqueeze(0).expand(tok_counts.shape[0], -1)[mask]            # flat result
 
         # actual scatter operation
         tokens_all.scatter_(0, scatter_idxs, torch.cat(x_embeds) + pe_embed[pe_idxs])

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -117,11 +117,10 @@ class EmbeddingEngine(torch.nn.Module):
 
         # per cell indices into positional encoding
         tok_counts = batch.tokens_lens.permute([2, 0, 1, 3]).sum(0).flatten()
-        max_len = tok_counts.max()                                                    # 1 sync, unavoidable
-        rows = torch.arange(max_len, device=tok_counts.device)                        # [max_len]
-        mask = rows.unsqueeze(0) < tok_counts.unsqueeze(1)                            # [N, max_len]
-        pe_idxs = rows.unsqueeze(0).expand(tok_counts.shape[0], -1)[mask]            # flat result
-
+        rows = torch.arange( tok_counts.max(), device=tok_counts.device).unsqueeze(0)
+        rows = rows.expand(tok_counts.shape[0], -1)
+        pe_idxs = rows[rows < tok_counts.unsqueeze(1)]
+        
         # actual scatter operation
         tokens_all.scatter_(0, scatter_idxs, torch.cat(x_embeds) + pe_embed[pe_idxs])
 


### PR DESCRIPTION
## Description
This PR introduces a minor change in the code, resulting in a significant performance gain.
<!--


Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number
Fixes #2173

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel

## Performance comparison with develop branch

- Run `../WeatherGenerator-private/hpc/launch-slurm.py --time 60`

| run_id   | HPC      | PR                                             | Ingested Samples per GPU                                                                                                            |
| -------- | -------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
| mf3vpsec  | JWB   |  develop (1 node)   | 1044
| ve8c4vuy | JWB   |  javad/dev/optimize_encoder (1 nodes)  | 1294

<img width="1319" height="757" alt="Screenshot from 2026-04-05 19-38-29" src="https://github.com/user-attachments/assets/37cf8eb3-9ce0-4bf3-bc3d-6440382163f5" />

- Run `../WeatherGenerator-private/hpc/launch-slurm.py --time 60 --base-config ./config/config_forecasting.yml`

| run_id   | HPC      | PR                                             | Ingested Samples per GPU                                                                                                            |
| -------- | -------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
| v3ngv74i | JWB   |  develop (1 node)   | 670
| yuvx9hwm | JWB   |  javad/dev/optimize_encoder (1 nodes)  | 760

<img width="1323" height="787" alt="Screenshot from 2026-04-05 19-53-39" src="https://github.com/user-attachments/assets/2c1599a7-f63d-4145-bdde-d5277f9effc0" />


- Run `../WeatherGenerator-private/hpc/launch-slurm.py --time 60 --base-config ./config/config_jepa.yml`

| run_id   | HPC      | PR                                             | Ingested Samples per GPU                                                                                                            |
| -------- | -------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
| d4vw793o | JWB   |  develop (1 node)   | 2308
| ob69315g | JWB   |  javad/dev/optimize_encoder (1 nodes)  | 4486

Performance improvements ranging from **14%** to **94%**, depending on the configuration, are expected.