### PR TITLE
Adding export into the integration test

### DIFF
--- a/integration_tests/export_test.py
+++ b/integration_tests/export_test.py
@@ -1,0 +1,123 @@
+"""
+Small test for the Weather Generator.
+This test must run on a GPU machine.
+It performs a training and inference of the Weather Generator model.
+
+Command:
+uv run pytest  ./integration_tests/small1.py
+"""
+
+import json
+import logging
+import os
+import glob
+import shutil
+from pathlib import Path
+import xarray as xr
+import numpy as np
+
+import omegaconf
+import pytest
+
+from weathergen.evaluate.run_evaluation import evaluate_from_config
+from weathergen.evaluate.export.export_inference import export_from_args
+from weathergen.run_train import main
+from weathergen.utils.metrics import get_train_metrics_path
+from weathergen.common.config import get_model_results
+from weathergen.common.io import zarrio_reader
+
+
+
+logger = logging.getLogger(__name__)
+
+# Read from git the current commit hash and take the first 5 characters:
+try:
+    from git import Repo
+
+    repo = Repo(search_parent_directories=False)
+    commit_hash = repo.head.object.hexsha[:5]
+    logger.info(f"Current commit hash: {commit_hash}")
+except Exception as e:
+    commit_hash = "unknown"
+    logger.warning(f"Could not get commit hash: {e}")
+
+WEATHERGEN_HOME = Path(__file__).parent.parent
+
+
+@pytest.mark.parametrize("test_run_id", ["test_small1_" + commit_hash])
+def test_export(test_run_id):
+    logger.info(f"test_export with run_id {test_run_id} {WEATHERGEN_HOME}")
+    if not find_inference(test_run_id):
+        logger.info(f"{test_run_id} not found, run train with run_id {test_run_id} {WEATHERGEN_HOME}")
+        main(
+            [
+                "train",
+                f"--base-config={WEATHERGEN_HOME}/integration_tests/small1.yml",
+                "--run-id",
+                test_run_id,
+            ]
+        )
+        infer(test_run_id)
+    export_inference(test_run_id)
+    check_export(test_run_id)
+    logger.info("end test_train")
+
+
+def infer(run_id):
+    logger.info("run inference")
+    main(
+        [
+            "inference",
+            "--mini-epoch",
+            "0",
+            "--from-run-id",
+            run_id,
+            "--run-id",
+            run_id,
+            "--config",
+            f"{WEATHERGEN_HOME}/integration_tests/small1.yml",
+        ]
+    )
+
+def find_inference(run_id):
+    try:
+        return get_model_results(run_id, mini_epoch=0, rank=0)
+    except FileNotFoundError as e:
+        return False
+
+
+def export_inference(run_id):
+    logger.info("export to netcdf")
+    export_from_args(
+        ["--run-id", run_id,
+         "--stream", "ERA5",
+         "--output-dir", f"{WEATHERGEN_HOME}/results/{run_id}",
+         "--format", "netcdf",
+         "--samples", "0", "1",
+         "--fsteps", "1" ,"2"]
+    )
+
+def check_export(run_id):
+    fname_zarr = get_model_results(run_id, mini_epoch = 0, rank = 0)
+    nc_folder = Path(WEATHERGEN_HOME / "results" / run_id)
+
+    with zarrio_reader(fname_zarr) as zio:
+        for sample in [0,1]:
+            #find timestamp for sample
+            out = zio.get_data(sample, "ERA5", 1)
+            zarr_ds = out.prediction.as_xarray()
+            min_timestamp = np.min(zarr_ds["valid_time"]) - np.timedelta64(6, "h")
+            frt = np.datetime_as_string(min_timestamp, unit="h")
+
+            #open correct nc file
+            nc_path = glob.glob(f"{str(nc_folder)}/prediction_{frt}*.nc")
+            nc_ds = xr.open_dataset(nc_path[0])
+
+            for fstep in [1,2]:
+                # extract and compare per sample/fstep
+                out = zio.get_data(sample, "ERA5", fstep)
+                zarr_ds = out.prediction.as_xarray()
+                zarr_values = zarr_ds.sel({"channel" :"t_850"}).values
+                nc_values = nc_ds.sel({"forecast_period" : np.timedelta64(6, "h") * fstep,"pressure": 850})["t"].values
+                
+                assert np.array_equal(np.squeeze(zarr_values),np.squeeze(nc_values)), "exporting data failed"

--- a/integration_tests/export_test.py
+++ b/integration_tests/export_test.py
@@ -1,10 +1,10 @@
 """
 Small test for the Weather Generator.
 This test must run on a GPU machine.
-It performs a training and inference of the Weather Generator model.
+It performs (training, inference - if necessary) and export of the Weather Generator model.
 
 Command:
-uv run pytest  ./integration_tests/small1.py
+uv run pytest  ./integration_tests/export_test.py
 """
 
 import json

--- a/integration_tests/small1_test.py
+++ b/integration_tests/small1_test.py
@@ -10,23 +10,15 @@ uv run pytest  ./integration_tests/small1.py
 import json
 import logging
 import os
-import glob
 import shutil
 from pathlib import Path
-import xarray as xr
-import numpy as np
 
 import omegaconf
 import pytest
 
 from weathergen.evaluate.run_evaluation import evaluate_from_config
-from weathergen.evaluate.export.export_inference import export_from_args
 from weathergen.run_train import main
 from weathergen.utils.metrics import get_train_metrics_path
-from weathergen.common.config import get_model_results
-from weathergen.common.io import zarrio_reader
-
-
 
 logger = logging.getLogger(__name__)
 
@@ -71,8 +63,6 @@ def test_train(setup, test_run_id):
     assert_missing_metrics_file(test_run_id)
     assert_train_loss_below_threshold(test_run_id)
     assert_val_loss_below_threshold(test_run_id)
-    export_inference(test_run_id)
-    check_export(test_run_id)
     logger.info("end test_train")
 
 
@@ -192,40 +182,3 @@ def assert_val_loss_below_threshold(run_id):
     # Check that the loss does not explode in a single mini_epoch
     # This is meant to be a quick test, not a convergence test
     assert loss_metric < 0.2, f"'{loss_avg_name}' is {loss_metric}, expected to be below 0.2"
-
-
-def export_inference(run_id):
-    logger.info("export to netcdf")
-    export_from_args(
-        ["--run-id", run_id,
-         "--stream", "ERA5",
-         "--output-dir", f"{WEATHERGEN_HOME}/results/{run_id}",
-         "--format", "netcdf",
-         "--samples", "0", "1",
-         "--fsteps", "1" ,"2"]
-    )
-
-def check_export(run_id):
-    fname_zarr = get_model_results(run_id, mini_epoch = 0, rank = 0)
-    nc_folder = Path(WEATHERGEN_HOME / "results" / run_id)
-
-    with zarrio_reader(fname_zarr) as zio:
-        for sample in [0,1]:
-            #find timestamp for sample
-            out = zio.get_data(sample, "ERA5", 1)
-            zarr_ds = out.prediction.as_xarray()
-            min_timestamp = np.min(zarr_ds["valid_time"]) - np.timedelta64(6, "h")
-            frt = np.datetime_as_string(min_timestamp, unit="h")
-
-            #open correct nc file
-            nc_path = glob.glob(f"{str(nc_folder)}/prediction_{frt}*.nc")
-            nc_ds = xr.open_dataset(nc_path[0])
-
-            for fstep in [1,2]:
-                # extract and compare per sample/fstep
-                out = zio.get_data(sample, "ERA5", fstep)
-                zarr_ds = out.prediction.as_xarray()
-                zarr_values = zarr_ds.sel({"channel" :"t_850"}).values
-                nc_values = nc_ds.sel({"forecast_period" : np.timedelta64(6, "h") * fstep,"pressure": 850})["t"].values
-                
-                assert np.array_equal(np.squeeze(zarr_values),np.squeeze(nc_values)), "exporting data failed"

--- a/integration_tests/small1_test.py
+++ b/integration_tests/small1_test.py
@@ -10,15 +10,23 @@ uv run pytest  ./integration_tests/small1.py
 import json
 import logging
 import os
+import glob
 import shutil
 from pathlib import Path
+import xarray as xr
+import numpy as np
 
 import omegaconf
 import pytest
 
 from weathergen.evaluate.run_evaluation import evaluate_from_config
+from weathergen.evaluate.export.export_inference import export_from_args
 from weathergen.run_train import main
 from weathergen.utils.metrics import get_train_metrics_path
+from weathergen.common.config import get_model_results
+from weathergen.common.io import zarrio_reader
+
+
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +71,8 @@ def test_train(setup, test_run_id):
     assert_missing_metrics_file(test_run_id)
     assert_train_loss_below_threshold(test_run_id)
     assert_val_loss_below_threshold(test_run_id)
+    export_inference(test_run_id)
+    check_export(test_run_id)
     logger.info("end test_train")
 
 
@@ -182,3 +192,40 @@ def assert_val_loss_below_threshold(run_id):
     # Check that the loss does not explode in a single mini_epoch
     # This is meant to be a quick test, not a convergence test
     assert loss_metric < 0.2, f"'{loss_avg_name}' is {loss_metric}, expected to be below 0.2"
+
+
+def export_inference(run_id):
+    logger.info("export to netcdf")
+    export_from_args(
+        ["--run-id", run_id,
+         "--stream", "ERA5",
+         "--output-dir", f"{WEATHERGEN_HOME}/results/{run_id}",
+         "--format", "netcdf",
+         "--samples", "0", "1",
+         "--fsteps", "1" ,"2"]
+    )
+
+def check_export(run_id):
+    fname_zarr = get_model_results(run_id, mini_epoch = 0, rank = 0)
+    nc_folder = Path(WEATHERGEN_HOME / "results" / run_id)
+
+    with zarrio_reader(fname_zarr) as zio:
+        for sample in [0,1]:
+            #find timestamp for sample
+            out = zio.get_data(sample, "ERA5", 1)
+            zarr_ds = out.prediction.as_xarray()
+            min_timestamp = np.min(zarr_ds["valid_time"]) - np.timedelta64(6, "h")
+            frt = np.datetime_as_string(min_timestamp, unit="h")
+
+            #open correct nc file
+            nc_path = glob.glob(f"{str(nc_folder)}/prediction_{frt}*.nc")
+            nc_ds = xr.open_dataset(nc_path[0])
+
+            for fstep in [1,2]:
+                # extract and compare per sample/fstep
+                out = zio.get_data(sample, "ERA5", fstep)
+                zarr_ds = out.prediction.as_xarray()
+                zarr_values = zarr_ds.sel({"channel" :"t_850"}).values
+                nc_values = nc_ds.sel({"forecast_period" : np.timedelta64(6, "h") * fstep,"pressure": 850})["t"].values
+                
+                assert np.array_equal(np.squeeze(zarr_values),np.squeeze(nc_values)), "exporting data failed"

--- a/packages/evaluate/src/weathergen/evaluate/export/export_inference.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/export_inference.py
@@ -275,8 +275,8 @@ def export_from_args(args: list) -> None:
     for dtype in args.type:
         _logger.info(
             f"Starting processing {dtype} for run ID {kwargs['run_id']}. "
-            f"Detected {kwargs['samples']} samples and {kwargs['fsteps']} forecast steps."
-        )
+            f"Processing {kwargs["samples"] if kwargs["samples"] is not None else "all"} samples and {kwargs["fsteps"] if kwargs["fsteps"] is not None else "all"} forecast steps.")
+        
 
         export_model_outputs(dtype, config, **kwargs)
 

--- a/packages/evaluate/src/weathergen/evaluate/export/export_inference.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/export_inference.py
@@ -275,8 +275,9 @@ def export_from_args(args: list) -> None:
     for dtype in args.type:
         _logger.info(
             f"Starting processing {dtype} for run ID {kwargs['run_id']}. "
-            f"Processing {kwargs["samples"] if kwargs["samples"] is not None else "all"} samples and {kwargs["fsteps"] if kwargs["fsteps"] is not None else "all"} forecast steps.")
-        
+            f"Processing {kwargs['samples'] if kwargs['samples'] is not None else 'all'} samples \
+and {kwargs['fsteps'] if kwargs['fsteps'] is not None else 'all'} forecast steps."
+        )
 
         export_model_outputs(dtype, config, **kwargs)
 

--- a/packages/evaluate/src/weathergen/evaluate/export/parsers/netcdf_parser.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/parsers/netcdf_parser.py
@@ -308,8 +308,9 @@ class NetcdfParser(CfParser):
             ds["forecast_reference_time"].encoding.update(time_encoding)
 
         if "forecast_period" in ds.coords:
-            ds["forecast_period"].attrs.update({"coordinates": "forecast_reference_time",
-                                                "dtype": "timedelta64[ns]"})
+            ds["forecast_period"].attrs.update(
+                {"coordinates": "forecast_reference_time", "dtype": "timedelta64[ns]"}
+            )
 
         return ds
 

--- a/packages/evaluate/src/weathergen/evaluate/export/parsers/netcdf_parser.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/parsers/netcdf_parser.py
@@ -308,7 +308,8 @@ class NetcdfParser(CfParser):
             ds["forecast_reference_time"].encoding.update(time_encoding)
 
         if "forecast_period" in ds.coords:
-            ds["forecast_period"].encoding.update({"coordinates": "forecast_reference_time"})
+            ds["forecast_period"].attrs.update({"coordinates": "forecast_reference_time",
+                                                "dtype": "timedelta64[ns]"})
 
         return ds
 

--- a/scripts/actions.sh
+++ b/scripts/actions.sh
@@ -106,6 +106,12 @@ case "$1" in
       uv sync --offline --all-packages --extra gpu
       uv run --offline pytest ./integration_tests/small_multi_stream_test.py --verbose -s
     );;
+    integration-test-export)
+    (
+      cd "$SCRIPT_DIR" || exit 1
+      uv sync --offline --all-packages --extra gpu
+      uv run --offline pytest ./integration_tests/export_test.py --verbose -s
+    );;
     integration-test-all)
     (
       cd "$SCRIPT_DIR" || exit 1


### PR DESCRIPTION
## Description

Adds expoting to netcdf to the end of the integration test so breaking changes can be flagged before they are merged
- if ran after another integration test it will find the inference zip and test export to netcdf
- if ran as a standalone test it will train and run inference and then export to netcdf
- runs export for 2 samples and 2 steps using t_850
- checks the array taken directly from zarr and the array found in the netcdf

- further tests for quaver and verif parser can be added in the future

- run on interactive gpu either with `uv run pytest  ./integration_tests/export_test.py` or `./scripts/actions.sh integration-test-export`

## Issue Number

Closes #2063 

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
