### PR TITLE
fix fsteps selection in export

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/export/export_core.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/export_core.py
@@ -46,6 +46,9 @@ def get_data_worker(args: tuple) -> tuple[int, int, xr.DataArray]:
     group_path = f"{sample}/{stream}/{fstep}/{dtype}"
     ds_group = _CACHED_ZIO.data_root.get(group_path)
 
+    if ds_group is None:
+        raise FileNotFoundError(f"Zarr group '{group_path}' not found in {_CACHED_FNAME_ZARR}")
+
     # Read raw arrays as numpy — no dask, no chunking overhead.
     data_arr = np.asarray(ds_group["data"])  # (npoints, nchannels) or (npoints, nchannels, nens)
     coords_arr = np.asarray(ds_group["coords"])  # (npoints, 2)
@@ -92,12 +95,33 @@ def get_fsteps(fsteps, fname_zarr: str):
             Path to the Zarr store.
     Returns
     -------
-        list[str]
+        list[int]
             List of forecast steps to be used for data retrieval.
     """
     with zarrio_reader(fname_zarr) as zio:
         zio_forecast_steps = sorted([int(step) for step in zio.forecast_steps])
-    return zio_forecast_steps if fsteps is None else sorted([int(fstep) for fstep in fsteps])
+
+    if fsteps is None:
+        return zio_forecast_steps
+
+    requested = sorted([int(fstep) for fstep in fsteps])
+    available_set = set(zio_forecast_steps)
+    valid = [f for f in requested if f in available_set]
+    missing = [f for f in requested if f not in available_set]
+
+    if missing:
+        _logger.warning(
+            f"Requested forecast steps {missing} are not available in the zarr store "
+            f"(available: {zio_forecast_steps}). They will be skipped."
+        )
+
+    if not valid:
+        raise ValueError(
+            f"None of the requested forecast steps {requested} exist in the zarr store. "
+            f"Available forecast steps: {zio_forecast_steps}"
+        )
+
+    return valid
 
 
 def get_samples(samples, fname_zarr: str):
@@ -112,17 +136,33 @@ def get_samples(samples, fname_zarr: str):
             Path to the Zarr store.
     Returns
     -------
-        list[str]
+        list[int]
             List of samples to be used for data retrieval.
     """
     with zarrio_reader(fname_zarr) as zio:
         zio_samples = sorted([int(sample) for sample in zio.samples])
-    samples = (
-        zio_samples
-        if samples is None
-        else sorted([int(sample) for sample in samples if sample in samples])
-    )
-    return samples
+
+    if samples is None:
+        return zio_samples
+
+    requested = sorted([int(sample) for sample in samples])
+    available_set = set(zio_samples)
+    valid = [s for s in requested if s in available_set]
+    missing = [s for s in requested if s not in available_set]
+
+    if missing:
+        _logger.warning(
+            f"Requested samples {missing} are not available in the zarr store "
+            f"(available range: {zio_samples[0]}–{zio_samples[-1]}). They will be skipped."
+        )
+
+    if not valid:
+        raise ValueError(
+            f"None of the requested samples {requested} exist in the zarr store. "
+            f"Available samples: {zio_samples}"
+        )
+
+    return valid
 
 
 def get_channels(channels, stream: str, fname_zarr: str) -> list[str]:


### PR DESCRIPTION
## Description

Fix the selection of fsteps and samples when a list is added to the cli. 

The original code blindly passed through requested fsteps without checking if they exist in the zarr. Now it:

- Intersects requested fsteps with available ones
- Logs a warning listing the skipped fsteps 
- Raises ValueError if none of the requested fsteps exist.

Same for samples. 

## Issue Number

closes https://github.com/ecmwf/WeatherGenerator/issues/2182

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
