### PR TITLE
Allow the saving and loading of optimiser state

### DIFF
--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -19,7 +19,7 @@ import tqdm
 from omegaconf import OmegaConf
 
 # FSDP2
-from torch.distributed.tensor import DTensor
+from torch.distributed.tensor import DTensor, distribute_tensor
 
 import weathergen.common.config as config
 from weathergen.common.config import Config
@@ -338,6 +338,10 @@ class Trainer(TrainerBase):
             lr_steps,
             self.training_cfg.learning_rate_scheduling,
         )
+
+        # Restore optimizer momentum buffers when continuing from a checkpoint
+        if run_id_contd is not None:
+            self._load_optimizer_state(run_id_contd, mini_epoch_contd)
 
         if self.cf.general.istep > 0 and is_root():
             str = f"Continuing run with learning rate: {self.lr_scheduler.get_lr()}"
@@ -681,7 +685,9 @@ class Trainer(TrainerBase):
         # Saving at mini_epoch == max_mini_epoch means that we are saving the latest checkpoint.
         max_mini_epoch = self.training_cfg.num_mini_epochs
         assert mini_epoch <= max_mini_epoch, (mini_epoch, max_mini_epoch)
+        # Gather full state dicts (collective ops for FSDP — all ranks must participate)
         model_state_dict = self._get_full_model_state_dict()
+        optim_state_dict = self._get_full_optimizer_state_dict()
 
         if is_root():
             filename = "".join(
@@ -699,11 +705,70 @@ class Trainer(TrainerBase):
             torch.save(model_state_dict, file_tmp)
             # move file (which is changing the link in the file system and very fast)
             file_tmp.replace(file_out)
-            if is_root():
-                logger.info(f"Saved model to {file_out}")
+            logger.info(f"Saved model to {file_out}")
+
+            # save optimizer state keyed by parameter name for robust resumption
+            param_names = [n for n, _ in self.model.named_parameters()]
+            named_optim_state = {}
+            for idx, pname in enumerate(param_names):
+                if idx in optim_state_dict["state"]:
+                    named_optim_state[pname] = optim_state_dict["state"][idx]
+            if named_optim_state:
+                optim_out = base_path / (filename + ".optim")
+                optim_tmp = base_path / (filename + "_tmp.optim")
+                torch.save(named_optim_state, optim_tmp)
+                optim_tmp.replace(optim_out)
+                logger.info(f"Saved optimizer state to {optim_out}")
 
             # save config
             config.save(self.cf, mini_epoch)
+
+    def _load_optimizer_state(self, run_id: str, mini_epoch):
+        """Load optimizer state from checkpoint if available.
+
+        Restores AdamW momentum buffers (exp_avg, exp_avg_sq) so that training
+        resumes smoothly when chaining jobs via train_continue.
+        """
+        path_run = config.get_path_model(run_id=run_id)
+        mini_epoch_id = (
+            f"chkpt{mini_epoch:05d}" if mini_epoch not in (-1, None) else "latest"
+        )
+        optim_file = path_run / f"{run_id}_{mini_epoch_id}.optim"
+
+        if not optim_file.exists():
+            if is_root():
+                logger.info(f"No optimizer state found at {optim_file}, starting fresh.")
+            return
+
+        if is_root():
+            logger.info(f"Loading optimizer state from {optim_file}")
+
+        named_state = torch.load(
+            optim_file, map_location=torch.device("cpu"), mmap=True, weights_only=True
+        )
+        is_model_sharded = self.cf.with_ddp and self.cf.with_fsdp
+
+        loaded = 0
+        for name, param in self.model.named_parameters():
+            if name not in named_state:
+                continue
+            entry = named_state[name]
+            new_entry = {}
+            for key, val in entry.items():
+                if isinstance(val, torch.Tensor) and val.dim() > 0 and is_model_sharded:
+                    new_entry[key] = distribute_tensor(
+                        val, param.device_mesh, param.placements
+                    )
+                elif isinstance(val, torch.Tensor):
+                    new_entry[key] = val.to(device=param.device)
+                else:
+                    new_entry[key] = val
+            self.optimizer.state[param] = new_entry
+            loaded += 1
+
+        if is_root():
+            total = sum(1 for _ in self.model.parameters())
+            logger.info(f"Loaded optimizer state for {loaded}/{total} parameters.")
 
     def _log(self, stage: Stage):
         """


### PR DESCRIPTION
## Description

Save and load the optimiser state. This PR should really be against develop, but feel free to review it here and then I will open the same changes against develop. This appeared to make a difference for JEPA pre-training. 

Possibly this should also be behind a config flag for the sake of storage.

## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
