### PR TITLE
Changes for latent forecast JEPA

### DIFF
--- a/config/config_jepa_latent_forecast.yml
+++ b/config/config_jepa_latent_forecast.yml
@@ -1,0 +1,350 @@
+# (C) Copyright 2025 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+# Temporal JEPA config: student sees time t, teacher (EMA) sees time t+1.
+# The predictor head learns to forecast in latent space.
+# No spatial masking — prediction task is purely temporal.
+
+embed_orientation: "channels"
+embed_unembed_mode: "block"
+embed_dropout_rate: 0.1
+
+ae_local_dim_embed: 1024
+ae_local_num_blocks: 4
+ae_local_num_heads: 16
+ae_local_dropout_rate: 0.1
+ae_local_with_qk_lnorm: True
+
+ae_local_num_queries: 1
+ae_local_queries_per_cell: False
+ae_adapter_num_heads: 16
+ae_adapter_embed: 128
+ae_adapter_with_qk_lnorm: True
+ae_adapter_with_residual: True
+ae_adapter_dropout_rate: 0.1
+
+ae_global_dim_embed: 2048
+ae_global_num_blocks: 2
+ae_global_num_heads: 32
+ae_global_dropout_rate: 0.1
+ae_global_with_qk_lnorm: True
+# TODO: switching to < 1 triggers triton-related issues.
+# See https://github.com/ecmwf/WeatherGenerator/issues/1050
+ae_global_att_dense_rate: 1.0
+ae_global_block_factor: 64
+ae_global_mlp_hidden_factor: 2
+ae_global_trailing_layer_norm: False
+
+ae_aggregation_num_blocks: 8
+ae_aggregation_num_heads: 32
+ae_aggregation_dropout_rate: 0.1
+ae_aggregation_with_qk_lnorm: True
+ae_aggregation_att_dense_rate: 1.0
+ae_aggregation_block_factor: 64
+ae_aggregation_mlp_hidden_factor: 2
+
+decoder_type: PerceiverIOCoordConditioning # CrossAttentionAdaNormConditioning
+pred_adapter_kv: False
+pred_self_attention: True
+pred_dyadic_dims: False
+pred_mlp_adaln: True
+num_class_tokens: 1
+num_register_tokens: 7
+
+# number of steps offset applied to first target window; if set to zero and forecast_steps=0 then
+# one is training an auto-encoder
+fe_num_blocks: 6
+fe_num_heads: 16
+fe_dropout_rate: 0.1
+fe_with_qk_lnorm: True
+fe_layer_norm_after_blocks: []  # Index starts at 0. Thus, [3] adds a LayerNorm after the fourth layer
+fe_impute_latent_noise_std: 0.0  # 1e-4
+# currently fixed to 1.0 (due to limitations with flex_attention and triton)
+forecast_att_dense_rate: 1.0
+with_step_conditioning: True # False
+
+healpix_level: 5
+# Use 2D RoPE instead of traditional global positional encoding
+# When True: uses 2D RoPE based on healpix cell coordinates (lat/lon)
+# When False: uses traditional pe_global positional encoding
+rope_2D: False
+
+with_mixed_precision: True
+with_flash_attention: True
+compile_model: False
+with_fsdp: False
+ddp_find_unused_parameters: False
+attention_dtype: bf16
+mixed_precision_dtype: bf16
+mlp_norm_eps: 1e-5
+norm_eps: 1e-4
+
+latent_noise_kl_weight: 0.0 # 1e-5
+latent_noise_gamma: 2.0
+latent_noise_saturate_encodings: 5 
+latent_noise_use_additive_noise: False
+latent_noise_deterministic_latents: True
+
+freeze_modules: ""
+
+norm_type: "LayerNorm"
+# type of zarr_store
+zarr_store: "zip" # "zarr" for LocalStore, "zip" for ZipStore
+
+#####################################
+
+streams_directory: "./config/streams/era5_1deg/"
+# streams_directory: "./config/streams/era5_nppatms_synop/"
+streams: ???
+
+general:
+
+  # mutable parameters
+  istep: 0
+  rank: ???
+  world_size: ???
+
+  # local_rank, 
+  # with_ddp,
+  # data_path_*, 
+  # model_path, 
+  # run_path, 
+  # path_shared_
+
+  multiprocessing_method: "fork"
+
+  desc: ""
+  run_id: ???
+  run_history: []
+
+# logging frequency in the training loop (in number of batches)
+train_logging:
+  terminal: 10
+  metrics: 20
+  checkpoint: 250
+  log_grad_norms: False
+
+  # Collapse monitoring for SSL training (JEPA/DINO/iBOT)
+  # Detects representation collapse via various metrics
+  # For forecasting, supports sequences of latents with per-step and aggregate metrics
+  collapse_monitoring:
+    enabled: true
+    compute_frequency: 100  # batches between metric computations
+    log_frequency: 100      # batches between metric logging
+    metrics:
+      effective_rank:
+        enabled: true
+        tensor_source: "both"  # "student", "teacher", or "both"
+        sample_size: 2048      # max samples for SVD (0 = no sampling)
+        # For forecasting sequences: "all" (per-step + aggregates),
+        # "aggregate_only" (mean/min/max/degradation), "per_step_only"
+        forecast_aggregation: "all"
+      singular_values:
+        enabled: true
+        tensor_source: "both"
+        sample_size: 2048
+        forecast_aggregation: "all"
+      dimension_variance:
+        enabled: true
+        tensor_source: "both"  # cheap to compute, good early indicator
+        forecast_aggregation: "all"
+      prototype_entropy:
+        enabled: true  # only applies to DINO
+      ema_beta:
+        enabled: true
+
+# parameters for data loading
+data_loading :
+
+  num_workers: 12
+  rng_seed: ???
+
+
+# config for training
+training_config:
+
+  # training_mode: "masking", "student_teacher", "latent_loss"
+  training_mode: ["student_teacher"]
+
+  # Collapse monitoring for SSL training (JEPA/DINO/iBOT)
+  # Detects representation collapse via various metrics
+  # For forecasting, supports sequences of latents with per-step and aggregate metrics
+  collapse_monitoring:
+    enabled: true
+    compute_frequency: 100  # batches between metric computations
+    log_frequency: 100      # batches between metric logging
+    metrics:
+      effective_rank:
+        enabled: true
+        tensor_source: "both"  # "student", "teacher", or "both"
+        sample_size: 2048      # max samples for SVD (0 = no sampling)
+        # For forecasting sequences: "all" (per-step + aggregates),
+        # "aggregate_only" (mean/min/max/degradation), "per_step_only"
+        forecast_aggregation: "all"
+      singular_values:
+        enabled: true
+        tensor_source: "both"
+        sample_size: 2048
+        forecast_aggregation: "all"
+      dimension_variance:
+        enabled: true
+        tensor_source: "both"  # cheap to compute, good early indicator
+        forecast_aggregation: "all"
+      prototype_entropy:
+        enabled: true  # only applies to DINO
+      ema_beta:
+        enabled: true
+
+  num_mini_epochs: 32
+  samples_per_mini_epoch: 4096
+  shuffle: True
+
+  start_date: 1979-01-01T00:00
+  end_date: 2022-12-31T00:00
+
+  time_window_step: 06:00:00
+  time_window_len: 06:00:00
+
+  # Number of time windows to shift the teacher's input relative to the student's.
+  # 0 = same time window (standard JEPA); 1 = teacher sees next 6h window, etc.
+  teacher_time_offset: 1
+
+  window_offset_prediction : 0
+  
+  learning_rate_scheduling :
+    lr_start: 1e-6
+    lr_max: 5e-5
+    lr_final_decay: 1e-6
+    lr_final: 0.0
+    num_steps_warmup: 512
+    num_steps_cooldown: 512
+    policy_warmup: "cosine"
+    policy_decay: "constant"
+    policy_cooldown: "linear"
+    parallel_scaling_policy: "sqrt"
+
+  optimizer:
+    grad_clip: 1.0
+    weight_decay: 0.1
+    adamw :
+      # parameters are scaled by number of DDP workers
+      beta1 : 0.975
+      beta2 : 0.9875
+      eps : 2e-08
+
+  losses : {
+    "student-teacher": {
+        enabled: True,
+        type: LossLatentSSLStudentTeacher,
+        weight: 1.0,
+        loss_fcts : {
+          "JEPA": {
+            'weight': 1, "loss_extra_args": {"temporal": true}, "out_dim": 2048, "head": mlp,
+            "num_layers": 2, "hidden_factor": 2,
+            target_source_correspondence: {0 : {0 : "independent"} },
+        },
+        },
+        target_and_aux_calc: { "EMATeacher" : 
+          { ema_ramp_up_ratio : null,
+            ema_halflife_in_thousands: 800000,
+            model_param_overrides : { 
+              training_config: { losses: { student-teacher:{ loss_fcts :{JEPA: {head: identity} }}}}
+            },
+          }
+        }
+      }
+  }
+  
+  # No spatial masking — all cells visible for both student and teacher.
+  # The prediction task is purely temporal (student at t, teacher at t+1).
+  model_input: {
+    "forecasting" : {
+      masking_strategy: "forecast",
+      num_samples: 1,
+      num_steps_input: 1,
+      masking_strategy_config : { 
+        diffusion_rn : True, 
+        rate : 0.0,
+        rate_sampling: False
+      },
+    },
+  }
+
+  target_input: {
+    "forecasting_target" : {
+      masking_strategy: "forecast",
+      num_samples: 1,
+      masking_strategy_config : { rate : 0.0, hl_mask: 0, rate_sampling: False },
+    },
+  }
+
+  forecast :
+    time_step: 00:00:00
+    num_steps: 0
+    policy: null
+
+
+# validation config; full validation config is merge of training and validation config
+validation_config: 
+
+  samples_per_mini_epoch: 256
+  shuffle: False
+
+  start_date: 2023-10-01T00:00
+  end_date: 2023-12-31T00:00
+  
+  # whether to track the exponential moving average of weights for validation
+  validate_with_ema: 
+    enabled : False
+    ema_ramp_up_ratio: 0.09
+    ema_halflife_in_thousands: 1e-3
+
+  # parameters for validation samples that are written to disk
+  output : {
+    # number of samples that are written
+    num_samples: 0,
+    # write samples in normalized model space
+    normalized_samples: False,
+    # output streams to write; default all
+    streams: null,
+  }
+
+  # run validation before training starts (mainly for model development)
+  validate_before_training: False
+  
+# test config; full test config is merge of validation and test config
+# test config is used by default when running inference
+
+# Tags for experiment tracking
+# These tags will be logged in MLFlow along with completed runs for train, eval, val
+# The tags are free-form, with the following rules:
+# - tags should be primitive types (strings, numbers, booleans). NO lists or dictionaries
+# - tags should not duplicate existing config entries.
+# - try to reuse existing tags where possible. MLFlow does not like having too many unique tags
+# - do not use long strings in values (less than 20 characters is a good rule of thumb, we may enforce this in the future)
+wgtags:
+  # The name of the organization of the person running the experiment.
+  # This may be autofilled in the future. Expected values are lowercase strings 
+  # e.g. "ecmwf", "cmcc", "metnor", "jsc", "escience"
+  org: null
+  # The Github issue corresponding to this run (number such as 1234)
+  # Github issues are the central point when running experiment and contain 
+  # links to hedgedocs, code branches, pull requests etc.
+  # It is recommended to associate a run with a Github issue.
+  issue: null
+  # The name of the experiment. This is a distinctive codename for the experiment campaign being run.
+  # This is expected to be the primary tag for comparing experiments in MLFlow, along with the
+  # issue number.
+  # Expected values are lowercase strings with no spaces, just underscores:
+  # Examples: "rollout_ablation_grid"  
+  exp: null
+  # *** Experiment-specific tags ***
+  # All extra tags (including lists, dictionaries, etc.) are treated 
+  # as strings by mlflow, so treat all extra tags as simple string key: value pairs.
+  grid: null

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -134,7 +134,21 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
 
         # teacher_time_offset: number of time windows to shift the teacher's input
         # relative to the student's. When > 0 the teacher sees a future time window.
-        self.teacher_time_offset = mode_cfg.get("teacher_time_offset", 0)
+        # Only active when student_teacher mode is used; ignored in masking mode to
+        # prevent stale offsets from JEPA pretraining leaking into forecasting
+        # finetuning/inference (where it would shift all target times by one window).
+        training_mode = mode_cfg.get("training_mode", [])
+        if "student_teacher" in training_mode:
+            self.teacher_time_offset = mode_cfg.get("teacher_time_offset", 0)
+        else:
+            configured_offset = mode_cfg.get("teacher_time_offset", 0)
+            if configured_offset != 0:
+                logger.warning(
+                    f"teacher_time_offset={configured_offset} is set but training_mode="
+                    f"{training_mode} does not include 'student_teacher'. "
+                    "Ignoring teacher_time_offset (setting to 0)."
+                )
+            self.teacher_time_offset = 0
 
         fsm = self.list_num_forecast_steps[0]
         forecast_len = (self.time_step * (fsm + 1)) // self.step_timedelta

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -132,9 +132,13 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
             self.forecast_policy = None
             self.time_step = np.timedelta64(0, "ms")
 
+        # teacher_time_offset: number of time windows to shift the teacher's input
+        # relative to the student's. When > 0 the teacher sees a future time window.
+        self.teacher_time_offset = mode_cfg.get("teacher_time_offset", 0)
+
         fsm = self.list_num_forecast_steps[0]
         forecast_len = (self.time_step * (fsm + 1)) // self.step_timedelta
-        perms_len = perms_len - (forecast_len + self.output_offset)
+        perms_len = perms_len - (forecast_len + self.output_offset + self.teacher_time_offset)
 
         self.repeat_data = cf.data_loading.get("repeat_data_in_mini_epoch", False)
 
@@ -664,10 +668,30 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                 idx, num_forecast_steps, i_max, stream_ds
             )
 
+            # When teacher_time_offset > 0, load a separate set of data windows
+            # shifted forward in time for the teacher (target) samples.
+            if self.teacher_time_offset > 0:
+                (input_data_target, output_data_target) = self._get_data_windows(
+                    idx + self.teacher_time_offset, num_forecast_steps, i_max, stream_ds
+                )
+            else:
+                input_data_target = input_data
+                output_data_target = output_data
+
             # tokenize windows
             # *_tokens = [ (cells_idx, cells_idx_lens), ... ] with length = #time_steps
             input_tokens = self.tokenizer.get_tokens_windows(stream_info, input_data, True)
             output_tokens = self.tokenizer.get_tokens_windows(stream_info, output_data, False)
+            if self.teacher_time_offset > 0:
+                input_tokens_target = self.tokenizer.get_tokens_windows(
+                    stream_info, input_data_target, True
+                )
+                output_tokens_target = self.tokenizer.get_tokens_windows(
+                    stream_info, output_data_target, False
+                )
+            else:
+                input_tokens_target = input_tokens
+                output_tokens_target = output_tokens
 
             for sidx, source_mask in enumerate(source_masks.masks):
                 # Map each source to its target
@@ -692,19 +716,23 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
             for tidx, target_mask in enumerate(target_masks.masks):
                 # depending on the mode, the the streamdata obj to have the target mask applied to
                 # the inputs. Hence the target mask is also the source mask here.
+                # Use time-offset data for teacher when teacher_time_offset > 0.
+                target_idx = idx + self.teacher_time_offset
                 sdata = self._build_stream_data(
                     target_select,
-                    idx,
+                    target_idx,
                     num_forecast_steps,
                     stream_info,
                     target_masks.metadata[tidx].params.get("num_steps_input", 1),
-                    input_data,
-                    output_data,
-                    input_tokens,
-                    output_tokens,
+                    input_data_target,
+                    output_data_target,
+                    input_tokens_target,
+                    output_tokens_target,
                     output_mask=target_mask,
                     input_mask=target_mask,
                 )
+
+
                 target_metadata = target_masks.metadata[tidx]
                 # also want to add the mask to the metadata
                 target_metadata.mask = target_mask

--- a/src/weathergen/train/loss_modules/loss_module_ssl.py
+++ b/src/weathergen/train/loss_modules/loss_module_ssl.py
@@ -219,20 +219,30 @@ class LossLatentSSLStudentTeacher(LossModuleBase):
             )
 
 
-def jepa_loss(student_patches_masked, student_masks, teacher_patches_masked, teacher_masks):
+def jepa_loss(
+    student_patches_masked, student_masks, teacher_patches_masked, teacher_masks, temporal=False
+):
     # TODO remove as we deal with batch dimension
     assert teacher_masks.shape[0] == 1 or teacher_masks.shape[0] == student_masks.shape[0]
     student_masks = student_masks.squeeze(dim=1)
     teacher_masks = teacher_masks.squeeze(dim=1)
-    masks_weight = (
-        (1 / student_masks.sum(-1).clamp(min=1.0))
-        .unsqueeze(-1)
-        .expand_as(student_masks)  # [student_masks_flat]
-    )
 
-    mask = torch.logical_and(teacher_masks, torch.logical_not(student_masks))
+    if temporal:
+        # Temporal JEPA: predict teacher's representation at ALL teacher-visible cells
+        # (no spatial masking exclusion since the prediction task is across time, not space)
+        mask = teacher_masks
+    else:
+        # Standard JEPA: predict only at cells the teacher sees but the student doesn't
+        mask = torch.logical_and(teacher_masks, torch.logical_not(student_masks))
+
     if mask.sum() == 0:
-        logger.warning("jepa_loss mask is all true, likely incorrect masking config.")
+        logger.warning("jepa_loss mask is all zeros, likely incorrect masking config.")
+
+    masks_weight = (
+        (1 / mask.sum(-1).clamp(min=1.0))
+        .unsqueeze(-1)
+        .expand_as(mask)
+    )
 
     assert mask.shape[0] == student_patches_masked.shape[0], (
         "mask.shape[0], batch dimension, has to match batch dimension for student_patches_masked."


### PR DESCRIPTION
## Description

Changes needed to enable "latent forecast" JEPA, where student receives t and teacher receives t+1.

Two notes: 1. this could be done using VJEPA2.1's context loss rather than an explicit if temporal: setting of the mask. 2. there is a slightly unclean bit early in msds where we enable teacher_time_offset only when we have student-teacher mode, to avoid this offset leaking into later e.g. forecast finetuning. This could also be controlled by explicitly setting teacher_time_offset : 0 in the forecast finetune config, but I think it should be a code guard.

## Issue Number

Closes #2109 

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
