### PR TITLE
change source interval in the export package

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/export/export_core.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/export_core.py
@@ -380,7 +380,7 @@ def export_model_outputs(data_type: str, config: OmegaConf, **kwargs) -> None:
                 processed_samples = []
 
                 for sample, _fstep, data in pool.imap_unordered(
-                    get_data_worker, batch_tasks, chunksize=max(1, n_fsteps)
+                    get_data_worker, batch_tasks, chunksize=1
                 ):
                     sample_results[sample].append(data)
                     pbar.update(1)

--- a/packages/evaluate/src/weathergen/evaluate/export/export_core.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/export_core.py
@@ -54,12 +54,6 @@ def get_data_worker(args: tuple) -> tuple[int, int, xr.DataArray]:
     coords_arr = np.asarray(ds_group["coords"])  # (npoints, 2)
     times_arr = np.asarray(ds_group["times"]).astype("datetime64[ns]")  # (npoints,)
     channels = list(ds_group.attrs["channels"])
-    source_interval_start = np.asarray(ds_group.attrs["source_interval"]["start"]).astype(
-        "datetime64[ns]"
-    )
-    source_interval_end = np.asarray(ds_group.attrs["source_interval"]["end"]).astype(
-        "datetime64[ns]"
-    )
 
     # Build a lightweight xarray DataArray with the same structure
     # that process_sample / assign_coords expects:
@@ -81,8 +75,6 @@ def get_data_worker(args: tuple) -> tuple[int, int, xr.DataArray]:
             "valid_time": ("ipoint", times_arr),
             "lat": ("ipoint", coords_arr[:, 0]),
             "lon": ("ipoint", coords_arr[:, 1]),
-            "source_interval_start": source_interval_start,
-            "source_interval_end": source_interval_end,
         },
     )
 
@@ -229,51 +221,53 @@ def get_grid_type(data_type, stream: str, fname_zarr: str) -> str:
 
 
 # TODO: this will change after restructuring the lead time.
-def get_ref_times(fname_zarr, stream, samples, fstep_hours, n_processes) -> list[np.datetime64]:
+def get_source_info(fname_zarr, stream, samples) -> tuple[list[np.datetime64], list[np.datetime64]]:
     """
-    Retrieve reference times for the specified samples from the Zarr store.
+    Retrieve source interval boundaries from the source group at forecast step 0.
 
-    Reads only the lightweight 'times' array from the zarr hierarchy
-    instead of loading the full data arrays.
+    Values are derived from the actual ``times`` array of the **source**
+    group at forecast step 0:
+    - ``source_start = min(source_times)``
+    - ``source_end   = max(source_times)``
+
+    The ``source_end`` also serves as the reference (initialisation) time.
 
     Parameters
     ----------
-        fname_zarr : str
-            Path to the Zarr store.
-        stream : str
-            Stream name to retrieve data for (e.g., 'ERA5').
-        samples : list
-            List of samples to process.
-        fstep_hours : np.timedelta64
-            Time difference between forecast steps in hours.
-        n_processes : int
-            Number of parallel processes to use (unused, kept for API compat).
+    fname_zarr : str
+        Path to the Zarr store.
+    stream : str
+        Stream name to retrieve data for (e.g., 'ERA5').
+    samples : list
+        List of samples to process.
+
     Returns
     -------
-        list[np.datetime64]
-            List of reference times corresponding to the samples.
+    tuple[list, list]
+        ``(source_starts, source_ends)`` — one entry per sample,
+        all as ``datetime64[ns]``.
     """
-    _logger.info(f"Retrieving reference times for {len(samples)} samples...")
+    _logger.info(f"Retrieving source info for {len(samples)} samples...")
 
-    ref_times = []
+    source_starts = []
+    source_ends = []
     with zarrio_reader(fname_zarr) as zio:
-        first_fstep = sorted([int(step) for step in zio.forecast_steps])[0]
+        for sample in tqdm(samples, desc="Getting source info"):
+            group_path = f"{sample}/{stream}/0/source"
+            source_group = zio.data_root.get(group_path)
 
-        for sample in tqdm(samples, desc="Getting ref times"):
-            # Navigate directly to the target group and read only the 'times' array,
-            # avoiding the expensive full-data load via get_data() / as_xarray().
-            group_path = f"{sample}/{stream}/{first_fstep}/target"
-            target_group = zio.data_root.get(group_path)
-
-            if target_group is None:
+            if source_group is None:
                 raise FileNotFoundError(f"Zarr group '{group_path}' not found in {fname_zarr}")
 
-            times_arr = np.array(target_group["times"]).astype("datetime64[ns]")
-            valid_time = times_arr[0]
-            ref_time = valid_time - fstep_hours * first_fstep
-            ref_times.append(ref_time)
+            times_arr = np.asarray(source_group["times"]).astype("datetime64[ns]")
+            source_start = np.min(times_arr)
+            source_end = np.max(times_arr)
 
-    return ref_times
+            _logger.debug(f"Sample {sample}: source_interval=[{source_start} .. {source_end}]")
+            source_starts.append(source_start)
+            source_ends.append(source_end)
+
+    return source_starts, source_ends
 
 
 def get_streams(stream, fname_zarr):
@@ -310,7 +304,6 @@ def export_model_outputs(data_type: str, config: OmegaConf, **kwargs) -> None:
     n_processes = kwargs.n_processes
     epoch = kwargs.epoch
     rank = kwargs.rank
-    fstep_hours = np.timedelta64(kwargs.fstep_hours, "h")
 
     if data_type not in ["target", "prediction"]:
         raise ValueError(f"Invalid type: {data_type}. Must be 'target' or 'prediction'.")
@@ -322,7 +315,7 @@ def export_model_outputs(data_type: str, config: OmegaConf, **kwargs) -> None:
     for stream in streams:
         grid_type = get_grid_type(data_type, stream, fname_zarr)
         channels = get_channels(channels, stream, fname_zarr)
-        ref_times = get_ref_times(fname_zarr, stream, samples, fstep_hours, n_processes)
+        source_starts, source_ends = get_source_info(fname_zarr, stream, samples)
         kwargs["grid_type"] = grid_type
         kwargs["channels"] = channels
         kwargs["data_type"] = data_type
@@ -356,7 +349,8 @@ def export_model_outputs(data_type: str, config: OmegaConf, **kwargs) -> None:
                 batch_start = batch_idx * batch_size
                 batch_end = min(batch_start + batch_size, len(samples))
                 batch_samples = samples[batch_start:batch_end]
-                batch_ref_times = ref_times[batch_start:batch_end]
+                batch_source_starts = source_starts[batch_start:batch_end]
+                batch_source_ends = source_ends[batch_start:batch_end]
 
                 # Map sample -> index within this batch for ref_times lookup.
                 sample_to_batch_idx = {s: i for i, s in enumerate(batch_samples)}
@@ -394,9 +388,15 @@ def export_model_outputs(data_type: str, config: OmegaConf, **kwargs) -> None:
                     # Check if this sample is complete (all fsteps received).
                     if len(sample_results[sample]) == n_fsteps:
                         b_idx = sample_to_batch_idx[sample]
-                        ref_time = batch_ref_times[b_idx]
+                        source_start = batch_source_starts[b_idx]
+                        source_end = batch_source_ends[b_idx]
                         results_iter = iter(sample_results[sample])
-                        processed = parser.process_sample(results_iter, ref_time=ref_time)
+                        processed = parser.process_sample(
+                            results_iter,
+                            ref_time=source_end,
+                            source_interval_start=source_start,
+                            source_interval_end=source_end,
+                        )
                         processed_samples.append(processed)
 
                         # Free memory immediately.

--- a/packages/evaluate/src/weathergen/evaluate/export/parsers/netcdf_parser.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/parsers/netcdf_parser.py
@@ -55,8 +55,7 @@ class NetcdfParser(CfParser):
         self,
         fstep_iterator_results: iter,
         ref_time: np.datetime64,
-        source_interval_start: np.datetime64 = None,
-        source_interval_end: np.datetime64 = None,
+        **kwargs,
     ):
         """
         Process results from get_data_worker: reshape, concatenate, add metadata, and save.

--- a/packages/evaluate/src/weathergen/evaluate/export/parsers/netcdf_parser.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/parsers/netcdf_parser.py
@@ -55,6 +55,8 @@ class NetcdfParser(CfParser):
         self,
         fstep_iterator_results: iter,
         ref_time: np.datetime64,
+        source_interval_start: np.datetime64 = None,
+        source_interval_end: np.datetime64 = None,
     ):
         """
         Process results from get_data_worker: reshape, concatenate, add metadata, and save.

--- a/packages/evaluate/src/weathergen/evaluate/export/parsers/quaver_parser.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/parsers/quaver_parser.py
@@ -72,6 +72,8 @@ class QuaverParser(CfParser):
         self,
         fstep_iterator_results: iter,
         ref_time: np.datetime64,
+        source_interval_start: np.datetime64 = None,
+        source_interval_end: np.datetime64 = None,
     ):
         """
         Process results from get_data_worker: reshape, concatenate, add metadata, and save.
@@ -79,6 +81,8 @@ class QuaverParser(CfParser):
         ----------
             fstep_iterator_results : Iterator over results from get_data_worker.
             ref_time : Forecast reference time for the sample.
+            source_interval_start : Start of the source (conditioning) window.
+            source_interval_end : End of the source (conditioning) window.
         Returns
         -------
             None
@@ -90,39 +94,50 @@ class QuaverParser(CfParser):
             if not isinstance(result, xr.DataArray):
                 result = result.as_xarray().squeeze()
             result = result.sel(channel=self.channels)
-            da_fs = self.assign_coords(result)
 
-            step = np.unique(result.forecast_step.values)
-            if len(step) != 1:
-                raise ValueError(f"Expected single step value, got {step}")
+            # Each zarr fstep may contain multiple hourly sub-steps
+            # concatenated along ipoint.  Split by unique valid_time so
+            # each GRIB message gets exactly one time step worth of grid
+            # points, with step = valid_time - source_interval_start.
+            unique_times = np.unique(result.valid_time.values)
 
-            step = int(step[0])
+            for vt in unique_times:
+                mask = result.valid_time.values == vt
+                sub = result.isel(ipoint=mask)
+                da_sub = self.assign_coords(sub)
 
-            sf_fields = []
-            pl_fields = []
-            for var in self.channels:
-                _, level, level_type = self.extract_var_info(var)
+                sf_fields = []
+                pl_fields = []
+                for var in self.channels:
+                    _, level, level_type = self.extract_var_info(var)
 
-                _logger.info(f"[Worker] Encoding var={var}, level={level}")
+                    _logger.info(f"[Worker] Encoding var={var}, level={level}")
 
-                field_data = da_fs.sel(channel=var)
-                field_data = self.scale_data(field_data, var)
-                template_field = self.template_cache.get((var, level), None)
-                if template_field is None:
-                    _logger.error(f"Template for var={var}, level={level} not found. Skipping.")
-                    continue
+                    field_data = da_sub.sel(channel=var)
+                    field_data = self.scale_data(field_data, var)
+                    template_field = self.template_cache.get((var, level), None)
+                    if template_field is None:
+                        _logger.error(f"Template for var={var}, level={level} not found. Skipping.")
+                        continue
 
-                metadata = self.get_metadata(ref_time=ref_time, step=step, level=level)
+                    metadata = self.get_metadata(
+                        ref_time=ref_time,
+                        valid_time=vt,
+                        source_interval_end=source_interval_end,
+                        level=level,
+                    )
 
-                encoded = self.encoder.encode(
-                    values=field_data.values, template=template_field, metadata=metadata
-                )
+                    encoded = self.encoder.encode(
+                        values=field_data.values,
+                        template=template_field,
+                        metadata=metadata,
+                    )
 
-                field_list = pl_fields if level_type == "pl" else sf_fields
-                field_list.append(encoded.to_field())
+                    field_list = pl_fields if level_type == "pl" else sf_fields
+                    field_list.append(encoded.to_field())
 
-            self.save(pl_fields, "pl")
-            self.save(sf_fields, "sfc")
+                self.save(pl_fields, "pl")
+                self.save(sf_fields, "sfc")
 
         _logger.info(f"Saved sample data to {self.output_format} in {self.output_dir}.")
 
@@ -220,16 +235,22 @@ class QuaverParser(CfParser):
     def get_metadata(
         self,
         ref_time: pd.Timestamp,
-        step: int,
+        valid_time: np.datetime64,
+        source_interval_end: np.datetime64,
         level: str,
     ):
         """
         Add metadata to the dataset attributes.
+
+        The GRIB ``step`` is computed as ``valid_time - source_interval_end``
+        (in hours), i.e. the lead time relative to the end of the
+        conditioning window.
         """
+        step_hours = int((valid_time - source_interval_end) / np.timedelta64(1, "h"))
 
         metadata = {
             "date": ref_time,
-            "step": step * self.fstep_hours.astype(int),
+            "step": step_hours,
             "expver": self.expver,
             "marsClass": "rd",
         }

--- a/packages/evaluate/src/weathergen/evaluate/export/parsers/verif_parser.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/parsers/verif_parser.py
@@ -76,6 +76,8 @@ class VerifParser(CfParser):
         self,
         fstep_iterator_results: iter,
         ref_time: np.datetime64,
+        source_interval_start: np.datetime64 = None,
+        source_interval_end: np.datetime64 = None,
     ):
         """
         Process results from get_data_worker: reshape, concatenate, add metadata, and save.
@@ -83,6 +85,8 @@ class VerifParser(CfParser):
         ----------
             fstep_iterator_results : Iterator over results from get_data_worker.
             ref_time : Forecast reference time for the sample.
+            source_interval_start : Start of the source (conditioning) window.
+            source_interval_end : End of the source (conditioning) window.
         Returns
         -------
             None
@@ -111,7 +115,7 @@ class VerifParser(CfParser):
         if da_fs:
             if self.zarr_coords is None:
                 self.zarr_coords = get_grid_points(da_fs[0])
-                self.zarr_dt = self.get_zarr_dt(da_fs[0])
+                self.zarr_dt = self.get_zarr_dt(source_interval_start, source_interval_end)
             # check consistency of grid points across forecast steps
             if len(da_fs) > 1:
                 assert np.array_equal(get_grid_points(da_fs[1]), get_grid_points(da_fs[0])), (
@@ -135,20 +139,25 @@ class VerifParser(CfParser):
                 vars_to_merge[verif_var] = merged
         return vars_to_merge
 
-    def get_zarr_dt(self, ds: xr.Dataset) -> np.timedelta64:
+    def get_zarr_dt(
+        self,
+        source_interval_start: np.datetime64,
+        source_interval_end: np.datetime64,
+    ) -> np.timedelta64:
         """
-        Compute the time difference between forecast steps in hours from the WG output dataset.
+        Compute the time difference between source interval start and end in hours.
         Parameters
         ----------
-            ds : xr.Dataset
-                Input dataset from which to compute the time difference.
+            source_interval_start : np.datetime64
+                Start of the source (conditioning) window.
+            source_interval_end : np.datetime64
+                End of the source (conditioning) window.
         Returns
         -------
             np.timedelta64
-                Time difference between forecast steps in hours.
+                Time difference between source interval start and end in hours.
         """
-        zarr_dt = ds.source_interval_end.values - ds.source_interval_start.values
-        zarr_dt = zarr_dt.astype("timedelta64[h]")
+        zarr_dt = (source_interval_end - source_interval_start).astype("timedelta64[h]")
 
         return zarr_dt
 

--- a/packages/evaluate/src/weathergen/evaluate/io/data/dataarray_builders.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/data/dataarray_builders.py
@@ -126,10 +126,6 @@ def build_gridded_dataarrays(
 
     # valid_time must be 2D (sample, ipoint) to match the shape produced by
     # get_data() → _force_consistent_grids → xr.concat(dim="sample").
-    # _add_lead_time_coord computes lead_time = valid_time - source_interval_start
-    # and needs both arrays to broadcast as (sample, ipoint).
-    # Each sample has its OWN valid_time (different initialisation dates),
-    # so we build a 2D array where row i is filled with sample i's time.
     vt_col = np.array(per_sample_valid_times, dtype="datetime64[ns]")  # (n_samples,)
     valid_time_2d = np.broadcast_to(
         vt_col[:, np.newaxis],  # (n_samples, 1)


### PR DESCRIPTION
## Description

implement a more solid way to retrieve the forecast steps that takes into account also the substeps. 

```
init_time = valid_time - source_end
```
Where `source_end` is the last valid_time of the `source` window. 


example:

```
uv run export --run-id b9i7napw --output-dir ./results/b9i7napw/ --format quaver --stream ERA5 --type prediction --samples 0 1 --fsteps 2 4 6 8 10 12 14 16 18 20 22 24 26 28 30 32  --quaver-template-folder ./grib_templates/ --quaver-template-grid-type o96 --expver j3xx --n-processes 48 --channels 2t msl 10u 10v t_500 t_850 z_500 z_850 q_500 q_850 v_500 v_850 u_500 u_850
```

```
Dimensions:        (time: 2, step: 60, isobaricInhPa: 2, values: 40320)
Coordinates:
  * time           (time) datetime64[ns] 16B 2023-10-01T05:00:00 2023-10-01T1...
  * step           (step) timedelta64[ns] 480B 07:00:00 ... 5 days 00:00:00
    valid_time     (time, step) datetime64[ns] 960B ...
  * isobaricInhPa  (isobaricInhPa) float64 16B 850.0 500.0
    latitude       (values) float64 323kB ...
    longitude      (values) float64 323kB ...
Dimensions without coordinates: values
Data variables:
    q              (time, step, isobaricInhPa, values) float32 39MB ...
    u              (time, step, isobaricInhPa, values) float32 39MB ...
    v              (time, step, isobaricInhPa, values) float32 39MB ...
    z              (time, step, isobaricInhPa, values) float32 39MB ...
    t              (time, step, isobaricInhPa, values) float32 39MB ...
Attributes:
    GRIB_edition:            2
    GRIB_centre:             ecmf
    GRIB_centreDescription:  European Centre for Medium-Range Weather Forecasts
    GRIB_subCentre:          0
    Conventions:             CF-1.7
    institution:             European Centre for Medium-Range Weather Forecasts
    history:                 2026-04-24T10:40 GRIB to CDM+CF via cfgrib-0.9.1...

```

steps:

```
> ds.step.astype("timedelta64[ns]")/3600000000000
<xarray.DataArray 'step' (step: 60)> Size: 480B
array([  7,   8,   9,  10,  11,  12,  19,  20,  21,  22,  23,  24,  31,
        32,  33,  34,  35,  36,  43,  44,  45,  46,  47,  48,  55,  56,
        57,  58,  59,  60,  67,  68,  69,  70,  71,  72,  79,  80,  81,
        82,  83,  84,  91,  92,  93,  94,  95,  96, 103, 104, 105, 106,
       107, 108, 115, 116, 117, 118, 119, 120], dtype='timedelta64[ns]')
```

## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/2264

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
