### PR TITLE
fixing order of coords

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/export/parsers/netcdf_parser.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/parsers/netcdf_parser.py
@@ -467,8 +467,8 @@ class NetcdfParser(CfParser):
                 )
             except KeyError:
                 _logger.warning(
-                    f"Coordinate '{coord}' not found in dataset for variable '{var_cfg.get('var', 'unknown')}'."
-                    " This coordinate will be skipped for this variable."
+                    f"Coordinate '{coord}' will be skipped for "
+                    f"variable '{var_cfg.get('var', 'unknown')}'."
                 )
 
         return coords

--- a/packages/evaluate/src/weathergen/evaluate/export/parsers/netcdf_parser.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/parsers/netcdf_parser.py
@@ -372,7 +372,7 @@ class NetcdfParser(CfParser):
         variables = {}
         dims_cfg = self.config.get("dimensions", {})
         ds, ds_attrs = self._assign_dim_attrs(ds, dims_cfg)
-        dims_list = ["pressure", "latitude", "longitude", "valid_time"]
+        dims_list = ["pressure", "valid_time", "latitude", "longitude"]
         for var_name, da in ds.data_vars.items():
             mapped_info = self.mapping.get(var_name, {})
             mapped_name = mapped_info.get("var", var_name)
@@ -459,11 +459,17 @@ class NetcdfParser(CfParser):
         coord_map = self.config.get("coordinates", {}).get(var_cfg.get("level_type"), {})
 
         for coord, new_name in coord_map.items():
-            coords[new_name] = (
-                ds.coords[coord].dims,
-                ds.coords[coord].values,
-                attrs[new_name],
-            )
+            try:
+                coords[new_name] = (
+                    ds.coords[coord].dims,
+                    ds.coords[coord].values,
+                    attrs[new_name],
+                )
+            except KeyError:
+                _logger.warning(
+                    f"Coordinate '{coord}' not found in dataset for variable '{var_cfg.get('var', 'unknown')}'."
+                    " This coordinate will be skipped for this variable."
+                )
 
         return coords
 

--- a/packages/evaluate/src/weathergen/evaluate/export/reshape.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/reshape.py
@@ -269,9 +269,11 @@ class Regridder:
         pos = dims.index("ncells")
         dims[pos : pos + 1] = ["latitude", "longitude"]
         dims = tuple(dims)
-
+        ordered_dims = ["valid_time", "pressure", "latitude", "longitude"] if len(dims) == 4 else ["valid_time", "latitude", "longitude"]
+        permutation_indices = [dims.index(o_dim) for o_dim in ordered_dims]
+        regridded_values = np.transpose(regridded_values, axes=permutation_indices)
         regrid_data = xr.DataArray(
-            data=regridded_values, dims=dims, coords=new_coords, attrs=attrs, name=data.name
+            data=regridded_values, dims=ordered_dims, coords=new_coords, attrs=attrs, name=data.name
         )
 
         return regrid_data

--- a/packages/evaluate/src/weathergen/evaluate/export/reshape.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/reshape.py
@@ -269,7 +269,11 @@ class Regridder:
         pos = dims.index("ncells")
         dims[pos : pos + 1] = ["latitude", "longitude"]
         dims = tuple(dims)
-        ordered_dims = ["valid_time", "pressure", "latitude", "longitude"] if len(dims) == 4 else ["valid_time", "latitude", "longitude"]
+        ordered_dims = (
+            ["valid_time", "pressure", "latitude", "longitude"]
+            if len(dims) == 4
+            else ["valid_time", "latitude", "longitude"]
+        )
         permutation_indices = [dims.index(o_dim) for o_dim in ordered_dims]
         regridded_values = np.transpose(regridded_values, axes=permutation_indices)
         regrid_data = xr.DataArray(


### PR DESCRIPTION
## Description

- always reorder the data so the coordinates are in the order (time, pressure, lat, lon)
- ensures compatibility with other tools 

Can be tested using `uv run export --run-id n04jupeb --stream ERA5 --output-dir ../n04jupeb --format netcdf --regrid-degree 1 --regrid-type regular_ll --type prediction` on JUPITER

## Issue Number

Closes #2281 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
