### PR TITLE
Store denoising steps during diffusion inference

### DIFF
--- a/src/weathergen/model/diffusion.py
+++ b/src/weathergen/model/diffusion.py
@@ -293,6 +293,10 @@ class DiffusionForecastEngine(torch.nn.Module):
             "x": [x.cpu()],
         }
 
+        # Per-step intermediate denoised states (one per ODE step).
+        # Returned to the caller so they can be treated as a forecast-step dimension.
+        intermediate_x: list[torch.Tensor] = []
+
         # Main sampling loop.
         x_next = x * t_steps[0]
         for i, (t_cur, t_next) in enumerate(
@@ -332,9 +336,13 @@ class DiffusionForecastEngine(torch.nn.Module):
                 if self.cur_token is not None:
                     track["l2_to_target"].append((x_next - self.cur_token).norm().item())
                     track["x"].append(self.cur_token.cpu())
+
+            # Record intermediate denoised state for this ODE step.
+            intermediate_x.append(x_next)
+
         self._plot_sampling_diagnostics(track, num_steps)
 
-        return x_next
+        return intermediate_x
 
     def _plot_sampling_diagnostics(self, track: dict, num_steps: int) -> None:
         """Save a diagnostic plot of the sampling trajectory."""

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -346,6 +346,9 @@ class Model(torch.nn.Module):
         self.register_token_idxs = list(range(cf.num_register_tokens))
         self.aux_token_idxs = list(range(cf.num_register_tokens + cf.num_class_tokens))
         self.num_aux_tokens = cf.num_register_tokens + cf.num_class_tokens
+        # One-shot flag to avoid log spam when warning about an unsupported
+        # diffusion-inference + multi-step-rollout combination.
+        self._warned_diffusion_multi_step = False
 
     def _create_latent_pred_head(
         self, global_cfg, name, loss_cfg, use_class_token, use_patch_token
@@ -730,6 +733,38 @@ class Model(torch.nn.Module):
                     coords=model_params.rope_coords,
                 )
 
+            # Diffusion inference returns the per-ODE-step intermediate denoised tokens as a
+            # list. Treat each intermediate state as its own forecast step in the output so the
+            # full denoising trajectory can be inspected downstream. The original `step` is
+            # still used to look up target coordinates (they share the same physical timestamp).
+            if isinstance(tokens, list):
+                # Diffusion inference currently only supports a single physical forecast
+                # step (forecast.num_steps=1); the per-ODE-step trajectory consumes the
+                # ModelOutput fstep dimension. Multi-step autoregressive rollouts on top of
+                # diffusion are not implemented yet.
+                if (
+                    len(batch.get_output_idxs()) > 1
+                    and not self._warned_diffusion_multi_step
+                ):
+                    logger.warning(
+                        "Diffusion inference is being run with forecast.num_steps=%d (>1). "
+                        "Only a single forecast step is supported in this mode; the "
+                        "per-ODE-step denoising trajectory will overwrite later forecast "
+                        "steps in the model output.",
+                        len(batch.get_output_idxs()),
+                    )
+                    self._warned_diffusion_multi_step = True
+                # Resize output to fit the diffusion trajectory.
+                output = self._reindex_output_for_trajectory(output, len(tokens))
+                for i, toks in enumerate(tokens):
+                    output = self.predict_decoders(
+                        model_params, step, toks, batch, output, out_step=i
+                    )
+                    output = self.predict_latent(
+                        model_params, step, toks, batch, output, out_step=i
+                    )
+                continue
+
             # decoder predictions
             output = self.predict_decoders(model_params, step, tokens, batch, output)
 
@@ -738,6 +773,18 @@ class Model(torch.nn.Module):
 
         return output
 
+    @staticmethod
+    def _reindex_output_for_trajectory(output: ModelOutput, n_steps: int) -> ModelOutput:
+        """
+        Resize a ModelOutput to hold ``n_steps`` forecast steps, preserving any latent entries
+        that were already attached to fstep 0 (e.g. encoder posteriors).
+        """
+        new_output = ModelOutput(n_steps)
+        if len(output.latent) > 0:
+            for k, v in output.latent[0].items():
+                new_output.add_latent_prediction(0, k, v)
+        return new_output
+
     def predict_latent(
         self,
         model_params: ModelParams,
@@ -745,19 +792,23 @@ class Model(torch.nn.Module):
         tokens: torch.Tensor,
         batch: ModelBatch,
         output: ModelOutput,
+        out_step: int | None = None,
     ) -> ModelOutput:
         """
         Compute latent predictions
         """
 
+        if out_step is None:
+            out_step = step
+
         # safe latent prediction
         tokens_post_norm = self.latent_pre_norm(tokens) if step == 0 else None
         latent_state = self.tokens_to_latent_state(tokens_post_norm, tokens)
-        output.add_latent_prediction(step, "latent_state", latent_state)
+        output.add_latent_prediction(out_step, "latent_state", latent_state)
 
         # latent predictions for SSL training
         for name, head in self.latent_heads.items():
-            output.add_latent_prediction(step, name, head(latent_state))
+            output.add_latent_prediction(out_step, name, head(latent_state))
 
         return output
 
@@ -768,6 +819,7 @@ class Model(torch.nn.Module):
         tokens: torch.Tensor,
         batch: ModelBatch,
         output: ModelOutput,
+        out_step: int | None = None,
     ) -> ModelOutput:
         """
         Compute decoder-based predictions
@@ -789,6 +841,9 @@ class Model(torch.nn.Module):
         # breakpoint()
         if not self.pred_heads:
             return output
+
+        if out_step is None:
+            out_step = step
 
         # remove register  and class tokens
         tokens = tokens[:, self.num_aux_tokens :]
@@ -869,6 +924,6 @@ class Model(torch.nn.Module):
             # recover batch dimension (ragged, so as list)
             pred = torch.split(pred, t_coords_lens, dim=1)
 
-            output.add_physical_prediction(step, stream_name, pred)
+            output.add_physical_prediction(out_step, stream_name, pred)
 
         return output

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -56,6 +56,43 @@ logger = logging.getLogger(__name__)
 # cfg_keys_to_filter = ["losses", "model_input", "target_input"]
 
 
+def _expand_targets_to_match_preds(preds, targets_and_auxs: dict) -> None:
+    """
+    Replicate per-fstep entries in each TargetAuxOutput so its ``physical`` and ``latent``
+    lists match the number of forecast steps in ``preds``.
+
+    Diffusion inference produces one ``preds`` fstep per ODE denoising step, but the
+    physical target is identical across the trajectory. Without this expansion the loss
+    calculator (which zips preds and targets with ``strict=True``) raises a length
+    mismatch.
+
+    The expansion replicates references — no tensor copies are made — and is a no-op when
+    the lengths already agree.
+    """
+    n_pred = len(preds.physical)
+    for t_aux in targets_and_auxs.values():
+        n_tgt = len(t_aux.physical)
+        if n_tgt == n_pred or n_tgt == 0:
+            continue
+        if n_pred % n_tgt != 0:
+            logger.warning(
+                "Cannot expand target/aux from %d to %d fsteps (not a multiple); "
+                "leaving unchanged.",
+                n_tgt,
+                n_pred,
+            )
+            continue
+        repeat = n_pred // n_tgt
+        t_aux.physical = [t_aux.physical[i // repeat] for i in range(n_pred)]
+        t_aux.latent = [t_aux.latent[i // repeat] for i in range(n_pred)]
+        # output_idxs is consumed by validation IO via batch.get_output_idxs(), but we
+        # keep the dataclass internally consistent in case other consumers read it.
+        if t_aux.output_idxs is not None and len(t_aux.output_idxs) == n_tgt:
+            t_aux.output_idxs = [
+                t_aux.output_idxs[i // repeat] for i in range(n_pred)
+            ]
+
+
 class Trainer(TrainerBase):
     def __init__(self, train_logging: Config):
         TrainerBase.__init__(self)
@@ -626,6 +663,14 @@ class Trainer(TrainerBase):
                                     self.model_params,
                                     self.model,
                                 )
+
+                            # Diffusion inference inflates the model output's fstep
+                            # dimension to one entry per ODE step (the denoising
+                            # trajectory). The physical target is identical for every
+                            # such step, so replicate target/aux entries to keep the
+                            # downstream loss calculator and validation IO aligned.
+                            if is_diffusion:
+                                _expand_targets_to_match_preds(preds, targets_and_auxs)
 
                         _ = self.loss_calculator_val.compute_loss(
                             preds=preds,

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -679,29 +679,26 @@ class Trainer(TrainerBase):
                         )
 
                         # log output
-                        if bidx < num_samples_write:
-                            # denormalization function for data
-                            denormalize_data_fct = (
-                                (lambda x0, x1: x1)
-                                if mode_cfg.get("output", {}).get("normalized_samples", False)
-                                else self.dataset_val.denormalize_target_channels
-                            )
-                            # write output (zarr only for first noise level, plots for all)
-                            write_output(
-                                self.cf,
-                                mode_cfg,
-                                batch_size,
-                                mini_epoch,
-                                bidx,
-                                denormalize_data_fct,
-                                batch,
-                                preds,
-                                targets_and_auxs,
-                                noise_level=noise_level
-                                if is_diffusion and len(noise_levels) > 1
-                                else None,
-                                write_zarr=False,  # (noise_idx == 0),
-                            )
+                        if noise_idx == 0:
+                            if bidx < num_samples_write:
+                                # denormalization function for data
+                                denormalize_data_fct = (
+                                    (lambda x0, x1: x1)
+                                    if mode_cfg.get("output", {}).get("normalized_samples", False)
+                                    else self.dataset_val.denormalize_target_channels
+                                )
+                                # write output (zarr only for first noise level, plots for all)
+                                write_output(
+                                    self.cf,
+                                    mode_cfg,
+                                    batch_size,
+                                    mini_epoch,
+                                    bidx,
+                                    denormalize_data_fct,
+                                    batch,
+                                    preds,
+                                    targets_and_auxs,
+                                )
 
                         pbar.update(batch_size)
 

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -30,20 +30,9 @@ def write_output(
     batch,
     model_output,
     target_aux_out,
-    noise_level=None,
-    write_zarr=True,
 ):
     """
     Interface for writing model output
-
-    Parameters
-    ----------
-    noise_level : float | None
-        Fixed diffusion noise level (eta) used for this validation pass.
-        When not None the value is embedded in plot filenames and titles.
-    write_zarr : bool
-        Whether to write zarr output. Default True. Set to False to only
-        generate plots without writing zarr data.
     """
 
     # TODO: how to handle multiple physical loss terms
@@ -61,6 +50,15 @@ def write_output(
 
     timestep_idxs = [0] if len(batch.get_output_idxs()) == 0 else batch.get_output_idxs()
     forecast_offset = timestep_idxs[0]
+
+    # Diffusion inference inflates the model output's fstep dimension to one entry per
+    # ODE denoising step (the trajectory). The batch only has the original physical
+    # forecast indices, so synthesize a contiguous run of indices starting at the
+    # original first index to cover every entry in model_output / target_aux_out.
+    n_pred_steps = len(model_output.physical)
+    if n_pred_steps > len(timestep_idxs):
+        timestep_idxs = list(range(forecast_offset, forecast_offset + n_pred_steps))
+
     targets_lens = []
 
     # TODO Maybe stopping at forecast_steps explained #1657
@@ -191,10 +189,10 @@ def write_output(
         sample_start,
         forecast_offset,
     )
-    if write_zarr:
-        with zarrio_writer(config.get_path_results(cf, mini_epoch)) as zio:
-            for subset in data.items():
-                zio.write_zarr(subset)
+
+    with zarrio_writer(config.get_path_results(cf, mini_epoch)) as zio:
+        for subset in data.items():
+            zio.write_zarr(subset)
 
     # Free arrays no longer needed after zarr writing
     del targets_all, targets_lens, sources, data


### PR DESCRIPTION
## Description

The ODE denoising steps during diffusion inference are treated as forecast dimension and the zarr file is written accordingly.


## Issue Number


Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
