### PR TITLE
enable per-channel location weight scaling

### DIFF
--- a/src/weathergen/train/loss_modules/loss_functions.py
+++ b/src/weathergen/train/loss_modules/loss_functions.py
@@ -114,7 +114,12 @@ def kernel_crps(
 
     # apply point weighting
     if weights_points is not None:
-        kcrps_locs_chs = kcrps_locs_chs * weights_points
+        if weights_points.dim() == 1:
+            # uniform location weight across channels
+            kcrps_locs_chs = kcrps_locs_chs * weights_points
+        else:
+            # per-channel location weight
+            kcrps_locs_chs = kcrps_locs_chs * weights_points.T.unsqueeze(0)
     # apply channel weighting
     kcrps_chs = torch.mean(torch.mean(kcrps_locs_chs, 0), -1)
     if weights_channels is not None:
@@ -195,7 +200,12 @@ def lp_loss(
         torch.abs(torch.where(mask_nan, target, 0) - torch.where(mask_nan, pred, 0)), p_norm
     )
     if weights_points is not None:
-        diff_p = (diff_p.transpose(1, 0) * weights_points).transpose(1, 0)
+        if weights_points.dim() == 1:
+            # uniform location weight across channels
+            diff_p = (diff_p.transpose(1, 0) * weights_points).transpose(1, 0)
+        else:
+            # per-channel location weight
+            diff_p = diff_p * weights_points
     loss_chs = diff_p.mean(0) if with_mean else diff_p.sum(0)
     loss_chs = torch.pow(loss_chs, 1.0 / p_norm) if with_p_root else loss_chs
     loss = torch.mean(loss_chs * weights_channels if weights_channels is not None else loss_chs)

--- a/src/weathergen/train/loss_modules/loss_module_physical.py
+++ b/src/weathergen/train/loss_modules/loss_module_physical.py
@@ -100,13 +100,25 @@ class LossPhysical(LossModuleBase):
         decay_factor = list(timestep_weight_config.values())[0]["decay_factor"]
         return weights_timestep_fct(len_forecast_steps, decay_factor)
 
-    def _get_location_weights(self, stream_info, target_coords):
+    def _get_location_weights(self, stream_info, target_coords, target_channels):
         location_weight_type = stream_info.get("location_weight", None)
         if location_weight_type is None:
             return None
         weights_locations_fct = getattr(loss_fns, location_weight_type)
         weights_locations = weights_locations_fct(target_coords)
         weights_locations = weights_locations.to(device=self.device, non_blocking=True)
+
+        # Channels not listed default to 1.0 (full weighting).
+        location_weight_fraction = stream_info.get("location_weight_fraction", None)
+        if location_weight_fraction is not None:
+            fractions = torch.tensor(
+                [location_weight_fraction.get(ch, 1.0) for ch in target_channels],
+                device=self.device,
+                dtype=weights_locations.dtype,
+            )
+            weights_locations = 1.0 + fractions.unsqueeze(0) * (
+                weights_locations.unsqueeze(1) - 1.0
+            )
 
         return weights_locations
 
@@ -263,7 +275,7 @@ class LossPhysical(LossModuleBase):
 
                     # get weights for locations
                     weights_locations = self._get_location_weights(
-                        stream_info, targets_coords_batch[target_idx]
+                        stream_info, targets_coords_batch[target_idx], target_channels
                     )
 
                     # loss_st_corr: loss for give source-target correspondence

--- a/src/weathergen/train/loss_modules/loss_module_physical.py
+++ b/src/weathergen/train/loss_modules/loss_module_physical.py
@@ -57,6 +57,9 @@ class LossPhysical(LossModuleBase):
         self.device = device
         self.name = "LossPhysical"
 
+        # cache for per-stream location-weight
+        self._location_weight_fractions: dict[str, torch.Tensor | None] = {}
+
         # dynamically load loss functions based on configuration and stage
         self.loss_fcts = [
             [
@@ -108,14 +111,21 @@ class LossPhysical(LossModuleBase):
         weights_locations = weights_locations_fct(target_coords)
         weights_locations = weights_locations.to(device=self.device, non_blocking=True)
 
-        # Channels not listed default to 1.0 (full weighting).
-        location_weight_fraction = stream_info.get("location_weight_fraction", None)
-        if location_weight_fraction is not None:
-            fractions = torch.tensor(
-                [location_weight_fraction.get(ch, 1.0) for ch in target_channels],
-                device=self.device,
-                dtype=weights_locations.dtype,
-            )
+        # Cache; reuse on every subsequent call.
+        stream_name = stream_info["name"]
+        if stream_name not in self._location_weight_fractions:
+            location_weight_fraction = stream_info.get("location_weight_fraction", None)
+            if location_weight_fraction is not None:
+                self._location_weight_fractions[stream_name] = torch.tensor(
+                    [location_weight_fraction.get(ch, 1.0) for ch in target_channels],
+                    device=self.device,
+                    dtype=weights_locations.dtype,
+                )
+            else:
+                self._location_weight_fractions[stream_name] = None
+
+        fractions = self._location_weight_fractions[stream_name]
+        if fractions is not None:
             weights_locations = 1.0 + fractions.unsqueeze(0) * (
                 weights_locations.unsqueeze(1) - 1.0
             )


### PR DESCRIPTION
## Description

Backward compatible per channel scaling of the location loss weighting.

Example config:
```yaml
location_weight: cosine_latitude
location_weight_fraction:
  q: 0.0    # no lat weighting
  u: 0.5    # half lat weighting
  t: 1.0    # full (same as omitting)
  # unlisted channels default to 1.0
channel_weights:
  q: 2.0    # applied after, as before
```

## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/2292

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
