### PR TITLE
Change of definition of time window from [,) to (,]

### DIFF
--- a/src/weathergen/datasets/data_reader_base.py
+++ b/src/weathergen/datasets/data_reader_base.py
@@ -288,7 +288,7 @@ def check_reader_data(rdata: ReaderData, dtr: DTRange) -> None:
         f"{rdata.datetimes.shape[0]}"
     )
 
-    assert np.logical_and(rdata.datetimes >= dtr.start, rdata.datetimes < dtr.end).all(), (
+    assert np.logical_and(rdata.datetimes > dtr.start, rdata.datetimes <= dtr.end).all(), (
         f"datetimes for data points violate window {dtr}."
     )
 
@@ -754,7 +754,7 @@ class DataReaderTimestep(DataReaderBase):
 
 # to avoid rounding issues
 # The basic time precision is 1 millisecond.
-# This should support all datasets (the small period expected is 1 second)
+# This should support all datasets (the smallest period expected is 1 second)
 t_epsilon = np.timedelta64(1, "ms")
 
 
@@ -803,8 +803,8 @@ def get_dataset_indexes_timestep(
         return (np.array([], dtype=np.int64), dtr)
 
     # relative time in dataset
-    delta_t_start = dtr.start - data_start_time
-    delta_t_end = dtr.end - data_start_time - t_epsilon
+    delta_t_start = dtr.start - data_start_time + t_epsilon
+    delta_t_end = dtr.end - data_start_time
     assert isinstance(delta_t_start, timedelta64), "delta_t_start must be timedelta64"
     start_didx = delta_t_start // period
     end_didx = delta_t_end // period

--- a/src/weathergen/datasets/data_reader_obs.py
+++ b/src/weathergen/datasets/data_reader_obs.py
@@ -78,8 +78,8 @@ class DataReaderObs(DataReaderBase):
 
         # load additional properties (mean, var)
         self._load_properties()
-        self.mean = np.array(self.properties["means"])  # [data_idx]
-        self.stdev = np.sqrt(np.array(self.properties["vars"]))  # [data_idx])
+        self.mean = np.array(self.properties["means"])
+        self.stdev = np.sqrt(np.array(self.properties["vars"]))
         self.mean_geoinfo = np.array(self.properties["means"])[self.geoinfo_idx]
         self.stdev_geoinfo = np.sqrt(np.array(self.properties["vars"])[self.geoinfo_idx])
 
@@ -248,17 +248,11 @@ class DataReaderObs(DataReaderBase):
         data = self.data.oindex[start_row:end_row, channels_idx]
         datetimes = self.dt[start_row:end_row][:, 0]
 
-        # indices_start, indices_end above work with [t_start, t_end] and violate
-        # our convention [t_start, t_end) where endpoint is excluded
-        # compute mask to enforce it
-        t_win = self.time_window_handler.window(idx)
-        t_mask = np.logical_and(datetimes >= t_win.start, datetimes < t_win.end)
-
         rdata = ReaderData(
-            coords=coords[t_mask],
-            geoinfos=geoinfos[t_mask],
-            data=data[t_mask],
-            datetimes=datetimes[t_mask],
+            coords=coords,
+            geoinfos=geoinfos,
+            data=data,
+            datetimes=datetimes,
         )
 
         dtr = self.time_window_handler.window(idx)


### PR DESCRIPTION
## Description

Change of definition of time window from [,) to (,]
## Issue Number

Closes #2295 

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
