### PR TITLE
Rolfhm use results path from config in integration test

### DIFF
--- a/integration_tests/small_multi_stream_test.py
+++ b/integration_tests/small_multi_stream_test.py
@@ -47,6 +47,10 @@ WEATHERGEN_HOME = Path(__file__).parent.parent
 @pytest.fixture()
 def setup(test_run_id):
     logger.info(f"setup fixture with {test_run_id}")
+
+    assert (WEATHERGEN_HOME/"results").exists(), "no results directory, did you run create-links?"
+    assert (WEATHERGEN_HOME/"models").exists(), "no models directory, did you run create-links?"
+
     shutil.rmtree(WEATHERGEN_HOME / "results" / test_run_id, ignore_errors=True)
     shutil.rmtree(WEATHERGEN_HOME / "models" / test_run_id, ignore_errors=True)
     yield

--- a/integration_tests/small_multi_stream_test.py
+++ b/integration_tests/small_multi_stream_test.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import omegaconf
 import pytest
 
+from weathergen.common.config import _get_shared_wg_path
 from weathergen.evaluate.run_evaluation import evaluate_from_config
 from weathergen.run_train import main
 from weathergen.utils.metrics import get_train_metrics_path
@@ -48,11 +49,8 @@ WEATHERGEN_HOME = Path(__file__).parent.parent
 def setup(test_run_id):
     logger.info(f"setup fixture with {test_run_id}")
 
-    assert (WEATHERGEN_HOME/"results").exists(), "no results directory, did you run create-links?"
-    assert (WEATHERGEN_HOME/"models").exists(), "no models directory, did you run create-links?"
-
-    shutil.rmtree(WEATHERGEN_HOME / "results" / test_run_id, ignore_errors=True)
-    shutil.rmtree(WEATHERGEN_HOME / "models" / test_run_id, ignore_errors=True)
+    shutil.rmtree(_get_shared_wg_path() / "results" / test_run_id, ignore_errors=True)
+    shutil.rmtree(_get_shared_wg_path() / "models" / test_run_id, ignore_errors=True)
     yield
     logger.info("end fixture")
 
@@ -163,7 +161,7 @@ def evaluate_multi_stream_results(run_id):
 
 def load_metrics(run_id):
     """Helper function to load metrics"""
-    file_path = get_train_metrics_path(base_path=WEATHERGEN_HOME / "results" / run_id, run_id=run_id)
+    file_path = get_train_metrics_path(base_path=_get_shared_wg_path() / "results" / run_id, run_id=run_id)
     if not file_path.is_file():
         raise FileNotFoundError(f"Metrics file not found for run_id: {run_id}")
     with open(file_path) as f:
@@ -173,7 +171,7 @@ def load_metrics(run_id):
 
 def assert_metrics_file_exists(run_id):
     """Test that the metrics file exists and can be loaded."""
-    file_path = get_train_metrics_path(base_path=WEATHERGEN_HOME / "results" / run_id, run_id=run_id)
+    file_path = get_train_metrics_path(base_path=_get_shared_wg_path() / "results" / run_id, run_id=run_id)
     assert file_path.is_file(), f"Metrics file does not exist for run_id: {run_id}"
     metrics = load_metrics(run_id)
     logger.info(f"Loaded metrics for run_id: {run_id}: {metrics}")


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number



Closes #2307

## Checklist before asking for review

-   [X] I have performed a self-review of my code
-   [X] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [X] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [X] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
