### PR TITLE
Bugfix + remove assertion FC_offset=0

### DIFF
--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -753,10 +753,11 @@ def validate_forecast_policy_and_steps(forecast_cfg: OmegaConf, mode: str):
     output_offset = forecast_cfg.get("offset", 0)
     assert isinstance(output_offset, int), TypeError(valid_forecast_offset)
     if output_offset == 0:
-        if isinstance(forecast_cfg.num_steps, int):
-            assert forecast_cfg.num_steps in [0, 1], valid_forecast_steps_offset0
-        else:
-            raise TypeError(valid_forecast_steps_offset0)
+        # if isinstance(forecast_cfg.num_steps, int):
+        #     assert forecast_cfg.num_steps in [0, 1], valid_forecast_steps_offset0
+        # else:
+        #     raise TypeError(valid_forecast_steps_offset0)
+        pass
     elif output_offset == 1:
         assert forecast_cfg.policy, (provide_forecast_policy, valid_forecast_policies)
         if isinstance(forecast_cfg.num_steps, int):

--- a/src/weathergen/model/encoder.py
+++ b/src/weathergen/model/encoder.py
@@ -117,7 +117,7 @@ class EncoderModule(torch.nn.Module):
         # global assimilation engine
         self.ae_global_engine = GlobalAssimilationEngine(cf, self.num_healpix_cells)
 
-        self.ln = torch.nn.LayerNorm(cf.ae_local_dim_embed, elementwise_affine=False)
+        self.ln = torch.nn.LayerNorm(cf.ae_global_dim_embed, elementwise_affine=False)
 
     def forward(self, model_params, batch):
         """


### PR DESCRIPTION
## Description

- removed assertion against usign forecast offset = 0 with higher forecast steps
- there was a bug in the layer norm at the output of the encoder: it needs to use `cf.ae_global_dim_embed` but was using the local one



## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
