### PR TITLE
Fixed logging for empty/spoofed samples

### DIFF
--- a/src/weathergen/train/loss_modules/loss_module_physical.py
+++ b/src/weathergen/train/loss_modules/loss_module_physical.py
@@ -278,7 +278,8 @@ class LossPhysical(LossModuleBase):
                         target_times = targets_times_batch[target_idx]
 
                         # spoofed inputs are masked in the output calculations
-                        sw = 0.0 if targets_is_spoof[target_idx] else 1.0
+                        is_spoof = targets_is_spoof[target_idx]
+                        sw = 0.0 if is_spoof else 1.0
                         spoof_weight = torch.tensor(sw, device=self.device, requires_grad=False)
 
                         # skip if either target or prediction has no data points
@@ -312,14 +313,14 @@ class LossPhysical(LossModuleBase):
 
                         for ch_n, v in zip(target_channels, loss_lfct_chs, strict=True):
                             losses_all[stream_name][str(timestep_idx)][loss_fct_name][ch_n] = (
-                                spoof_weight * v if v != 0.0 and sw > 0.0 else torch.nan
+                                spoof_weight * v if v != 0.0 and not is_spoof else torch.nan
                             )
 
                         # Add the weighted and normalized loss from this loss function to the total
                         # batch loss
                         loss_cur_w = spoof_weight * loss_fct_weight * loss_lfct * output_step_weight
                         loss_st_corr = loss_st_corr + loss_cur_w
-                        ctr_loss_fcts += 1 if (loss_cur_w > 0.0 and sw > 0.0) else 0
+                        ctr_loss_fcts += 1 if (loss_cur_w > 0.0 and not is_spoof) else 0
 
                     loss_timestep = loss_timestep + loss_st_corr
                     ctr_batch += 1 if ctr_loss_fcts > 0.0 else 0

--- a/src/weathergen/train/loss_modules/loss_module_physical.py
+++ b/src/weathergen/train/loss_modules/loss_module_physical.py
@@ -312,14 +312,14 @@ class LossPhysical(LossModuleBase):
 
                         for ch_n, v in zip(target_channels, loss_lfct_chs, strict=True):
                             losses_all[stream_name][str(timestep_idx)][loss_fct_name][ch_n] = (
-                                spoof_weight * v if v != 0.0 else torch.nan
+                                spoof_weight * v if v != 0.0 and sw > 0.0 else torch.nan
                             )
 
                         # Add the weighted and normalized loss from this loss function to the total
                         # batch loss
                         loss_cur_w = spoof_weight * loss_fct_weight * loss_lfct * output_step_weight
                         loss_st_corr = loss_st_corr + loss_cur_w
-                        ctr_loss_fcts += 1 if (loss_lfct > 0.0 and sw > 0.0) else 0
+                        ctr_loss_fcts += 1 if (loss_cur_w > 0.0 and sw > 0.0) else 0
 
                     loss_timestep = loss_timestep + loss_st_corr
                     ctr_batch += 1 if ctr_loss_fcts > 0.0 else 0


### PR DESCRIPTION
## Description

Fixed logging for empty/spoofed samples (see #2326 for broken state)

```
LossPhysical.METOP_AVHRR_IASI.mse.avg : 1.0971E+00 
LossPhysical.ERA5.mse.avg : 7.4605E-01 
LossPhysical.METEOSAT_SEVIRI_IR.mse.avg : 1.0271E+00 
LossPhysical.GOES_ABI_IR.mse.avg : 1.1871E+00 
LossPhysical.HIMAWARI_AHI_IR.mse.avg : 1.0541E+00 
LossPhysical.loss_avg : 7.9690E-01 
```

## Issue Number

Closes #2326 

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
