### PR TITLE
revert aborting behavior in run_train.py

### DIFF
--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -23,7 +23,7 @@ import weathergen.common.config as config
 import weathergen.utils.cli as cli
 from weathergen.common.logger import init_loggers
 from weathergen.train.trainer import Trainer, get_trainer
-from weathergen.utils.distributed import is_root
+from weathergen.utils.distributed import get_world_size
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +64,7 @@ def main(argl: list[str]):
     except Exception:
         extype, value, tb = sys.exc_info()
         traceback.print_exc()
-        if is_root():
+        if get_world_size() == 1:
             pdb.post_mortem(tb)
 
 


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->
Change conditional for entering pdb on abort from `is_root()` back to `get_world_size() == 1`

## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->
closes #2338 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
