### PR TITLE
Allow for climatologies to automatically be read by the inference config

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/io/merge_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/merge_reader.py
@@ -236,8 +236,14 @@ class WeatherGenMergeReader(Reader):
         """
         for reader in self.readers:
             clim_data_path = reader.get_climatology_filename(stream)
-            if clim_data_path:
+            if clim_data_path and Path(clim_data_path).exists():
                 return clim_data_path
+            else:
+                _logger.warning(
+                    f"Climatology file {clim_data_path} does not exist or configuration is invalid"
+                    " for stream {stream} in reader with run_id {reader.run_id}."
+                    " Please check that the path is correct and that the file exists."
+                )
         return None
 
     def get_stream(self, stream: str):

--- a/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
@@ -25,7 +25,6 @@ from weathergen.common.config import (
     load_run_config,
 )
 from weathergen.common.io import zarrio_reader
-
 from weathergen.evaluate.io.data.dataarray_builders import EnsembleSelect
 from weathergen.evaluate.io.data.io_orchestration import (
     _build_io_state,

--- a/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
@@ -25,6 +25,7 @@ from weathergen.common.config import (
     load_run_config,
 )
 from weathergen.common.io import zarrio_reader
+
 from weathergen.evaluate.io.data.dataarray_builders import EnsembleSelect
 from weathergen.evaluate.io.data.io_orchestration import (
     _build_io_state,
@@ -118,27 +119,54 @@ class WeatherGenReader(Reader):
             Full climatology path if available, otherwise None.
         """
         stream_dict = self.get_stream(stream)
+        explicit_path = stream_dict.get("climatology_path", None)
+        if explicit_path:
+            return str(explicit_path)
 
-        clim_data_path = stream_dict.get("climatology_path", None)
-        if not clim_data_path:
-            clim_base_dir = self.inference_cfg.get("data_path_aux", None)
-            clim_fn = next(
-                (
-                    item.get("climatology_filename")
-                    for item in self.inference_cfg.get("streams", [])
-                    if item.get("name") == stream
-                ),
-                None,
+        clim_base_dir = self.inference_cfg.get("data_path_aux", None)
+        if not clim_base_dir:
+            _logger.warning(
+                "No 'data_path_aux' defined in inference config."
+                " Cannot infer climatology path for stream %s.",
+                stream,
             )
-            if clim_base_dir and clim_fn:
-                clim_data_path = Path(clim_base_dir) / clim_fn
-            else:
-                _logger.warning(
-                    f"No climatology path specified for stream {stream}. Setting climatology to "
-                    "NaN. Add 'climatology_path' to evaluation config to use metrics like ACC."
-                )
+            return None
 
-        return str(clim_data_path) if clim_data_path else None
+        clim_fn = next(
+            (
+                item.get("filenames")
+                for item in self.inference_cfg.get("streams", [])
+                if item.get("name") == stream
+            ),
+            None,
+        )
+        if isinstance(clim_fn, oc.ListConfig) and len(clim_fn) == 1:
+            climatology_partial_filename = clim_fn[0]
+        else:
+            _logger.warning(
+                f"Many source filenames found for stream {stream} in model config."
+                " In that case the climatology filename should be specified"
+                " explicitly via 'climatology_path' in the evaluation config."
+            )
+            return None
+
+        clim_data_path = (
+            Path(clim_base_dir)
+            / "climatology"
+            / climatology_partial_filename.replace(".zarr", "_climatology.zarr")
+        )
+
+        if not clim_data_path.exists():
+            _logger.warning(
+                f"Climatology file {clim_data_path} does not exist or configuration is invalid."
+                " Setting climatology to NaN."
+                " Please check that the path is correct and that the file exists."
+            )
+            return None
+        else:
+            _logger.info(f"Using climatology file: {clim_data_path}")
+
+        return str(clim_data_path)
 
     def get_channels(self, stream: str) -> list[str]:
         """

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -1098,7 +1098,7 @@ class Scores:
             for k in range(n_categories):
                 rps_sum = rps_sum + ((p_cat <= k).astype(float) - (gt_cat <= k).astype(float)) ** 2
 
-        return (rps_sum / (n_categories-1)).mean(self._agg_dims)
+        return (rps_sum / (n_categories - 1)).mean(self._agg_dims)
 
     def calc_rpss(
         self,


### PR DESCRIPTION
## Description

With this PR we can:

1) Explicitly give the climatology filenames through the evaluation config.
2) If the user do not give explicitly such path, the climatology filename will be found through the inference config of the models and the `data_path_aux `  from the `paths.yml`

## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/2331

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
