### PR TITLE
Cooldown masking rate

### DIFF
--- a/src/weathergen/datasets/batch.py
+++ b/src/weathergen/datasets/batch.py
@@ -273,6 +273,9 @@ class ModelBatch:
     # device of the tensors in the batch
     device: str | torch.device
 
+    # logical training step used while building the batch
+    train_step: int | None
+
     def __init__(
         self,
         streams: dict,
@@ -280,6 +283,7 @@ class ModelBatch:
         num_target_samples: int,
         output_offset,
         output_steps,
+        train_step: int | None = None,
     ) -> None:
         """ """
 
@@ -287,6 +291,7 @@ class ModelBatch:
         self.output_offset = output_offset
         self.output_steps = output_steps
         self.output_idxs = list(range(output_offset, output_steps))
+        self.train_step = train_step
 
         self.source_samples = BatchSamples(
             streams, num_source_samples, output_steps, self.output_idxs

--- a/src/weathergen/datasets/batch.py
+++ b/src/weathergen/datasets/batch.py
@@ -273,9 +273,6 @@ class ModelBatch:
     # device of the tensors in the batch
     device: str | torch.device
 
-    # logical training step used while building the batch
-    train_step: int | None
-
     def __init__(
         self,
         streams: dict,
@@ -283,7 +280,6 @@ class ModelBatch:
         num_target_samples: int,
         output_offset,
         output_steps,
-        train_step: int | None = None,
     ) -> None:
         """ """
 
@@ -291,7 +287,6 @@ class ModelBatch:
         self.output_offset = output_offset
         self.output_steps = output_steps
         self.output_idxs = list(range(output_offset, output_steps))
-        self.train_step = train_step
 
         self.source_samples = BatchSamples(
             streams, num_source_samples, output_steps, self.output_idxs

--- a/src/weathergen/datasets/masking.py
+++ b/src/weathergen/datasets/masking.py
@@ -254,7 +254,7 @@ class Masker:
                 0.0,
                 1.0,
             )
-            rate = rate * (1.0 - cool_down_progress)
+            rate = rate + (1.0 - rate) * cool_down_progress
         assert 0.0 <= rate <= 1.0, f"rate out of bounds: {rate}"
 
         return rate

--- a/src/weathergen/datasets/masking.py
+++ b/src/weathergen/datasets/masking.py
@@ -122,7 +122,14 @@ class Masker:
                                         specific to the masking strategy. See above.
     """
 
-    def __init__(self, healpix_level: int, stage: Stage, streams=None, mode_cfg=None):
+    def __init__(
+        self,
+        healpix_level: int,
+        stage: Stage,
+        streams=None,
+        mode_cfg=None,
+        total_train_steps: int | None = None,
+    ):
         self.rng = None
 
         self.mask_value = 0.0
@@ -133,6 +140,7 @@ class Masker:
         self.healpix_num_cells = 12 * (4**healpix_level)
 
         self.stage = stage
+        self.total_train_steps = total_train_steps
 
         # Build and store per-stream effective masking configs
         if streams is not None and mode_cfg is not None:
@@ -217,21 +225,37 @@ class Masker:
 
         return cfgs
 
-    def _get_sampling_rate(self, cfg):
+    def _get_sampling_rate(self, cfg, train_step: int = 0):
         """
         Get the sampling, if requested by sampling it itself
         """
 
         rate = cfg.get("rate", None)
         assert rate is not None, 'No sampling rate "rate" specified.'
+        rate = float(rate)
 
+        cool_down_steps = cfg.get("cool_down_steps", None)
         if cfg.get("rate_sampling", False):
             rate = np.clip(
                 np.abs(self.rng.normal(loc=rate, scale=1.0 / (2.5 * np.pi))),
                 0.01,
                 0.99,
             )
-        assert 0.0 <= rate <= 1.0, f"keep_rate out of bounds: {rate}"
+        elif self.stage == "train" and cool_down_steps:
+            assert self.total_train_steps is not None, (
+                "cool_down_steps requires total_train_steps to schedule the final "
+                "training steps."
+            )
+            assert self.total_train_steps > 0, "total_train_steps must be greater than zero."
+            cool_down_steps = min(cool_down_steps, self.total_train_steps)
+            cool_down_start = self.total_train_steps - cool_down_steps
+            cool_down_progress = np.clip(
+                (train_step - cool_down_start) / cool_down_steps,
+                0.0,
+                1.0,
+            )
+            rate = rate * (1.0 - cool_down_progress)
+        assert 0.0 <= rate <= 1.0, f"rate out of bounds: {rate}"
 
         return rate
 
@@ -346,6 +370,7 @@ class Masker:
         training_mode: str,
         num_cells: int,
         stream_info: dict,
+        train_step: int = 0,
     ) -> tuple[np.typing.NDArray, list[np.typing.NDArray], list[SampleMetaData]]:
         """
         Construct teacher/student keep masks for a stream.
@@ -390,6 +415,7 @@ class Masker:
                         masking_strategy_config=masking_config,
                         target_relationship_mask=("independent", None),
                         channel_names=source_channel_names,
+                        train_step=train_step,
                     )
 
                 # get all losses and flatten
@@ -444,6 +470,7 @@ class Masker:
                         masking_strategy_config=masking_config,
                         target_relationship_mask=(relationship, target_masks.get_mask(target_idx)),
                         channel_names=source_channel_names,
+                        train_step=train_step,
                     )
 
                 corr = target_idx
@@ -492,6 +519,7 @@ class Masker:
         masking_strategy_config: dict,
         target_relationship_mask: (str, np.typing.NDArray),
         channel_names: list[str] | None = None,
+        train_step: int = 0,
     ) -> (np.typing.NDArray, dict):
         """Get effective mask, combining with target mask if specified.
 
@@ -537,10 +565,12 @@ class Masker:
 
         # get mask
         mask, params = self._generate_cell_mask(
+            
             num_cells,
             strategy,
             masking_strategy_config,
             channel_names=channel_names,
+            train_step=train_step,
         )
 
         # handle cases where mask needs to be combined with target_mask
@@ -564,6 +594,7 @@ class Masker:
         strategy: str,
         masking_strategy_config: dict,
         channel_names: list[str] | None = None,
+        train_step: int = 0,
     ) -> (np.typing.NDArray, dict):
         """Generate a boolean keep mask at data healpix level (True = keep cell).
 
@@ -593,7 +624,7 @@ class Masker:
         # generate cell mask
 
         if strategy == "random":
-            keep_rate = self._get_sampling_rate(masking_strategy_config)
+            keep_rate = self._get_sampling_rate(masking_strategy_config, train_step)
             mask = self.rng.uniform(0, 1, num_cells) < keep_rate
 
         elif "forecast" in strategy or strategy == "causal":
@@ -604,7 +635,7 @@ class Masker:
 
         elif strategy == "healpix":
             # prepare healpix-based masking
-            keep_rate = self._get_sampling_rate(masking_strategy_config)
+            keep_rate = self._get_sampling_rate(masking_strategy_config, train_step)
             hl_mask, num_parent_cells, num_children_per_parent, num_parents_to_keep = (
                 self._prepare_healpix_based_masking(masking_strategy_config, keep_rate)
             )
@@ -623,7 +654,7 @@ class Masker:
         # Spatial healpix based cropping, select contiguous region
         elif strategy == "cropping_healpix":
             # prepare healpix-based masking
-            keep_rate = self._get_sampling_rate(masking_strategy_config)
+            keep_rate = self._get_sampling_rate(masking_strategy_config, train_step)
             hl_mask, num_parent_cells, num_children_per_parent, num_parents_to_keep = (
                 self._prepare_healpix_based_masking(masking_strategy_config, keep_rate)
             )

--- a/src/weathergen/datasets/masking.py
+++ b/src/weathergen/datasets/masking.py
@@ -21,6 +21,7 @@ from weathergen.datasets.noise_schedule import (
 )
 from weathergen.datasets.tokenizer_utils import precompute_cell_ids
 from weathergen.train.utils import Stage
+from weathergen.utils.distributed import is_root
 from weathergen.utils.utils import is_stream_diagnostic, is_stream_forcing
 
 logger = logging.getLogger(__name__)
@@ -225,7 +226,7 @@ class Masker:
 
         return cfgs
 
-    def _get_sampling_rate(self, cfg, train_step: int = 0):
+    def _get_sampling_rate(self, cfg, train_step: int = 0, keep_rate_cap: float = 1.0):
         """
         Get the sampling, if requested by sampling it itself
         """
@@ -254,7 +255,12 @@ class Masker:
                 0.0,
                 1.0,
             )
-            rate = rate + (1.0 - rate) * cool_down_progress
+            rate = rate + (keep_rate_cap - rate) * cool_down_progress
+            if is_root() and train_step % 50 == 0 and cool_down_progress > 0:
+                logger.info(
+                    f"Masking cooldown active: step={train_step}, "
+                    f"keep_rate={rate:.4f}, progress={cool_down_progress:.3f}"
+                )
         assert 0.0 <= rate <= 1.0, f"rate out of bounds: {rate}"
 
         return rate
@@ -464,6 +470,14 @@ class Masker:
                 if is_stream_diagnostic(stream_info, self.stage) or is_stream_dropped:
                     source_mask, mask_params = torch.zeros(num_cells, dtype=torch.bool), {}
                 else:
+                    target_cfg = list(target_cfgs.values())[target_cfg_idx]
+                    teacher_rate = float(
+                        target_cfg.get("masking_strategy_config", {}).get("rate", 1.0)
+                    )
+                    cool_down_teacher_rate_fraction = float(
+                        masking_config.get("cool_down_teacher_rate_fraction", 0.9)
+                    )
+                    keep_rate_cap = teacher_rate * cool_down_teacher_rate_fraction
                     source_mask, mask_params = self._get_mask(
                         num_cells=num_cells,
                         strategy=source_cfg.get("masking_strategy"),
@@ -471,6 +485,7 @@ class Masker:
                         target_relationship_mask=(relationship, target_masks.get_mask(target_idx)),
                         channel_names=source_channel_names,
                         train_step=train_step,
+                        keep_rate_cap=keep_rate_cap,
                     )
 
                 corr = target_idx
@@ -520,6 +535,7 @@ class Masker:
         target_relationship_mask: (str, np.typing.NDArray),
         channel_names: list[str] | None = None,
         train_step: int = 0,
+        keep_rate_cap: float = 1.0,
     ) -> (np.typing.NDArray, dict):
         """Get effective mask, combining with target mask if specified.
 
@@ -565,12 +581,12 @@ class Masker:
 
         # get mask
         mask, params = self._generate_cell_mask(
-            
             num_cells,
             strategy,
             masking_strategy_config,
             channel_names=channel_names,
             train_step=train_step,
+            keep_rate_cap=keep_rate_cap,
         )
 
         # handle cases where mask needs to be combined with target_mask
@@ -595,6 +611,7 @@ class Masker:
         masking_strategy_config: dict,
         channel_names: list[str] | None = None,
         train_step: int = 0,
+        keep_rate_cap: float = 1.0,
     ) -> (np.typing.NDArray, dict):
         """Generate a boolean keep mask at data healpix level (True = keep cell).
 
@@ -624,7 +641,7 @@ class Masker:
         # generate cell mask
 
         if strategy == "random":
-            keep_rate = self._get_sampling_rate(masking_strategy_config, train_step)
+            keep_rate = self._get_sampling_rate(masking_strategy_config, train_step, keep_rate_cap)
             mask = self.rng.uniform(0, 1, num_cells) < keep_rate
 
         elif "forecast" in strategy or strategy == "causal":
@@ -635,7 +652,7 @@ class Masker:
 
         elif strategy == "healpix":
             # prepare healpix-based masking
-            keep_rate = self._get_sampling_rate(masking_strategy_config, train_step)
+            keep_rate = self._get_sampling_rate(masking_strategy_config, train_step, keep_rate_cap)
             hl_mask, num_parent_cells, num_children_per_parent, num_parents_to_keep = (
                 self._prepare_healpix_based_masking(masking_strategy_config, keep_rate)
             )
@@ -654,7 +671,7 @@ class Masker:
         # Spatial healpix based cropping, select contiguous region
         elif strategy == "cropping_healpix":
             # prepare healpix-based masking
-            keep_rate = self._get_sampling_rate(masking_strategy_config, train_step)
+            keep_rate = self._get_sampling_rate(masking_strategy_config, train_step, keep_rate_cap)
             hl_mask, num_parent_cells, num_children_per_parent, num_parents_to_keep = (
                 self._prepare_healpix_based_masking(masking_strategy_config, keep_rate)
             )

--- a/src/weathergen/datasets/masking.py
+++ b/src/weathergen/datasets/masking.py
@@ -244,8 +244,7 @@ class Masker:
             )
         elif self.stage == "train" and cool_down_steps:
             assert self.total_train_steps is not None, (
-                "cool_down_steps requires total_train_steps to schedule the final "
-                "training steps."
+                "cool_down_steps requires total_train_steps to schedule the final training steps."
             )
             assert self.total_train_steps > 0, "total_train_steps must be greater than zero."
             cool_down_steps = min(cool_down_steps, self.total_train_steps)

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -168,6 +168,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         self.data_loader_rng_seed = rs if rs > nw else rs * 97
 
         self.rng = None
+        self.train_step = 0
 
 
     def check_samples(self, fsm: int):

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -102,7 +102,6 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         # initialise healpix
         self.healpix_level = cf.healpix_level
         self.num_healpix_cells = 12 * 4**self.healpix_level
-        self.tokenizer = TokenizerMasking(cf.healpix_level, self.masker)
 
         forecast_cfg = FORECAST_DEFAULTS | OmegaConf.to_object(mode_cfg.get("forecast", {}))
         self.output_offset = forecast_cfg["offset"]
@@ -149,6 +148,18 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         # check samples per mini epoch
         self.samples_per_mini_epoch = mode_cfg.samples_per_mini_epoch
         self.check_samples(self._get_fsm())
+        if stage == "train":
+            self.total_train_steps = int((self.len * mode_cfg.num_mini_epochs) / self.batch_size)
+        else:
+            self.total_train_steps = None
+        self.masker = Masker(
+            cf.healpix_level,
+            stage,
+            self.streams,
+            self.mode_cfg,
+            total_train_steps=self.total_train_steps,
+        )
+        self.tokenizer = TokenizerMasking(cf.healpix_level, self.masker)
         self.streams_datasets = self._init_stream_datasets(cf)
 
         # RNG seed setup

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -102,7 +102,6 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         # initialise healpix
         self.healpix_level = cf.healpix_level
         self.num_healpix_cells = 12 * 4**self.healpix_level
-        self.masker = Masker(cf.healpix_level, stage, self.streams, self.mode_cfg)
         self.tokenizer = TokenizerMasking(cf.healpix_level, self.masker)
 
         forecast_cfg = FORECAST_DEFAULTS | OmegaConf.to_object(mode_cfg.get("forecast", {}))
@@ -608,7 +607,7 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
 
         return (input_data, output_data)
 
-    def _get_source_target_masks(self, training_mode):
+    def _get_source_target_masks(self, training_mode, train_step: int):
         """
         Generate source and target masks for all streams.
         """
@@ -619,6 +618,7 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                 training_mode,
                 self.num_healpix_cells,
                 stream_info,
+                train_step,
             )
             # identical for all streams
             num_target_samples = len(masks[stream_info["name"]][0])
@@ -645,7 +645,7 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
 
         return batch
 
-    def _get_batch(self, idx: int, num_forecast_steps: int):
+    def _get_batch(self, idx: int, num_forecast_steps: int, train_step: int):
         """
         Assemble a batch using the sample corresponding to idx
         """
@@ -655,7 +655,9 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
         target_cfgs = self.mode_cfg.get("target_input", {})
 
         # get/coordinate masks
-        masks_streams, num_source_samples, num_target_samples = self._get_source_target_masks(mode)
+        masks_streams, num_source_samples, num_target_samples = self._get_source_target_masks(
+            mode, train_step
+        )
 
         source_select, target_select = [], []
         if "masking" in mode:
@@ -676,6 +678,7 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
             num_target_samples,
             self.output_offset,
             num_output_steps,
+            train_step,
         )
 
         # for all streams
@@ -812,7 +815,11 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
         # idx_raw is used to index into the dataset; the decoupling is needed
         # since there are empty batches
         idx_raw = iter_start
+        worker_info = torch.utils.data.get_worker_info()
+        train_step_offset = worker_info.id if worker_info is not None else 0
+        train_step_stride = worker_info.num_workers if worker_info is not None else 1
         for i, _bidx in enumerate(range(iter_start, iter_end, self.batch_size)):
+            train_step = self.train_step + i * train_step_stride + train_step_offset
             # num_forecast_steps needs to be constant per batch
             # (amortized through data parallel training)
             num_forecast_steps = perms_num_forecast_steps[i]
@@ -823,7 +830,7 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                 idx: TIndex = perms[idx_raw % perms.shape[0]]
                 idx_raw += 1
 
-                batch = self._get_batch(idx, num_forecast_steps)
+                batch = self._get_batch(idx, num_forecast_steps, train_step)
 
                 # ensure the batch is valid, i.e. not completely empty and no NaN values
                 # student teacher has no classical targets

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -171,7 +171,6 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         self.rng = None
         self.train_step = 0
 
-
     def check_samples(self, fsm: int):
         """Check if samples_per_mini_epoch is suitable
         Repeated both to initialise the MultiStreamDataSampler and for each mini epoch"""

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -678,7 +678,6 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
             num_target_samples,
             self.output_offset,
             num_output_steps,
-            train_step,
         )
 
         # for all streams

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -158,6 +158,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
 
         self.rng = None
 
+
     def check_samples(self, fsm: int):
         """Check if samples_per_mini_epoch is suitable
         Repeated both to initialise the MultiStreamDataSampler and for each mini epoch"""

--- a/src/weathergen/datasets/tokenizer_masking.py
+++ b/src/weathergen/datasets/tokenizer_masking.py
@@ -84,11 +84,14 @@ class TokenizerMasking(Tokenizer):
         training_mode: str,
         num_cells: int,
         stream_info: dict,
+        train_step: int = 0,
     ) -> tuple[np.typing.NDArray, list[np.typing.NDArray], list[SampleMetaData]]:
         """
         Create masks for samples
         """
-        return self.masker.build_samples_for_stream(training_mode, num_cells, stream_info)
+        return self.masker.build_samples_for_stream(
+            training_mode, num_cells, stream_info, train_step
+        )
 
     def cell_to_token_mask(self, idxs_cells, idxs_cells_lens, mask):
         """ """

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -457,6 +457,7 @@ class Trainer(TrainerBase):
 
         apply_fct_to_blocks(self.model, cf.freeze_modules, set_to_eval)
 
+        self.dataset.train_step = self.cf.general.istep
         dataset_iter = iter(self.data_loader)
 
         self.optimizer.zero_grad()

--- a/src/weathergen/utils/plot_training.py
+++ b/src/weathergen/utils/plot_training.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
+import polars as pl
 import yaml
 
 import weathergen.common.config as config
@@ -112,11 +113,11 @@ def _check_run_id_dict(run_id_dict: dict) -> bool:
         return False
 
     for k, v in run_id_dict.items():
-        if not isinstance(k, str) or not isinstance(v, list) or len(v) != 2:
+        if not isinstance(k, str) or not isinstance(v, list) or len(v) not in (2, 3):
             raise argparse.ArgumentTypeError(
                 (
-                    "Each key must be a string and",
-                    f" each value must be a list of [job_id, experiment_name], but got: {k}: {v}",
+                    "Each key must be a string and each value must be a list of",
+                    f" [job_id, experiment_name(, x_offset)], but got: {k}: {v}",
                 )
             )
 
@@ -181,7 +182,10 @@ def _read_yaml_config(yaml_file_path):
     for k, v in config_dict_temp.items():
         assert isinstance(v["slurm_id"], int), "slurm_id has to be int."
         assert isinstance(v["description"], str), "description has to be str."
-        config_dict[k] = [v["slurm_id"], v["description"]]
+        # optional x-offset (in samples), e.g. to align a continued run with its first segment
+        x_offset = v.get("x_offset", 0)
+        assert isinstance(x_offset, int), "x_offset has to be int."
+        config_dict[k] = [v["slurm_id"], v["description"], x_offset]
 
     # Validate the structure: {run_id: [job_id, experiment_name]}
     _check_run_id_dict(config_dict)
@@ -848,6 +852,19 @@ def plot_train(args=None):
         TrainLogger.read(run_id, model_path=model_base_dir, cols_patterns=streams)
         for run_id in runs_ids
     ]
+
+    # apply per-run x-offsets so continued runs align with their first segment
+    for run_data in runs_data:
+        run_cfg = runs_ids[run_data.run_id]
+        x_offset = run_cfg[2] if len(run_cfg) > 2 else 0
+        if x_offset:
+            for mode in ("train", "val", "system"):
+                df = getattr(run_data, mode)
+                if df is None or df.is_empty():
+                    continue
+                cols = [c for c in df.columns if "samples" in c]
+                if cols:
+                    setattr(run_data, mode, df.with_columns([pl.col(c) + x_offset for c in cols]))
 
     # determine which runs are still alive (as a process, though they might hang internally)
     ret = subprocess.run(["squeue"], capture_output=True)


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->
Adding a masking-rate cooldown for pre-training: the student's keep rate increases linearly from its base value (`rate`) to `cool_down_teacher_rate_fraction × teacher rate` over the final `cool_down_steps` of training. With `cool_down_teacher_rate_fraction ` < 1, the student always sees slightly less data than the teacher. Requires the total number of training steps to be known. To enable the masking cooldown, add the following to `masking_strategy_config`:

```
masking_strategy_config:
  rate: 0.2 # Base value
  cool_down_steps: 10000 # cooldown over the last 10000 steps of training
  cool_down_teacher_rate_fraction: 0.7   # student increases to 0.7 x teacher rate
```

Main changes:
* `masking.py` / `tokenizer_masking.py`: linear cool down schedule of the students keep rate, limited to the teacher-rate fraction.
* `multi_stream_data_sampler.py`: fixes the initialization order so the masker receives the current training step for the schedule.
* (`plot_training.py`: adds an optional `x_offset` per run in the plot config, used to align continued runs in the analysis plots for this issue.)

In the [HedgeDoc](https://gitlab.jsc.fz-juelich.de/hedgedoc/06WLQYYnTpStAw-5uhIWHQ) the results for cooldown of the masking rate can be found.

## Issue Number

Closes #2328 

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
