### PR TITLE
adjust check_samples function

### DIFF
--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -149,7 +149,6 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         max_index = self.index_range.end - (
             (  # max time units needed to make a forecast
                 self.time_step * (fsm + self.output_offset)  # translation due to forecasting
-                + self.len_timedelta  # length of forecasting window
             )
             // self.step_timedelta  # as number of indexs
         )
@@ -169,7 +168,7 @@ accomodate any number of samples or forecast steps"
 samples_per_mini_epoch reduced to {available_samples} to avoid repeating data. \
 Set repeat_data_in_mini_epoch to True if this is undesired."
                 )
-                self.samples_per_mini_epoch = max(available_samples - 1, 1)
+                self.samples_per_mini_epoch = max(available_samples, 1)
             else:
                 logger.info("Sufficient available samples in the time range specified")
         else:


### PR DESCRIPTION
## Description


This should fix the off by one error raised in #2357. Check the issue for the bug description.

With this bug fix, the following setting should yield single sample training. 

```
  start_date: 1979-01-01T00:00
  end_date: 1979-01-01T12:00
  ```
  
  ```
  forecast :
      time_step: 06:00:00
      num_steps: 1
      offset: 0
      policy: "fixed"
 ```

However, no checks for other edge cases involving `check_samples` were done. Please review with respect to potential edge cases where the fix breaks the code. 

Potential reviewers: @clessig @shmh40 @enssow @grassesi 



Closes #2357 

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->


## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
