### PR TITLE
Make regions stream-specific in evaluation package

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
@@ -541,7 +541,7 @@ def plot_data(
         "dpi_val": global_plotting_opts.get("dpi_val", 300),
         "fig_size": global_plotting_opts.get("fig_size"),
         "fps": global_plotting_opts.get("fps", 2),
-        "regions": global_plotting_opts.get("regions", ["global"]),
+        "regions": global_plotting_opts.get("regions", stream_cfg.get("regions", ["global"])),
         "log_x": global_plotting_opts.get("log_x", False),
         "log_y": global_plotting_opts.get("log_y", False),
         "n_bins": global_plotting_opts.get("n_bins", 50),
@@ -766,7 +766,6 @@ def plot_summary(cfg: dict, scores_dict: dict, summary_dir: Path):
     runs = cfg.run_ids
     metrics = cfg.evaluation.metrics
     print_summary = cfg.evaluation.get("print_summary", False)
-    regions = cfg.evaluation.get("regions", ["global"])
     # image_format / dpi_val etc. live at the top level of the config,
     # not under a "global_plotting_options" sub-key.
     plt_opt = cfg.get("global_plotting_options", cfg)
@@ -786,8 +785,8 @@ def plot_summary(cfg: dict, scores_dict: dict, summary_dir: Path):
     sc_plotter = ScoreCards(plot_cfg, summary_dir)
     br_plotter = BarPlots(plot_cfg, summary_dir)
     quantile_plotter = QuantilePlots(plot_cfg, summary_dir)
-    for region in regions:
-        for metric in metrics:
+    for metric in metrics:
+        for region in scores_dict[metric].keys():
             if eval_opt.get("summary_plots", False):
                 plot_metric_region(metric, region, runs, scores_dict, plotter, print_summary)
             if eval_opt.get("ratio_plots", False):

--- a/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
@@ -25,6 +25,13 @@ from omegaconf import DictConfig, OmegaConf, open_dict
 from weathergen.common.logger import init_loggers
 from weathergen.common.paths import _REPO_ROOT
 from weathergen.common.platform_env import get_platform_env
+from weathergen.metrics.mlflow_utils import (
+    MlFlowUpload,
+    get_or_create_mlflow_parent_run,
+    log_scores,
+    setup_mlflow,
+)
+
 from weathergen.evaluate.io.csv_reader import CsvReader
 from weathergen.evaluate.io.merge_reader import WeatherGenMergeReader
 from weathergen.evaluate.io.wegen_reader import (
@@ -43,12 +50,6 @@ from weathergen.evaluate.scores.score_orchestration import (
     metric_list_to_json,
 )
 from weathergen.evaluate.utils.dict_utils import merge, parse_metric_params, triple_nested_dict
-from weathergen.metrics.mlflow_utils import (
-    MlFlowUpload,
-    get_or_create_mlflow_parent_run,
-    log_scores,
-    setup_mlflow,
-)
 
 _DEFAULT_PLOT_DIR = _REPO_ROOT / "plots"
 
@@ -317,10 +318,8 @@ def evaluate_from_config(cfg: dict, mlflow_client: MlflowClient | None) -> None:
             run["max_workers"] = max_workers
 
         for stream in run.get("streams", {}):
-            regions = (
-                run.get("streams", {})
-                .get(stream, {})
-                .get("regions", cfg.evaluation.get("regions", ["global"]))
+            regions = cfg.evaluation.get(
+                "regions", run.get("streams", {}).get(stream, {}).get("regions", ["global"])
             )
             tasks.append(
                 {

--- a/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
@@ -25,13 +25,6 @@ from omegaconf import DictConfig, OmegaConf, open_dict
 from weathergen.common.logger import init_loggers
 from weathergen.common.paths import _REPO_ROOT
 from weathergen.common.platform_env import get_platform_env
-from weathergen.metrics.mlflow_utils import (
-    MlFlowUpload,
-    get_or_create_mlflow_parent_run,
-    log_scores,
-    setup_mlflow,
-)
-
 from weathergen.evaluate.io.csv_reader import CsvReader
 from weathergen.evaluate.io.merge_reader import WeatherGenMergeReader
 from weathergen.evaluate.io.wegen_reader import (
@@ -50,6 +43,12 @@ from weathergen.evaluate.scores.score_orchestration import (
     metric_list_to_json,
 )
 from weathergen.evaluate.utils.dict_utils import merge, parse_metric_params, triple_nested_dict
+from weathergen.metrics.mlflow_utils import (
+    MlFlowUpload,
+    get_or_create_mlflow_parent_run,
+    log_scores,
+    setup_mlflow,
+)
 
 _DEFAULT_PLOT_DIR = _REPO_ROOT / "plots"
 

--- a/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
@@ -25,6 +25,13 @@ from omegaconf import DictConfig, OmegaConf, open_dict
 from weathergen.common.logger import init_loggers
 from weathergen.common.paths import _REPO_ROOT
 from weathergen.common.platform_env import get_platform_env
+from weathergen.metrics.mlflow_utils import (
+    MlFlowUpload,
+    get_or_create_mlflow_parent_run,
+    log_scores,
+    setup_mlflow,
+)
+
 from weathergen.evaluate.io.csv_reader import CsvReader
 from weathergen.evaluate.io.merge_reader import WeatherGenMergeReader
 from weathergen.evaluate.io.wegen_reader import (
@@ -43,12 +50,6 @@ from weathergen.evaluate.scores.score_orchestration import (
     metric_list_to_json,
 )
 from weathergen.evaluate.utils.dict_utils import merge, parse_metric_params, triple_nested_dict
-from weathergen.metrics.mlflow_utils import (
-    MlFlowUpload,
-    get_or_create_mlflow_parent_run,
-    log_scores,
-    setup_mlflow,
-)
 
 _DEFAULT_PLOT_DIR = _REPO_ROOT / "plots"
 
@@ -298,7 +299,6 @@ def evaluate_from_config(cfg: dict, mlflow_client: MlflowClient | None) -> None:
     private_paths = cfg.get("private_paths")
     summary_dir = Path(cfg.evaluation.get("summary_dir", _DEFAULT_PLOT_DIR))
     metrics = cfg.evaluation.metrics
-    regions = cfg.evaluation.get("regions", ["global"])
     plot_score_maps = cfg.evaluation.get("plot_score_maps", False)
     global_plotting_opts = cfg.get("global_plotting_options", {})
     default_streams = cfg.get("default_streams", {})
@@ -318,6 +318,11 @@ def evaluate_from_config(cfg: dict, mlflow_client: MlflowClient | None) -> None:
             run["max_workers"] = max_workers
 
         for stream in run.get("streams", {}):
+            regions = (
+                run.get("streams", {})
+                .get(stream, {})
+                .get("regions", cfg.evaluation.get("regions", ["global"]))
+            )
             tasks.append(
                 {
                     "run_id": run_id,

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -111,9 +111,9 @@ class EmbeddingEngine(torch.nn.Module):
 
         # if the assert is hit, max_number_tokens_local_per_cell in config needs to be increased
         max_tokens = self.cf.get("ae_local_max_tokens_per_cell", 64)
-        assert (
-            batch.tokens_lens.flatten(0, 2).sum(0).max() <= max_tokens
-        ), "max number of tokens per cell for positional encoding exceeded."
+        assert batch.tokens_lens.flatten(0, 2).sum(0).max() <= max_tokens, (
+            "max number of tokens per cell for positional encoding exceeded."
+        )
         " Increase ae_local_max_tokens_per_cell in config."
 
         if batch.tokens_lens.shape[2] == 1:


### PR DESCRIPTION
## Description

This PR makes regions to be stream-specific. Instructions:

1) If regions are given under `global_plotting_options`, then for all the streams maps will be plotted for these regions.
2) If regions are given under `evaluation`, then for all the streams scores will be calculated for these regions.
3) If regions are given under a stream for example:

```
default_streams:
  ERA5:
    channels: ["t_850", "q_850", "2t", "q_500", "z_500"]
    regions: ["global", "nhem"]

```
then scores and maps are calculated and plotted respectively for these regions. However, for this to take place no regions should be given under `global_plotting_options` or `evaluation`. If those are given there, then 1) or 2) or both take place depending on which place the user has placed the regions list.

## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/2252

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [X] I have performed a self-review of my code
-   [X] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
