### PR TITLE
updating mse_ens and linting

### DIFF
--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -111,9 +111,9 @@ class EmbeddingEngine(torch.nn.Module):
 
         # if the assert is hit, max_number_tokens_local_per_cell in config needs to be increased
         max_tokens = self.cf.get("ae_local_max_tokens_per_cell", 64)
-        assert (
-            batch.tokens_lens.flatten(0, 2).sum(0).max() <= max_tokens
-        ), "max number of tokens per cell for positional encoding exceeded."
+        assert batch.tokens_lens.flatten(0, 2).sum(0).max() <= max_tokens, (
+            "max number of tokens per cell for positional encoding exceeded."
+        )
         " Increase ae_local_max_tokens_per_cell in config."
 
         if batch.tokens_lens.shape[2] == 1:

--- a/src/weathergen/train/loss_modules/loss_functions.py
+++ b/src/weathergen/train/loss_modules/loss_functions.py
@@ -86,23 +86,15 @@ def mse_ens(
     weights_channels : shape (num_channels,)  or None
     weights_points   : shape (num_data_points,) or None
     """
-    mask_nan = ~torch.isnan(target)
-    t = torch.where(mask_nan, target, torch.zeros_like(target))
-    p = torch.where(mask_nan.unsqueeze(0), pred, torch.zeros_like(pred))
-
     if use_ensemble_mean:
-        # MSE( target, mean_over_members(pred) )
-        diff_sq = (t - p.mean(0)).pow(2)  # [num_data_points, num_channels]
-    else:
-        # mean_over_members( MSE(target, member) )
-        diff_sq = (t.unsqueeze(0) - p).pow(2).mean(0)  # [num_data_points, num_channels]
+        # lp_loss collapses the ensemble via .mean(0) before computing MSE
+        return mse(target, pred, weights_channels, weights_points)
 
-    if weights_points is not None:
-        diff_sq = (diff_sq.transpose(1, 0) * weights_points).transpose(1, 0)
-
-    loss_chs = diff_sq.mean(0)  # [num_channels]
-    loss = torch.mean(loss_chs * weights_channels if weights_channels is not None else loss_chs)
-    return loss, loss_chs
+    losses, losses_chs = zip(
+        *[mse(target, member.unsqueeze(0), weights_channels, weights_points) for member in pred],
+        strict=False,
+    )
+    return torch.stack(list(losses)).mean(), torch.stack(list(losses_chs)).mean(0)
 
 
 def kernel_crps(

--- a/src/weathergen/train/loss_modules/loss_functions.py
+++ b/src/weathergen/train/loss_modules/loss_functions.py
@@ -62,9 +62,47 @@ def stats_normalized_erf(target, ens, mu, stddev):
     return torch.mean(d * d)  # + torch.mean( torch.sqrt( stddev) )
 
 
-def mse_ens(target, ens, mu, stddev):
-    mse_loss = torch.nn.functional.mse_loss
-    return torch.stack([mse_loss(target, mem) for mem in ens], 0).mean()
+def mse_ens(
+    target: torch.Tensor,
+    pred: torch.Tensor,
+    weights_channels: torch.Tensor | None,
+    weights_points: torch.Tensor | None,
+    use_ensemble_mean: bool = False,
+):
+    """
+    MSE loss for ensemble predictions, with two modes:
+
+    use_ensemble_mean=False (default):
+        Mean of per-member MSE — equivalent to mean(mse(target, mem) for mem in ens).
+        Penalises every member independently; each member is pushed toward the target.
+
+    use_ensemble_mean=True:
+        MSE of the ensemble mean against the target.
+        Collapses the ensemble to a single prediction before comparing, which
+        ignores spread and rewards a well-calibrated ensemble mean.
+
+    target : shape (num_data_points, num_channels)
+    pred   : shape (ens_dim, num_data_points, num_channels)
+    weights_channels : shape (num_channels,)  or None
+    weights_points   : shape (num_data_points,) or None
+    """
+    mask_nan = ~torch.isnan(target)
+    t = torch.where(mask_nan, target, torch.zeros_like(target))
+    p = torch.where(mask_nan.unsqueeze(0), pred, torch.zeros_like(pred))
+
+    if use_ensemble_mean:
+        # MSE( target, mean_over_members(pred) )
+        diff_sq = (t - p.mean(0)).pow(2)  # [num_data_points, num_channels]
+    else:
+        # mean_over_members( MSE(target, member) )
+        diff_sq = (t.unsqueeze(0) - p).pow(2).mean(0)  # [num_data_points, num_channels]
+
+    if weights_points is not None:
+        diff_sq = (diff_sq.transpose(1, 0) * weights_points).transpose(1, 0)
+
+    loss_chs = diff_sq.mean(0)  # [num_channels]
+    loss = torch.mean(loss_chs * weights_channels if weights_channels is not None else loss_chs)
+    return loss, loss_chs
 
 
 def kernel_crps(


### PR DESCRIPTION
## Description

Implemented mse_ens with the updated signature with 2 options:
1- applying mse on each ensemble member vs target and then take the mean (default)
2- calculating the mean of all ensembles and then calculate the loss (configurable)

The default one to be decided after discussion

## Issue Number
Closes #2250


Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [X] I have performed a self-review of my code
-   [X] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
