### PR TITLE
Stream-specific regions in eval_config.yml

### DIFF
--- a/config/evaluate/eval_config.yml
+++ b/config/evaluate/eval_config.yml
@@ -2,7 +2,7 @@
 # NB. global options apply to all run_ids 
 
 #global_plotting_options:
-#  regions: ["europe", "global"]
+#  regions: ["europe", "global"] # Have regions here, if you want for them to apply to all streams (map generation)
 #  image_format : "png" #options: "png", "pdf", "svg", "eps", "jpg" ..
 #  animation_format: "gif" #options: "mp4", "gif"
 #  dpi_val : 300
@@ -30,7 +30,7 @@
 
 evaluation:
   metrics  : ["rmse", "mae"]
-  regions: ["global", "nhem"]
+  # regions: ["global", "nhem"] # Have regions here, if you want for them to apply to all streams (scores calculation)
   summary_plots : true
   ratio_plots : false
   heat_maps : false
@@ -48,6 +48,7 @@ evaluation:
 
 default_streams:
   ERA5:
+    regions: ["global"]
     channels: ["2t", "10u"] #, "10v", "z_500", "t_850", "u_850", "v_850", "q_850", ]
     evaluation:
       forecast_step: "all"
@@ -63,6 +64,7 @@ default_streams:
       plot_histograms: true
       plot_animations: true
   CERRA:
+    regions: ["europe"]
     channels: ["z_500", "t_850", "u_850"] #, "blah"]
     evaluation:
       forecast_step: "all"

--- a/config/evaluate/eval_config_default.yml
+++ b/config/evaluate/eval_config_default.yml
@@ -1,7 +1,7 @@
 #optional: if commented out all is taken care of by the default settings
 # NB. global options apply to all run_ids
 #global_plotting_options:
-#  regions: ["europe", "global"]
+#  regions: ["europe", "global"] # Have regions here, if you want for them to apply to all streams (map generation)
 #  image_format : "png" #options: "png", "pdf", "svg", "eps", "jpg" ..
 #  animation_format: "gif" #options: "mp4", "gif"
 #  dpi_val : 300
@@ -25,7 +25,7 @@
 
 evaluation:
   metrics: ["rmse", "mae"]
-  regions: ["global", "nhem"]
+  # regions: ["global", "nhem"] # Have regions here, if you want for them to apply to all streams (scores calculation)
   summary_plots : true
   ratio_plots : false
   heat_maps : false
@@ -42,6 +42,7 @@ evaluation:
 
 default_streams:
   ERA5:
+    regions: ["global"]
     channels: ["2t", "10u", "10v", "z_500", "t_850", "u_850", "v_850", "q_850"]
     evaluation:
       forecast_step: "all"
@@ -54,6 +55,7 @@ default_streams:
       plot_histograms: false
       plot_animations: true
   CERRA:
+    regions: ["europe"]
     channels: ["z_500", "t_850", "u_850"] #, "blah"]
     evaluation:
       forecast_step: "all"


### PR DESCRIPTION
Commented out regions in global plotting options and evaluation sections. Include them under streams.

## Description

Make regions to be stream specific.


## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/2375

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
