### PR TITLE
Fixes for using forecast offset=1

### DIFF
--- a/config/streams/era5_1deg_forecasting/era5.yml
+++ b/config/streams/era5_1deg_forecasting/era5.yml
@@ -13,7 +13,7 @@ ERA5 :
   stream_id : 0
   source_exclude : ['w_', 'skt', 'tcw', 'cp', 'tp']
   target_exclude : ['w_', 'slor', 'sdor', 'tcw', 'cp', 'tp']
-  geoinfo_channels : ['lsm', 'slor', 'sdor', 'insolation', 'cos_local_time', 'sin_local_time', 'cos_julian_day', 'sin_julian_day']
+  # geoinfo_channels : ['lsm', 'slor', 'sdor', 'insolation', 'cos_local_time', 'sin_local_time', 'cos_julian_day', 'sin_julian_day']
   loss_weight : 1.
   location_weight : cosine_latitude
   masking_rate : 0.6

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
@@ -507,6 +507,7 @@ def _plot_all_samples(
 
     plotter.clean_data_selection()
 
+
 def plot_data(
     reader: Reader,
     stream: str,

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
@@ -508,6 +508,21 @@ def _plot_all_samples(
     plotter.clean_data_selection()
 
 
+def _plot_distribution_analysis(
+    plotter_cfg: dict,
+    output_basedir: str,
+    stream: str,
+    fstep: int | str,
+    tars: xr.DataArray,
+    preds: xr.DataArray,
+    channels: list[str],
+) -> None:
+    """Aggregate-over-samples distribution histogram for one fstep (loky worker)."""
+    matplotlib.use("Agg")
+    plotter = Plotter(plotter_cfg, Path(output_basedir), stream)
+    plotter.create_distribution_histograms(tars, preds, channels, fstep, stream)
+
+
 def plot_data(
     reader: Reader,
     stream: str,

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
@@ -507,22 +507,6 @@ def _plot_all_samples(
 
     plotter.clean_data_selection()
 
-
-def _plot_distribution_analysis(
-    plotter_cfg: dict,
-    output_basedir: str,
-    stream: str,
-    fstep: int | str,
-    tars: xr.DataArray,
-    preds: xr.DataArray,
-    channels: list[str],
-) -> None:
-    """Aggregate-over-samples distribution histogram for one fstep (loky worker)."""
-    matplotlib.use("Agg")
-    plotter = Plotter(plotter_cfg, Path(output_basedir), stream)
-    plotter.create_distribution_histograms(tars, preds, channels, fstep, stream)
-
-
 def plot_data(
     reader: Reader,
     stream: str,

--- a/src/weathergen/train/loss_modules/loss_module_latent_diffusion.py
+++ b/src/weathergen/train/loss_modules/loss_module_latent_diffusion.py
@@ -94,8 +94,9 @@ class LossLatentDiffusion(LossModuleBase):
             for _, _, loss_fct_name in self.loss_fcts
         }
 
-        pred_tokens_all = [pl["latent_state"].z_pre_norm for pl in preds.latent if pl]
+        pred_tokens_all = [pl["latent_state"].z_pre_norm for pl in preds.latent if ("latent_state" in pl)]
         target_tokens_all = [latent["diffusion_latent"] for latent in targets.latent if latent]
+        assert len(pred_tokens_all) == len(target_tokens_all), "Mismatch between predicted and target token lengths"
 
         eta = torch.tensor(
             [targets.aux_outputs["noise_level_rn"]], device=self.device, dtype=torch.float32

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -72,6 +72,9 @@ def _expand_targets_to_match_preds(preds, targets_and_auxs: dict) -> None:
     """
     n_pred = len(preds.physical)
     for t_aux in targets_and_auxs.values():
+        # if the first entry is None (e.g. when forecast_offset > 0), then remove it
+        if not t_aux.physical[0]:
+            t_aux.physical = t_aux.physical[1:]
         n_tgt = len(t_aux.physical)
         if n_tgt == n_pred or n_tgt == 0:
             continue

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -63,6 +63,8 @@ def write_output(
 
     # TODO Maybe stopping at forecast_steps explained #1657
     for t_idx in timestep_idxs:
+        if cf.training_config.forecast.offset == 1:
+            t_idx = t_idx - 1
         preds_all += [[]]
         targets_all += [[]]
         targets_coords_all += [[]]


### PR DESCRIPTION
## Description

The code in its curent state is written for forecast offset=0. When this is set to one, training and inference fail. 

This PR introduces fixes for this


## Issue Number

No issue 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
