### PR TITLE
Score animations with fixed colorbar

### DIFF
--- a/config/evaluate/eval_config.yml
+++ b/config/evaluate/eval_config.yml
@@ -5,6 +5,8 @@
 #  regions: ["europe", "global"] # Have regions here, if you want for them to apply to all streams (map generation)
 #  image_format : "png" #options: "png", "pdf", "svg", "eps", "jpg" ..
 #  animation_format: "gif" #options: "mp4", "gif"
+#  log_colorbar: true
+
 #  dpi_val : 300
 #  fps: 2
 #  n_bins: 50 #number of bins for histograms. 
@@ -36,7 +38,8 @@ evaluation:
   heat_maps : false
   summary_dir: "./plots/"
   plot_ensemble: "members" #supported: false, "std", "minmax", "members"
-  plot_score_maps: false #plot scores on a 2D maps. it slows down score computation 
+  plot_score_maps: false #plot scores on a 2D maps. it slows down score computation
+  plot_score_animations: false #plot animations of score maps across forecast steps. it slows down score computation
   print_summary: false #print out score values on screen. it can be verbose
   log_scale: false
   add_grid: false

--- a/config/evaluate/eval_config_default.yml
+++ b/config/evaluate/eval_config_default.yml
@@ -31,7 +31,8 @@ evaluation:
   heat_maps : false
   summary_dir: "./plots/"
   plot_ensemble: "members" #supported: false, "std", "minmax", "members"
-  plot_score_maps: false #plot scores on a 2D maps. it slows down score computation 
+  plot_score_maps: false #plot scores on a 2D maps. it slows down score computation
+  plot_score_animations: false #plot animations of score maps across forecast steps. it slows down score computation
   print_summary: false #print out score values on screen. it can be verbose
   log_scale: false
   add_grid: false

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
@@ -278,27 +278,25 @@ def _build_single_animation(
     stream: str,
     region: str | None,
     var: str,
-    sa: object,
+    sample: object,
     fsteps: list,
     image_format: str,
     animation_format: str,
     duration_ms: int,
     prefix: str = "map",
-    score_animation: bool = False,
 ) -> list[str]:
     """Build one animation for a single (region, sample/ens, variable) combination.
 
     All work is I/O + Pillow — no matplotlib state involved.
 
-    When ``score_animation=False`` (default) the function scans ``output_dir`` for
-    per-sample map/histogram frames whose filenames follow::
+    The function scans ``output_dir`` for per-sample map/histogram frames whose filenames follow:
 
-        {prefix}_{run_id}_{tag}_{sa}_{valid_time}_{stream}_{region}_{var}_{fstep:03d}
+        {prefix}_{run_id}_{tag}_{sample}_{valid_time}_{stream}_{region}_{var}_{fstep:03d}
 
     When ``score_animation=True`` filenames are constructed deterministically because
     the fstep is embedded in the tag (``score_maps_{metric}_fstep_{N}``) rather
     than being a zero-padded suffix.  Pass ``tag="score_maps_{metric}"`` and
-    ``sa`` as the ensemble value (or ``None`` for no ensemble).
+    ``sample`` as the ensemble value (or ``None`` for no ensemble).
 
     Returns the list of source frame paths assembled into the animation, or an
     empty list when no (or fewer than two for score maps) frames were found.
@@ -307,8 +305,8 @@ def _build_single_animation(
         return []
 
     region_part = region if region else ""
-    if sa is not None:
-        head = "_".join(filter(None, [prefix, run_id, tag, str(sa)]))
+    if sample is not None:
+        head = "_".join(filter(None, [prefix, run_id, tag, str(sample)]))
     else:
         head = "_".join(filter(None, [prefix, run_id, tag]))
     tail = "_".join(filter(None, [stream, region_part, var]))
@@ -324,8 +322,8 @@ def _build_single_animation(
     )
     if not image_paths:
         return []
-    if sa is not None:
-        anim_parts = ["animation", run_id, tag, str(sa), stream]
+    if sample is not None:
+        anim_parts = ["animation", run_id, tag, str(sample), stream]
     else:
         anim_parts = ["animation", run_id, tag, stream]
     if region:
@@ -395,7 +393,7 @@ def _dispatch_animations(
             "stream": plotter.stream,
             "region": region,
             "var": var,
-            "sa": sa,
+            "sample": sample,
             "fsteps": list(fsteps),
             "image_format": plotter.image_format,
             "animation_format": plotter.animation_format,
@@ -404,7 +402,7 @@ def _dispatch_animations(
         }
         for prefix, output_dir in prefixes
         for region in plotter.regions
-        for sa in samples
+        for sample in samples
         for var in variables
     ]
 
@@ -447,7 +445,7 @@ def _dispatch_score_map_animations(
             stream=stream,
             region=region,
             var=var,
-            sa=None,
+            sample=None,
             fsteps=list(fsteps),
             image_format=plotter_cfg["image_format"],
             animation_format=plotter_cfg["animation_format"],

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
@@ -25,6 +25,7 @@ from weathergen.evaluate.io.data.io_orchestration import dispatch_parallel, get_
 from weathergen.evaluate.io.io_reader import Reader, ReaderOutput
 from weathergen.evaluate.plotting.bar_plots import BarPlots
 from weathergen.evaluate.plotting.line_plots import LinePlots
+from weathergen.evaluate.plotting.plot_orchestration_utils import _compute_ranges, _compute_scores
 from weathergen.evaluate.plotting.plot_utils import (
     bar_plot_metric_region,
     heat_maps_metric_region,
@@ -36,11 +37,8 @@ from weathergen.evaluate.plotting.plot_utils import (
 from weathergen.evaluate.plotting.plotter import Plotter
 from weathergen.evaluate.plotting.quantile_plots import QuantilePlots
 from weathergen.evaluate.plotting.score_cards import ScoreCards
-from weathergen.evaluate.scores.score import VerifiedData, get_score
-from weathergen.evaluate.scores.score_orchestration import get_next_fstep_data
 from weathergen.evaluate.utils.array_utils import bias_ranges, common_ranges
 from weathergen.evaluate.utils.clim_utils import get_climatology
-from weathergen.evaluate.utils.regions import RegionBoundingBox
 
 _logger = logging.getLogger(__name__)
 
@@ -49,113 +47,14 @@ _logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def _compute_scores_for_fstep(
-    region: str,
-    fstep: int,
-    metric_names: list[str],
-    metric_params: list,
-    score_data: VerifiedData,
-    preds_r: xr.DataArray,
-) -> tuple[str, int, list, xr.DataArray, list[str]]:
-    """Compute scores for a single (region, fstep) pair (parallelisable worker).
-
-    Returns ``(region, fstep, score_results, preds_r, metric_names)``.
-    """
-    score_results: list[xr.DataArray | None] = [
-        get_score(score_data, m, agg_dims="sample", parameters=p)
-        for m, p in zip(metric_names, metric_params, strict=False)
-    ]
-    return region, fstep, score_results, preds_r, metric_names
-
-
-def _compute_scores_and_ranges(
-    regions: list[str],
-    metrics_dict: dict,
-    fsteps: list,
-    da_preds: dict,
-    da_tars: dict,
-    aligned_clim_data: dict | None,
-    n_workers: int | None = None,
-) -> tuple[dict, dict]:
-    """Compute scores for all (region, fstep) pairs and accumulate per-channel colour ranges.
-
-    Score computation is parallelised across (region, fstep) pairs; range accumulation
-    is done sequentially once all results are available.
-
-    Returns
-    -------
-    computed : dict[tuple, tuple]
-        ``{(region, fstep): (score_results, preds_r, metric_names)}``
-    score_ranges_dict : dict
-        ``{metric: {region: {channel: {'vmin': float, 'vmax': float}}}}``
-    """
-    # Build one task per (region, fstep) with pre-applied region masking.
-    tasks = []
-    for region in regions:
-        bbox = RegionBoundingBox.from_region_name(region)
-        metrics = metrics_dict[region]
-        metric_names = list(metrics.keys())
-        metric_params = list(metrics.values())
-        for fstep in fsteps:
-            tars_fs = da_tars[fstep]
-            preds_fs = da_preds[fstep]
-            preds_next, tars_next = get_next_fstep_data(fstep, da_preds, da_tars, fsteps)
-            climatology = aligned_clim_data[fstep] if aligned_clim_data else None
-            tars_r, preds_r, tars_next_r, preds_next_r = [
-                bbox.apply_mask(x) if x is not None else None
-                for x in (tars_fs, preds_fs, tars_next, preds_next)
-            ]
-            tasks.append(
-                dict(
-                    region=region,
-                    fstep=fstep,
-                    metric_names=metric_names,
-                    metric_params=metric_params,
-                    score_data=VerifiedData(
-                        preds_r, tars_r, preds_next_r, tars_next_r, climatology
-                    ),
-                    preds_r=preds_r,
-                )
-            )
-
-    # Compute scores in parallel across (region, fstep) pairs.
-    calls = [delayed(_compute_scores_for_fstep)(**t) for t in tasks]
-    raw_results = dispatch_parallel(
-        calls, n_workers=n_workers, backend="loky", desc="Score computation"
-    )
-
-    # Accumulate per-channel colour ranges from the completed results.
-    computed: dict[tuple, tuple] = {}
-    score_ranges_dict: dict = {}
-    for region, fstep, score_results, preds_r, metric_names in raw_results:
-        computed[(region, fstep)] = (score_results, preds_r, metric_names)
-        for metric, result in zip(metric_names, score_results, strict=False):
-            if result is None:
-                continue
-            score_ranges_dict.setdefault(metric, {}).setdefault(region, {})
-            for ch in result.coords["channel"].values:
-                vals = result.sel(channel=ch).values.flatten()
-                vals = vals[~np.isnan(vals)]
-                if vals.size == 0:
-                    continue
-                ch_key = str(ch)
-                vmin, vmax = float(vals.min()), float(vals.max())
-                prev = score_ranges_dict[metric][region].get(ch_key)
-                score_ranges_dict[metric][region][ch_key] = {
-                    "vmin": min(prev["vmin"], vmin) if prev else vmin,
-                    "vmax": max(prev["vmax"], vmax) if prev else vmax,
-                }
-
-    return computed, score_ranges_dict
-
-
-def plot_score_maps_per_stream(
+def run_score_map_pipeline(
     reader: Reader,
     stream: str,
     regions: list[str],
     metrics_dict: dict,
     output_data: "ReaderOutput | None" = None,
     global_plotting_options: dict | None = None,
+    plot_score_animations: bool = False,
 ) -> None:
     """Plot spatial score maps for all regions and forecast steps.
 
@@ -173,6 +72,8 @@ def plot_score_maps_per_stream(
         Pre-loaded data; when provided ``reader.get_data()`` is skipped.
     global_plotting_options : dict | None
         Global plotting options. These can be passed to the plotter and can be used to set options.
+    plot_score_animations : bool
+        Whether to build animations of score maps across forecast steps.
     """
     if not reader.is_gridded_data(stream):
         _logger.debug(f"RUN {reader.run_id} - {stream}: Skipping score maps (non-gridded data).")
@@ -220,7 +121,7 @@ def plot_score_maps_per_stream(
     output_basedir = str(reader.runplot_dir)
     run_id = reader.run_id
 
-    _computed, score_ranges_dict = _compute_scores_and_ranges(
+    _computed, raw_results = _compute_scores(
         regions,
         metrics_dict,
         fsteps,
@@ -229,10 +130,12 @@ def plot_score_maps_per_stream(
         aligned_clim_data,
         n_workers=n_plot_workers,
     )
+
+    score_ranges_dict = _compute_ranges(raw_results)
+
     fstep_tasks: list[dict] = []
     for region in regions:
         for fstep in fsteps:
-            score_results, preds_r, metric_names = _computed[(region, fstep)]
             fstep_tasks.append(
                 {
                     "plotter_cfg": plotter_cfg,
@@ -241,9 +144,7 @@ def plot_score_maps_per_stream(
                     "map_dir": str(map_dir),
                     "stream": stream,
                     "region": region,
-                    "preds": preds_r,
-                    "score_results": score_results,
-                    "metric_names": metric_names,
+                    "computed": _computed[(region, fstep)],
                     "fstep": fstep,
                     "run_id": run_id,
                 }
@@ -259,29 +160,19 @@ def plot_score_maps_per_stream(
     dispatch_parallel(calls, n_workers=n_plot_workers, backend="loky", desc=f"Score maps {stream}")
 
     # Derive variables and ens_values from the computed results.
-    all_metrics = list(score_ranges_dict.keys())
-    all_variables = sorted(
-        {
-            ch
-            for metric_dict in score_ranges_dict.values()
-            for region_dict in metric_dict.values()
-            for ch in region_dict
-        }
-    )
-    first_preds = next(iter(_computed.values()))[1]  # preds_r
-    ens_values = list(first_preds.coords["ens"].values) if "ens" in first_preds.dims else [None]
-    _dispatch_score_map_animations(
-        map_dir=map_dir,
-        plotter_cfg=plotter_cfg,
-        run_id=run_id,
-        stream=stream,
-        metrics=all_metrics,
-        regions=regions,
-        variables=all_variables,
-        ens_values=ens_values,
-        fsteps=fsteps,
-        n_workers=n_plot_workers,
-    )
+    if plot_score_animations:
+        _dispatch_score_map_animations(
+            map_dir=map_dir,
+            plotter_cfg=plotter_cfg,
+            run_id=run_id,
+            stream=stream,
+            metrics=list(dict.fromkeys(m for metrics in metrics_dict.values() for m in metrics)),
+            regions=regions,
+            variables=channels,
+            ens_values=list(ensemble) if ensemble else [None],
+            fsteps=fsteps,
+            n_workers=n_plot_workers,
+        )
 
 
 def _plot_score_maps_per_stream(
@@ -291,13 +182,13 @@ def _plot_score_maps_per_stream(
     map_dir: str,
     stream: str,
     region: str,
-    preds: xr.DataArray,
-    score_results: list,
-    metric_names: list[str],
+    computed: tuple[list, xr.DataArray, list[str]],
     fstep: int,
     run_id: str = "",
 ) -> None:
     """Plot 2D score maps for all metrics/channels for one (region, fstep)."""
+
+    score_results, preds, metric_names = computed
     valid = [(m, r) for m, r in zip(metric_names, score_results, strict=False) if r is not None]
     if not valid:
         return
@@ -323,9 +214,7 @@ def _plot_score_maps_per_stream(
     plot_tasks: list[dict] = []
     for metric in plot_metrics.coords["metric"].values:
         for ens_val in ens_values:
-            tag = f"score_maps_{metric}_fstep_{fstep}" + (
-                f"_ens_{ens_val}" if ens_val is not None else ""
-            )
+            tag = "score_maps" + (f"_ens_{ens_val}" if ens_val is not None else "") + f"_{metric}"
             for channel in plot_metrics.coords["channel"].values:
                 sel = {"metric": metric, "channel": channel}
                 if ens_val is not None:
@@ -345,6 +234,7 @@ def _plot_score_maps_per_stream(
                         "map_dir": str(map_dir),
                         "channel": str(channel),
                         "region": region,
+                        "fstep": fstep,
                         "tag": tag,
                         "title": title,
                     }
@@ -363,12 +253,14 @@ def _scatter_plot_single(
     map_dir: str,
     channel: str,
     region: str,
+    fstep: int,
     tag: str,
     title: str,
 ) -> None:
     """Plot a single score-map scatter plot (picklable for loky workers)."""
     matplotlib.use("Agg")
     plotter = Plotter(plotter_cfg, Path(output_basedir), stream)
+    plotter.update_data_selection({"sample": None, "stream": stream, "forecast_step": fstep})
     plotter.scatter_plot(
         data, Path(map_dir), channel, region, tag=tag, map_kwargs=scores_cfg, title=title
     )
@@ -414,45 +306,32 @@ def _build_single_animation(
     if not output_dir.is_dir():
         return []
 
-    if score_animation:
-        # Deterministic lookup: fstep is embedded in the full tag.
-        # tag = "score_maps_{metric}", sa = ens_val | None, var = channel.
-        image_paths: list[str] = []
-        for fstep in sorted(fsteps):
-            full_tag = f"{tag}_fstep_{fstep}"
-            if sa is not None:
-                full_tag += f"_ens_{sa}"
-            fname = f"map_{run_id}_{full_tag}_{stream}_{region}_{var}.{image_format}"
-            path = output_dir / fname
-            if path.exists():
-                image_paths.append(str(path))
-        if len(image_paths) < 2:
-            return []
-        ens_part = f"_ens_{sa}" if sa is not None else ""
-        anim_name = f"animation_{run_id}_{tag}{ens_part}_{stream}_{region}_{var}.{animation_format}"
-        out_path = str(output_dir / anim_name)
-    else:
-        # Directory scan: fstep is the zero-padded final element of the filename stem.
-        region_part = region if region else ""
+    region_part = region if region else ""
+    if sa is not None:
         head = "_".join(filter(None, [prefix, run_id, tag, str(sa)]))
-        tail = "_".join(filter(None, [stream, region_part, var]))
-        suffix = f".{image_format}"
-        fstep_strs = {str(f).zfill(3) for f in fsteps}
-        image_paths = sorted(
-            str(f)
-            for f in output_dir.iterdir()
-            if f.name.startswith(head + "_")
-            and f.name.endswith(suffix)
-            and f"_{tail}_" in f.name
-            and f.stem.rsplit("_", 1)[-1] in fstep_strs
-        )
-        if not image_paths:
-            return []
+    else:
+        head = "_".join(filter(None, [prefix, run_id, tag]))
+    tail = "_".join(filter(None, [stream, region_part, var]))
+    suffix = f".{image_format}"
+    fstep_strs = {str(f).zfill(3) for f in fsteps}
+    image_paths = sorted(
+        str(f)
+        for f in output_dir.iterdir()
+        if f.name.startswith(head + "_")
+        and f.name.endswith(suffix)
+        and f"_{tail}_" in f.name
+        and f.stem.rsplit("_", 1)[-1] in fstep_strs
+    )
+    if not image_paths:
+        return []
+    if sa is not None:
         anim_parts = ["animation", run_id, tag, str(sa), stream]
-        if region:
-            anim_parts.append(region)
-        anim_parts.append(var)
-        out_path = f"{output_dir / '_'.join(filter(None, anim_parts))}.{animation_format}"
+    else:
+        anim_parts = ["animation", run_id, tag, stream]
+    if region:
+        anim_parts.append(region)
+    anim_parts.append(var)
+    out_path = f"{output_dir / '_'.join(filter(None, anim_parts))}.{animation_format}"
 
     if animation_format.lower() == "mp4":
         frames = [imageio.imread(p) for p in image_paths]
@@ -564,11 +443,11 @@ def _dispatch_score_map_animations(
         dict(
             output_dir=map_dir,
             run_id=run_id,
-            tag=f"score_maps_{metric}",
+            tag="score_maps" + (f"_ens_{ens_val}" if ens_val is not None else "") + f"_{metric}",
             stream=stream,
             region=region,
             var=var,
-            sa=ens_val,
+            sa=None,
             fsteps=list(fsteps),
             image_format=plotter_cfg["image_format"],
             animation_format=plotter_cfg["animation_format"],

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
@@ -49,12 +49,113 @@ _logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
+def _compute_scores_for_fstep(
+    region: str,
+    fstep: int,
+    metric_names: list[str],
+    metric_params: list,
+    score_data: VerifiedData,
+    preds_r: xr.DataArray,
+) -> tuple[str, int, list, xr.DataArray, list[str]]:
+    """Compute scores for a single (region, fstep) pair (parallelisable worker).
+
+    Returns ``(region, fstep, score_results, preds_r, metric_names)``.
+    """
+    score_results: list[xr.DataArray | None] = [
+        get_score(score_data, m, agg_dims="sample", parameters=p)
+        for m, p in zip(metric_names, metric_params, strict=False)
+    ]
+    return region, fstep, score_results, preds_r, metric_names
+
+
+def _compute_scores_and_ranges(
+    regions: list[str],
+    metrics_dict: dict,
+    fsteps: list,
+    da_preds: dict,
+    da_tars: dict,
+    aligned_clim_data: dict | None,
+    n_workers: int | None = None,
+) -> tuple[dict, dict]:
+    """Compute scores for all (region, fstep) pairs and accumulate per-channel colour ranges.
+
+    Score computation is parallelised across (region, fstep) pairs; range accumulation
+    is done sequentially once all results are available.
+
+    Returns
+    -------
+    computed : dict[tuple, tuple]
+        ``{(region, fstep): (score_results, preds_r, metric_names)}``
+    score_ranges_dict : dict
+        ``{metric: {region: {channel: {'vmin': float, 'vmax': float}}}}``
+    """
+    # Build one task per (region, fstep) with pre-applied region masking.
+    tasks = []
+    for region in regions:
+        bbox = RegionBoundingBox.from_region_name(region)
+        metrics = metrics_dict[region]
+        metric_names = list(metrics.keys())
+        metric_params = list(metrics.values())
+        for fstep in fsteps:
+            tars_fs = da_tars[fstep]
+            preds_fs = da_preds[fstep]
+            preds_next, tars_next = get_next_fstep_data(fstep, da_preds, da_tars, fsteps)
+            climatology = aligned_clim_data[fstep] if aligned_clim_data else None
+            tars_r, preds_r, tars_next_r, preds_next_r = [
+                bbox.apply_mask(x) if x is not None else None
+                for x in (tars_fs, preds_fs, tars_next, preds_next)
+            ]
+            tasks.append(
+                dict(
+                    region=region,
+                    fstep=fstep,
+                    metric_names=metric_names,
+                    metric_params=metric_params,
+                    score_data=VerifiedData(
+                        preds_r, tars_r, preds_next_r, tars_next_r, climatology
+                    ),
+                    preds_r=preds_r,
+                )
+            )
+
+    # Compute scores in parallel across (region, fstep) pairs.
+    calls = [delayed(_compute_scores_for_fstep)(**t) for t in tasks]
+    raw_results = dispatch_parallel(
+        calls, n_workers=n_workers, backend="loky", desc="Score computation"
+    )
+
+    # Accumulate per-channel colour ranges from the completed results.
+    computed: dict[tuple, tuple] = {}
+    score_ranges_dict: dict = {}
+    for region, fstep, score_results, preds_r, metric_names in raw_results:
+        computed[(region, fstep)] = (score_results, preds_r, metric_names)
+        for metric, result in zip(metric_names, score_results, strict=False):
+            if result is None:
+                continue
+            score_ranges_dict.setdefault(metric, {}).setdefault(region, {})
+            for ch in result.coords["channel"].values:
+                vals = result.sel(channel=ch).values.flatten()
+                vals = vals[~np.isnan(vals)]
+                if vals.size == 0:
+                    continue
+                ch_key = str(ch)
+                vmin, vmax = float(vals.min()), float(vals.max())
+                prev = score_ranges_dict[metric][region].get(ch_key)
+                score_ranges_dict[metric][region][ch_key] = {
+                    "vmin": min(prev["vmin"], vmin) if prev else vmin,
+                    "vmax": max(prev["vmax"], vmax) if prev else vmax,
+                }
+
+    return computed, score_ranges_dict
+
+
 def plot_score_maps_per_stream(
     reader: Reader,
     stream: str,
     regions: list[str],
     metrics_dict: dict,
     output_data: "ReaderOutput | None" = None,
+    global_plotting_options: dict | None = None,
 ) -> None:
     """Plot spatial score maps for all regions and forecast steps.
 
@@ -70,6 +171,8 @@ def plot_score_maps_per_stream(
         Dictionary mapping region names to metric dicts.
     output_data : ReaderOutput | None
         Pre-loaded data; when provided ``reader.get_data()`` is skipped.
+    global_plotting_options : dict | None
+        Global plotting options. These can be passed to the plotter and can be used to set options.
     """
     if not reader.is_gridded_data(stream):
         _logger.debug(f"RUN {reader.run_id} - {stream}: Skipping score maps (non-gridded data).")
@@ -105,38 +208,42 @@ def plot_score_maps_per_stream(
         max_workers=reader.eval_cfg.get("max_workers", None),
     )
 
-    cfg = reader.global_plotting_options
+    cfg = global_plotting_options
     plotter_cfg = {
         "image_format": cfg.get("image_format", "png"),
         "dpi_val": cfg.get("dpi_val", 300),
         "fig_size": cfg.get("fig_size", None),
+        "animation_format": cfg.get("animation_format", "gif"),
+        "fps": cfg.get("fps", 2),
+        "log_colorbar": cfg.get("log_colorbar", False),
     }
     output_basedir = str(reader.runplot_dir)
     run_id = reader.run_id
 
+    _computed, score_ranges_dict = _compute_scores_and_ranges(
+        regions,
+        metrics_dict,
+        fsteps,
+        da_preds,
+        da_tars,
+        aligned_clim_data,
+        n_workers=n_plot_workers,
+    )
     fstep_tasks: list[dict] = []
     for region in regions:
-        bbox = RegionBoundingBox.from_region_name(region)
-        metrics = metrics_dict[region]
         for fstep in fsteps:
-            tars_fs = da_tars[fstep]
-            preds_fs = da_preds[fstep]
-            preds_next, tars_next = get_next_fstep_data(fstep, da_preds, da_tars, fsteps)
-            climatology = aligned_clim_data[fstep] if aligned_clim_data else None
-            tars_r, preds_r, tars_next_r, preds_next_r = [
-                bbox.apply_mask(x) if x is not None else None
-                for x in (tars_fs, preds_fs, tars_next, preds_next)
-            ]
-            score_data = VerifiedData(preds_r, tars_r, preds_next_r, tars_next_r, climatology)
+            score_results, preds_r, metric_names = _computed[(region, fstep)]
             fstep_tasks.append(
                 {
                     "plotter_cfg": plotter_cfg,
+                    "score_ranges_dict": score_ranges_dict,
                     "output_basedir": output_basedir,
                     "map_dir": str(map_dir),
                     "stream": stream,
                     "region": region,
-                    "score_data": score_data,
-                    "metrics": dict(metrics),
+                    "preds": preds_r,
+                    "score_results": score_results,
+                    "metric_names": metric_names,
                     "fstep": fstep,
                     "run_id": run_id,
                 }
@@ -151,28 +258,46 @@ def plot_score_maps_per_stream(
     calls = [delayed(_plot_score_maps_per_stream)(**t) for t in fstep_tasks]
     dispatch_parallel(calls, n_workers=n_plot_workers, backend="loky", desc=f"Score maps {stream}")
 
+    # Derive variables and ens_values from the computed results.
+    all_metrics = list(score_ranges_dict.keys())
+    all_variables = sorted(
+        {
+            ch
+            for metric_dict in score_ranges_dict.values()
+            for region_dict in metric_dict.values()
+            for ch in region_dict
+        }
+    )
+    first_preds = next(iter(_computed.values()))[1]  # preds_r
+    ens_values = list(first_preds.coords["ens"].values) if "ens" in first_preds.dims else [None]
+    _dispatch_score_map_animations(
+        map_dir=map_dir,
+        plotter_cfg=plotter_cfg,
+        run_id=run_id,
+        stream=stream,
+        metrics=all_metrics,
+        regions=regions,
+        variables=all_variables,
+        ens_values=ens_values,
+        fsteps=fsteps,
+        n_workers=n_plot_workers,
+    )
+
 
 def _plot_score_maps_per_stream(
     plotter_cfg: dict,
+    score_ranges_dict: dict,
     output_basedir: str,
     map_dir: str,
     stream: str,
     region: str,
-    score_data: "VerifiedData",
-    metrics: dict[str, object],
+    preds: xr.DataArray,
+    score_results: list,
+    metric_names: list[str],
     fstep: int,
     run_id: str = "",
 ) -> None:
     """Plot 2D score maps for all metrics/channels for one (region, fstep)."""
-    preds = score_data.prediction
-
-    metric_names = list(metrics.keys())
-    metric_params = list(metrics.values())
-    score_results: list[xr.DataArray | None] = [
-        get_score(score_data, m, agg_dims="sample", parameters=p)
-        for m, p in zip(metric_names, metric_params, strict=False)
-    ]
-
     valid = [(m, r) for m, r in zip(metric_names, score_results, strict=False) if r is not None]
     if not valid:
         return
@@ -209,9 +334,11 @@ def _plot_score_maps_per_stream(
                 title = f"{metric} - {channel}: fstep {fstep}" + (
                     f", ens {ens_val}" if ens_val is not None else ""
                 )
+                scores_cfg = score_ranges_dict.get(metric, {}).get(region, {}).get(channel, {})
                 plot_tasks.append(
                     {
                         "plotter_cfg": plotter_cfg,
+                        "scores_cfg": scores_cfg,
                         "output_basedir": output_basedir,
                         "stream": stream,
                         "data": data,
@@ -229,6 +356,7 @@ def _plot_score_maps_per_stream(
 
 def _scatter_plot_single(
     plotter_cfg: dict,
+    scores_cfg: dict,
     output_basedir: str,
     stream: str,
     data: xr.DataArray,
@@ -241,7 +369,9 @@ def _scatter_plot_single(
     """Plot a single score-map scatter plot (picklable for loky workers)."""
     matplotlib.use("Agg")
     plotter = Plotter(plotter_cfg, Path(output_basedir), stream)
-    plotter.scatter_plot(data, Path(map_dir), channel, region, tag=tag, title=title)
+    plotter.scatter_plot(
+        data, Path(map_dir), channel, region, tag=tag, map_kwargs=scores_cfg, title=title
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -262,45 +392,67 @@ def _build_single_animation(
     animation_format: str,
     duration_ms: int,
     prefix: str = "map",
+    score_animation: bool = False,
 ) -> list[str]:
-    """Build one GIF for a single (region, sample, variable) combination.
+    """Build one animation for a single (region, sample/ens, variable) combination.
 
     All work is I/O + Pillow — no matplotlib state involved.
 
-    Returns the list of source frame paths that were assembled into the GIF
-    (empty list if no frames were found).
-    """
-    # Both map and histogram filenames follow the same pattern:
-    #   {prefix}_{run_id}_{tag}_{sample}_{valid_time}_{stream}_{region}_{var}_{fstep:03d}
-    # For all_samples histograms, valid_time is omitted.
-    # We match files by checking a fixed prefix and suffix, allowing any
-    # valid_time (or none) in between — no glob wildcards needed.
-    region_part = region if region else ""
-    head = "_".join(filter(None, [prefix, run_id, tag, str(sa)]))
-    tail = "_".join(filter(None, [stream, region_part, var]))
-    suffix = f".{image_format}"
-    fstep_strs = {str(f).zfill(3) for f in fsteps}
+    When ``score_animation=False`` (default) the function scans ``output_dir`` for
+    per-sample map/histogram frames whose filenames follow::
 
+        {prefix}_{run_id}_{tag}_{sa}_{valid_time}_{stream}_{region}_{var}_{fstep:03d}
+
+    When ``score_animation=True`` filenames are constructed deterministically because
+    the fstep is embedded in the tag (``score_maps_{metric}_fstep_{N}``) rather
+    than being a zero-padded suffix.  Pass ``tag="score_maps_{metric}"`` and
+    ``sa`` as the ensemble value (or ``None`` for no ensemble).
+
+    Returns the list of source frame paths assembled into the animation, or an
+    empty list when no (or fewer than two for score maps) frames were found.
+    """
     if not output_dir.is_dir():
         return []
 
-    image_paths = sorted(
-        str(f)
-        for f in output_dir.iterdir()
-        if f.name.startswith(head + "_")
-        and f.name.endswith(suffix)
-        and f"_{tail}_" in f.name
-        and f.stem.rsplit("_", 1)[-1] in fstep_strs
-    )
-
-    if not image_paths:
-        return []
-
-    anim_parts = ["animation", run_id, tag, str(sa), stream]
-    if region:
-        anim_parts.append(region)
-    anim_parts.append(var)
-    out_path = f"{output_dir / '_'.join(filter(None, anim_parts))}.{animation_format}"
+    if score_animation:
+        # Deterministic lookup: fstep is embedded in the full tag.
+        # tag = "score_maps_{metric}", sa = ens_val | None, var = channel.
+        image_paths: list[str] = []
+        for fstep in sorted(fsteps):
+            full_tag = f"{tag}_fstep_{fstep}"
+            if sa is not None:
+                full_tag += f"_ens_{sa}"
+            fname = f"map_{run_id}_{full_tag}_{stream}_{region}_{var}.{image_format}"
+            path = output_dir / fname
+            if path.exists():
+                image_paths.append(str(path))
+        if len(image_paths) < 2:
+            return []
+        ens_part = f"_ens_{sa}" if sa is not None else ""
+        anim_name = f"animation_{run_id}_{tag}{ens_part}_{stream}_{region}_{var}.{animation_format}"
+        out_path = str(output_dir / anim_name)
+    else:
+        # Directory scan: fstep is the zero-padded final element of the filename stem.
+        region_part = region if region else ""
+        head = "_".join(filter(None, [prefix, run_id, tag, str(sa)]))
+        tail = "_".join(filter(None, [stream, region_part, var]))
+        suffix = f".{image_format}"
+        fstep_strs = {str(f).zfill(3) for f in fsteps}
+        image_paths = sorted(
+            str(f)
+            for f in output_dir.iterdir()
+            if f.name.startswith(head + "_")
+            and f.name.endswith(suffix)
+            and f"_{tail}_" in f.name
+            and f.stem.rsplit("_", 1)[-1] in fstep_strs
+        )
+        if not image_paths:
+            return []
+        anim_parts = ["animation", run_id, tag, str(sa), stream]
+        if region:
+            anim_parts.append(region)
+        anim_parts.append(var)
+        out_path = f"{output_dir / '_'.join(filter(None, anim_parts))}.{animation_format}"
 
     if animation_format.lower() == "mp4":
         frames = [imageio.imread(p) for p in image_paths]
@@ -386,6 +538,55 @@ def _dispatch_animations(
         n_workers=get_num_workers(max_workers=max_workers),
         backend="loky",
         desc="Animations",
+    )
+    return [p for r in results if r for p in r]
+
+
+def _dispatch_score_map_animations(
+    map_dir: Path,
+    plotter_cfg: dict,
+    run_id: str,
+    stream: str,
+    metrics: list[str],
+    regions: list[str],
+    variables: list[str],
+    ens_values: list,
+    fsteps: list,
+    n_workers: int | None = None,
+) -> list[str]:
+    """Build score-map animations in parallel for all (metric, region, variable[, ens]) combos.
+
+    Returns the paths of all source frames assembled into animations.
+    """
+    duration_ms = int(1000 / plotter_cfg["fps"]) if plotter_cfg["fps"] > 0 else 400
+
+    tasks = [
+        dict(
+            output_dir=map_dir,
+            run_id=run_id,
+            tag=f"score_maps_{metric}",
+            stream=stream,
+            region=region,
+            var=var,
+            sa=ens_val,
+            fsteps=list(fsteps),
+            image_format=plotter_cfg["image_format"],
+            animation_format=plotter_cfg["animation_format"],
+            duration_ms=duration_ms,
+            score_animation=True,
+        )
+        for metric in metrics
+        for region in regions
+        for var in variables
+        for ens_val in ens_values
+    ]
+
+    calls = [delayed(_build_single_animation)(**t) for t in tasks]
+    results = dispatch_parallel(
+        calls,
+        n_workers=n_workers,
+        backend="loky",
+        desc=f"Score map animations {stream}",
     )
     return [p for r in results if r for p in r]
 

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration_utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration_utils.py
@@ -1,0 +1,124 @@
+import numpy as np
+import xarray as xr
+from joblib import delayed
+
+from weathergen.evaluate.io.data.io_orchestration import dispatch_parallel
+from weathergen.evaluate.scores.score import VerifiedData, get_score
+from weathergen.evaluate.scores.score_orchestration import get_next_fstep_data
+from weathergen.evaluate.utils.regions import RegionBoundingBox
+
+
+def _compute_scores_for_fstep(
+    region: str,
+    fstep: int,
+    metric_names: list[str],
+    metric_params: list,
+    score_data: VerifiedData,
+    preds_r: xr.DataArray,
+) -> tuple[str, int, list, xr.DataArray, list[str]]:
+    """Compute scores for a single (region, fstep) pair (parallelisable worker).
+
+    Returns ``(region, fstep, score_results, preds_r, metric_names)``.
+    """
+    score_results: list[xr.DataArray | None] = [
+        get_score(score_data, m, agg_dims="sample", parameters=p)
+        for m, p in zip(metric_names, metric_params, strict=False)
+    ]
+    return region, fstep, score_results, preds_r, metric_names
+
+
+def _compute_scores(
+    regions: list[str],
+    metrics_dict: dict,
+    fsteps: list,
+    da_preds: dict,
+    da_tars: dict,
+    aligned_clim_data: dict | None,
+    n_workers: int | None = None,
+) -> tuple[dict, dict]:
+    """Compute scores for all (region, fstep) pairs. Score computation is parallelised across
+      (region, fstep) pairs.
+
+    Returns
+    -------
+    computed : dict[tuple, tuple]
+        ``{(region, fstep): (score_results, preds_r, metric_names)}``
+    raw_results : list[tuple]
+        List of raw results from parallel score computation, each item is a tuple of
+        ``(region, fstep, score_results, preds_r, metric_names)``.
+    """
+    # Build one task per (region, fstep) with pre-applied region masking.
+    tasks = []
+    for region in regions:
+        bbox = RegionBoundingBox.from_region_name(region)
+        metrics = metrics_dict[region]
+        metric_names = list(metrics.keys())
+        metric_params = list(metrics.values())
+        for fstep in fsteps:
+            tars_fs = da_tars[fstep]
+            preds_fs = da_preds[fstep]
+            preds_next, tars_next = get_next_fstep_data(fstep, da_preds, da_tars, fsteps)
+            climatology = aligned_clim_data[fstep] if aligned_clim_data else None
+            tars_r, preds_r, tars_next_r, preds_next_r = [
+                bbox.apply_mask(x) if x is not None else None
+                for x in (tars_fs, preds_fs, tars_next, preds_next)
+            ]
+            tasks.append(
+                dict(
+                    region=region,
+                    fstep=fstep,
+                    metric_names=metric_names,
+                    metric_params=metric_params,
+                    score_data=VerifiedData(
+                        preds_r, tars_r, preds_next_r, tars_next_r, climatology
+                    ),
+                    preds_r=preds_r,
+                )
+            )
+
+    # Compute scores in parallel across (region, fstep) pairs.
+    calls = [delayed(_compute_scores_for_fstep)(**t) for t in tasks]
+    raw_results = dispatch_parallel(
+        calls, n_workers=n_workers, backend="loky", desc="Score computation"
+    )
+
+    # Accumulate per-channel colour ranges from the completed results.
+    computed: dict[tuple, tuple] = {}
+    for region, fstep, score_results, preds_r, metric_names in raw_results:
+        computed[(region, fstep)] = (score_results, preds_r, metric_names)
+
+    return computed, raw_results
+
+
+def _compute_ranges(
+    raw_results: list[tuple[str, int, list, xr.DataArray, list[str]]],
+) -> dict:
+    """Compute colour ranges for each metric/region/channel from the raw score results.
+
+    Returns
+    -------
+    score_ranges_dict : dict
+        ``{metric: {region: {channel: {'vmin': float, 'vmax': float}}}}``
+    """
+    # Accumulate per-channel colour ranges from the completed results.
+
+    score_ranges_dict: dict = {}
+    for region, _, score_results, _, metric_names in raw_results:
+        for metric, result in zip(metric_names, score_results, strict=False):
+            if result is None:
+                continue
+            score_ranges_dict.setdefault(metric, {}).setdefault(region, {})
+            for ch in result.coords["channel"].values:
+                vals = result.sel(channel=ch).values.flatten()
+                vals = vals[~np.isnan(vals)]
+                if vals.size == 0:
+                    continue
+                ch_key = str(ch)
+                vmin, vmax = float(vals.min()), float(vals.max())
+                prev = score_ranges_dict[metric][region].get(ch_key)
+                score_ranges_dict[metric][region][ch_key] = {
+                    "vmin": min(prev["vmin"], vmin) if prev else vmin,
+                    "vmax": max(prev["vmax"], vmax) if prev else vmax,
+                }
+
+    return score_ranges_dict

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -36,6 +36,7 @@ except ImportError:
     HAS_DATASHADER = False
 
 from weathergen.common.config import _load_private_conf
+
 from weathergen.evaluate.plotting.plot_utils import DefaultMarkerSize, format_datetime
 from weathergen.evaluate.utils.regions import RegionBoundingBox
 

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -36,7 +36,6 @@ except ImportError:
     HAS_DATASHADER = False
 
 from weathergen.common.config import _load_private_conf
-
 from weathergen.evaluate.plotting.plot_utils import DefaultMarkerSize, format_datetime
 from weathergen.evaluate.utils.regions import RegionBoundingBox
 

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -36,6 +36,7 @@ except ImportError:
     HAS_DATASHADER = False
 
 from weathergen.common.config import _load_private_conf
+
 from weathergen.evaluate.plotting.plot_utils import DefaultMarkerSize, format_datetime
 from weathergen.evaluate.utils.regions import RegionBoundingBox
 
@@ -137,6 +138,7 @@ class Plotter:
         self.dpi_val = plotter_cfg.get("dpi_val")
         self.fig_size = plotter_cfg.get("fig_size")
         self.fps = plotter_cfg.get("fps")
+        self.log_colorbar = plotter_cfg.get("log_colorbar", False)
         self.regions = plotter_cfg.get("regions")
         self.log_x = plotter_cfg.get("log_x", False)
         self.log_y = plotter_cfg.get("log_y", False)
@@ -626,6 +628,7 @@ class Plotter:
             "vmax": kw.pop("vmax", None),
             "cmap": plt.get_cmap(kw.pop("colormap", "coolwarm")),
             "use_datashader": kw.pop("use_datashader", False),
+            "levels": kw.pop("levels", None),
             # HEALPix grid
             "add_healpix_grid": kw.pop("add_healpix_grid", False),
             "healpix_nside": kw.pop("healpix_nside", 4),
@@ -634,16 +637,6 @@ class Plotter:
             "healpix_step": kw.pop("healpix_step", 64),
             "healpix_linestyle": kw.pop("healpix_linestyle", "-"),
         }
-
-        # Colour normalisation
-        if isinstance(kw.get("levels", False), oc.listconfig.ListConfig):
-            parsed["norm"] = mpl.colors.BoundaryNorm(
-                kw.pop("levels", None), parsed["cmap"].N, extend="both"
-            )
-        else:
-            parsed["norm"] = mpl.colors.Normalize(
-                vmin=parsed["vmin"], vmax=parsed["vmax"], clip=False
-            )
 
         parsed["extra"] = kw  # remaining kwargs forwarded to scatter
         return parsed
@@ -907,10 +900,18 @@ class Plotter:
                     opts["vmin"] = float(p_lo)
                 if opts["vmax"] is None:
                     opts["vmax"] = float(p_hi)
-                # Rebuild norm with the robust limits
-                opts["norm"] = mpl.colors.Normalize(
-                    vmin=opts["vmin"], vmax=opts["vmax"], clip=False
+
+        if isinstance(opts["levels"], oc.listconfig.ListConfig):
+            opts["norm"] = mpl.colors.BoundaryNorm(opts["levels"], opts["cmap"].N, extend="both")
+        elif self.log_colorbar and opts["vmin"] is not None and opts["vmin"] > 0:
+            opts["norm"] = mpl.colors.LogNorm(vmin=opts["vmin"], vmax=opts["vmax"])
+        else:
+            if self.log_colorbar:
+                _logger.warning(
+                    "log_colorbar=True but vmin=%.3g <= 0; falling back to linear norm.",
+                    opts["vmin"],
                 )
+            opts["norm"] = mpl.colors.Normalize(vmin=opts["vmin"], vmax=opts["vmax"], clip=False)
 
         if regionname == "global":
             ax.set_global()

--- a/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
@@ -24,13 +24,6 @@ from omegaconf import DictConfig, OmegaConf, open_dict
 from weathergen.common.logger import init_loggers
 from weathergen.common.paths import _REPO_ROOT
 from weathergen.common.platform_env import get_platform_env
-from weathergen.metrics.mlflow_utils import (
-    MlFlowUpload,
-    get_or_create_mlflow_parent_run,
-    log_scores,
-    setup_mlflow,
-)
-
 from weathergen.evaluate.io.csv_reader import CsvReader
 from weathergen.evaluate.io.merge_reader import WeatherGenMergeReader
 from weathergen.evaluate.io.wegen_reader import (
@@ -49,6 +42,12 @@ from weathergen.evaluate.scores.score_orchestration import (
     metric_list_to_json,
 )
 from weathergen.evaluate.utils.dict_utils import merge, parse_metric_params, triple_nested_dict
+from weathergen.metrics.mlflow_utils import (
+    MlFlowUpload,
+    get_or_create_mlflow_parent_run,
+    log_scores,
+    setup_mlflow,
+)
 
 _DEFAULT_PLOT_DIR = _REPO_ROOT / "plots"
 

--- a/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
@@ -24,6 +24,13 @@ from omegaconf import DictConfig, OmegaConf, open_dict
 from weathergen.common.logger import init_loggers
 from weathergen.common.paths import _REPO_ROOT
 from weathergen.common.platform_env import get_platform_env
+from weathergen.metrics.mlflow_utils import (
+    MlFlowUpload,
+    get_or_create_mlflow_parent_run,
+    log_scores,
+    setup_mlflow,
+)
+
 from weathergen.evaluate.io.csv_reader import CsvReader
 from weathergen.evaluate.io.merge_reader import WeatherGenMergeReader
 from weathergen.evaluate.io.wegen_reader import (
@@ -33,8 +40,8 @@ from weathergen.evaluate.io.wegen_reader import (
 )
 from weathergen.evaluate.plotting.plot_orchestration import (
     plot_data,
-    plot_score_maps_per_stream,
     plot_summary,
+    run_score_map_pipeline,
 )
 from weathergen.evaluate.plotting.plot_utils import collect_channels
 from weathergen.evaluate.scores.score_orchestration import (
@@ -42,12 +49,6 @@ from weathergen.evaluate.scores.score_orchestration import (
     metric_list_to_json,
 )
 from weathergen.evaluate.utils.dict_utils import merge, parse_metric_params, triple_nested_dict
-from weathergen.metrics.mlflow_utils import (
-    MlFlowUpload,
-    get_or_create_mlflow_parent_run,
-    log_scores,
-    setup_mlflow,
-)
 
 _DEFAULT_PLOT_DIR = _REPO_ROOT / "plots"
 
@@ -186,6 +187,7 @@ def _process_stream(
     regions: list[str],
     metrics: dict[str, object],
     plot_score_maps: bool,
+    plot_score_animations: bool,
 ) -> tuple[str, str, dict[str, dict[str, dict[str, float]]]]:
     """
     Worker function for a single stream of a single run.
@@ -209,6 +211,8 @@ def _process_stream(
         Dict of metrics to be processed and their parameters.
     plot_score_maps:
         Bool to define if the score maps need to be plotted or not.
+    plot_score_animations:
+        Bool to define if the score animations need to be plotted or not.
     """
     type_ = run.get("type", "zarr")
     reader = get_reader(type_, run, run_id, private_paths, regions, metrics)
@@ -269,13 +273,14 @@ def _process_stream(
     scores_dict = merge(stream_loaded_scores, stream_computed_scores)
 
     if score_maps:
-        plot_score_maps_per_stream(
+        run_score_map_pipeline(
             reader,
             stream,
             regions_to_compute,
             metrics_to_compute,
             output_data=output_data,
             global_plotting_options=global_plotting_opts,
+            plot_score_animations=plot_score_animations,
         )
 
     return run_id, stream, scores_dict
@@ -299,6 +304,7 @@ def evaluate_from_config(cfg: dict, mlflow_client: MlflowClient | None) -> None:
     summary_dir = Path(cfg.evaluation.get("summary_dir", _DEFAULT_PLOT_DIR))
     metrics = cfg.evaluation.metrics
     plot_score_maps = cfg.evaluation.get("plot_score_maps", False)
+    plot_score_animations = cfg.evaluation.get("plot_score_animations", False)
     global_plotting_opts = cfg.get("global_plotting_options", {})
     default_streams = cfg.get("default_streams", {})
     max_workers = cfg.get("max_workers")  # global hard cap for parallel workers
@@ -330,6 +336,7 @@ def evaluate_from_config(cfg: dict, mlflow_client: MlflowClient | None) -> None:
                     "regions": regions,
                     "metrics": metrics,
                     "plot_score_maps": plot_score_maps,
+                    "plot_score_animations": plot_score_animations,
                 }
             )
 

--- a/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
@@ -16,7 +16,6 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-# Third-party
 import mlflow
 from mlflow.client import MlflowClient
 from omegaconf import DictConfig, OmegaConf, open_dict
@@ -25,6 +24,13 @@ from omegaconf import DictConfig, OmegaConf, open_dict
 from weathergen.common.logger import init_loggers
 from weathergen.common.paths import _REPO_ROOT
 from weathergen.common.platform_env import get_platform_env
+from weathergen.metrics.mlflow_utils import (
+    MlFlowUpload,
+    get_or_create_mlflow_parent_run,
+    log_scores,
+    setup_mlflow,
+)
+
 from weathergen.evaluate.io.csv_reader import CsvReader
 from weathergen.evaluate.io.merge_reader import WeatherGenMergeReader
 from weathergen.evaluate.io.wegen_reader import (
@@ -43,12 +49,6 @@ from weathergen.evaluate.scores.score_orchestration import (
     metric_list_to_json,
 )
 from weathergen.evaluate.utils.dict_utils import merge, parse_metric_params, triple_nested_dict
-from weathergen.metrics.mlflow_utils import (
-    MlFlowUpload,
-    get_or_create_mlflow_parent_run,
-    log_scores,
-    setup_mlflow,
-)
 
 _DEFAULT_PLOT_DIR = _REPO_ROOT / "plots"
 
@@ -276,6 +276,7 @@ def _process_stream(
             regions_to_compute,
             metrics_to_compute,
             output_data=output_data,
+            global_plotting_options=global_plotting_opts,
         )
 
     return run_id, stream, scores_dict


### PR DESCRIPTION
## Description

1) This PR allows for score animations with fixed colorbar. See examples in the comments.

2) Some restructuring needed to take place so this PR should be reviewed carefully.

**IMPORTANT:** Since the score animations are mainly animations over forecast steps, the colorbar depicts all the accumulated error growth over those which might lead to the misconception that there is negligible error at lower number of forecast steps. To avoid this, I added the possibility of plotting a colorbar on log scale. See examples below in the comments.

Instructions:

```
global_plotting_options:
  log_colorbar: false

evaluation:
  metrics  : ["rmse", "froct", "mae"]
  regions: ["global", "nhem"]
  plot_score_maps: true
  plot_score_animations: true
```


## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/1828

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [X] I have performed a self-review of my code
-   [X] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
