### PR TITLE
Apply scale_z_channels to climatology in evaluation

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/utils/clim_utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils/clim_utils.py
@@ -15,6 +15,8 @@ import xarray as xr
 from scipy.spatial import cKDTree
 from tqdm import tqdm
 
+from weathergen.evaluate.utils.derived_channels import scale_z_channels
+
 _logger = logging.getLogger(__name__)
 
 
@@ -245,6 +247,7 @@ def get_climatology(reader, da_tars, stream: str) -> dict | None:
     if clim_data_path is not None:
         clim_data = xr.open_dataset(clim_data_path)
         _logger.info("Aligning climatological data with target structure...")
-        return align_clim_data(da_tars, clim_data)
+        aligned = align_clim_data(da_tars, clim_data)
+        return {fstep: scale_z_channels(da, stream) for fstep, da in aligned.items()}
 
     return None


### PR DESCRIPTION
## Description

`scale_z_channels` (division by `g=9.80665`) is applied to WeGen output for evaluation. It hasn't been applied to the climatology which impacts e.g. ACC calculation

## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/2407

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
