### PR TITLE
Add timeseries plotting

### DIFF
--- a/config/evaluate/eval_config.yml
+++ b/config/evaluate/eval_config.yml
@@ -90,6 +90,8 @@ default_streams:
       plot_target: false
       plot_histograms: true
       plot_animations: true
+      plot_timeseries: false
+
   CERRA:
     regions: ["europe"]
     channels: ["z_500", "t_850", "u_850"] #, "blah"]
@@ -104,6 +106,8 @@ default_streams:
       plot_target: false
       plot_histograms: true
       plot_animations: true
+      plot_timeseries: false
+      
   IMERG_ANEMOI:
     channels: ["tp_imerg_0"]
     evaluation:
@@ -119,6 +123,7 @@ default_streams:
       plot_target: false
       plot_histograms: true
       plot_animations: true
+      plot_timeseries: false
 
 run_ids :
   ar40mckx:
@@ -158,6 +163,7 @@ run_ids :
           plot_target: false
           plot_histograms: true
           plot_animations: true
+          plot_timeseries: false
 
   
 

--- a/config/evaluate/eval_config_default.yml
+++ b/config/evaluate/eval_config_default.yml
@@ -55,6 +55,7 @@ default_streams:
       plot_maps: true
       plot_histograms: false
       plot_animations: true
+      plot_timeseries: false
   CERRA:
     regions: ["europe"]
     channels: ["z_500", "t_850", "u_850"] #, "blah"]
@@ -69,4 +70,5 @@ default_streams:
       plot_target: false
       plot_histograms: true
       plot_animations: true
+      plot_timeseries: false
       

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
@@ -644,8 +644,10 @@ def _dispatch_timeseries_plots(
     output_dir: str,
     stream: str,
     run_id: str,
-    num_plot_workers: int,
+    samples: dict,
+    channels: dict,
     ensemble: list,
+    n_workers: int,
 ) -> None:
     """Build and dispatch timeseries plot tasks for all (channel, sample[, ens]) triples."""
     data_ts = Timeseries(da_preds, da_tars)
@@ -659,14 +661,14 @@ def _dispatch_timeseries_plots(
             "stream": stream,
             "ens": ens,
         }
-        for channel in data_ts.get_channels()
-        for sample in data_ts.get_samples()
+        for channel in channels
+        for sample in samples
         for ens in ens_members
     ]
     calls = [delayed(data_ts.plot_single_timeseries)(**t) for t in ts_tasks]
     dispatch_parallel(
         calls,
-        n_workers=num_plot_workers,
+        n_workers=n_workers,
         backend="loky",
         desc=f"Timeseries {run_id} - {stream}",
     )
@@ -1004,8 +1006,10 @@ def plot_data(
             output_dir=output_dir,
             stream=stream,
             run_id=run_id,
-            num_plot_workers=num_plot_workers,
+            samples=plot_sample_set,
+            channels=plot_channel_set,
             ensemble=list(available_data.ensemble),
+            n_workers=num_plot_workers,
         )
 
     if plot_animations:

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
@@ -645,18 +645,23 @@ def _dispatch_timeseries_plots(
     stream: str,
     run_id: str,
     num_plot_workers: int,
+    ensemble: list,
 ) -> None:
-    """Build and dispatch timeseries plot tasks for all (channel, sample) pairs."""
+    """Build and dispatch timeseries plot tasks for all (channel, sample[, ens]) triples."""
     data_ts = Timeseries(da_preds, da_tars)
+    has_ens = any("ens" in v.dims for v in da_preds.values())
+    ens_members = ensemble if has_ens else [None]
     ts_tasks = [
         {
             "output_dir": output_dir,
             "channel": str(channel),
             "sample": sample,
             "stream": stream,
+            "ens": ens,
         }
         for channel in data_ts.get_channels()
         for sample in data_ts.get_samples()
+        for ens in ens_members
     ]
     calls = [delayed(data_ts.plot_single_timeseries)(**t) for t in ts_tasks]
     dispatch_parallel(
@@ -1000,6 +1005,7 @@ def plot_data(
             stream=stream,
             run_id=run_id,
             num_plot_workers=num_plot_workers,
+            ensemble=list(available_data.ensemble),
         )
 
     if plot_animations:

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
@@ -21,6 +21,7 @@ import xarray as xr
 from joblib import delayed
 from PIL import Image
 from tqdm import tqdm
+from weathergen.evaluate.plotting.timeseries import Timeseries
 
 from weathergen.evaluate.io.data.io_orchestration import dispatch_parallel, get_num_workers
 from weathergen.evaluate.io.io_reader import Reader, ReaderOutput
@@ -633,6 +634,40 @@ def _dispatch_score_map_animations(
 
 
 # ---------------------------------------------------------------------------
+# Timeseries plots
+# ---------------------------------------------------------------------------
+
+
+def _dispatch_timeseries_plots(
+    da_preds: dict,
+    da_tars: dict,
+    output_dir: str,
+    stream: str,
+    run_id: str,
+    num_plot_workers: int,
+) -> None:
+    """Build and dispatch timeseries plot tasks for all (channel, sample) pairs."""
+    data_ts = Timeseries(da_preds, da_tars)
+    ts_tasks = [
+        {
+            "output_dir": output_dir,
+            "channel": str(channel),
+            "sample": sample,
+            "stream": stream,
+        }
+        for channel in data_ts.get_channels()
+        for sample in data_ts.get_samples()
+    ]
+    calls = [delayed(data_ts.plot_single_timeseries)(**t) for t in ts_tasks]
+    dispatch_parallel(
+        calls,
+        n_workers=num_plot_workers,
+        backend="loky",
+        desc=f"Timeseries {run_id} - {stream}",
+    )
+
+
+# ---------------------------------------------------------------------------
 # Per-sample map / histogram plots
 # ---------------------------------------------------------------------------
 
@@ -773,7 +808,7 @@ def plot_data(
     stream_cfg = reader.get_stream(stream)
     plot_settings = stream_cfg.get("plotting", {})
 
-    plot_keys = ("plot_maps", "plot_histograms", "plot_animations")
+    plot_keys = ("plot_maps", "plot_histograms", "plot_animations", "plot_timeseries")
     if not plot_settings or not any(plot_settings.get(k, False) for k in plot_keys):
         return
 
@@ -807,6 +842,9 @@ def plot_data(
     plot_target = plot_settings.get("plot_target", True)
     if not isinstance(plot_target, bool):
         raise TypeError("plot_target must be a boolean.")
+    plot_timeseries = plot_settings.get("plot_timeseries", False)
+    if not isinstance(plot_timeseries, bool):
+        raise TypeError("plot_timeseries must be a boolean.")
     plot_histograms = plot_settings.get("plot_histograms", False)
     if not isinstance(plot_histograms, bool) and plot_histograms not in {
         "across-samples",
@@ -952,6 +990,16 @@ def plot_data(
             n_workers=num_plot_workers,
             backend="loky",
             desc=f"Across-samples plots {run_id} - {stream}",
+        )
+
+    if plot_timeseries:
+        _dispatch_timeseries_plots(
+            da_preds=da_preds,
+            da_tars=da_tars,
+            output_dir=output_dir,
+            stream=stream,
+            run_id=run_id,
+            num_plot_workers=num_plot_workers,
         )
 
     if plot_animations:

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
@@ -21,7 +21,6 @@ import xarray as xr
 from joblib import delayed
 from PIL import Image
 from tqdm import tqdm
-from weathergen.evaluate.plotting.timeseries import Timeseries
 
 from weathergen.evaluate.io.data.io_orchestration import dispatch_parallel, get_num_workers
 from weathergen.evaluate.io.io_reader import Reader, ReaderOutput
@@ -44,6 +43,7 @@ from weathergen.evaluate.plotting.plot_utils import (
 from weathergen.evaluate.plotting.plotter import Plotter
 from weathergen.evaluate.plotting.quantile_plots import QuantilePlots
 from weathergen.evaluate.plotting.score_cards import ScoreCards
+from weathergen.evaluate.plotting.timeseries import Timeseries
 from weathergen.evaluate.scores.score import VerifiedData, get_score
 from weathergen.evaluate.utils.array_utils import bias_ranges, common_ranges
 from weathergen.evaluate.utils.clim_utils import get_climatology, needs_climatology
@@ -643,6 +643,7 @@ def _dispatch_timeseries_plots(
     da_tars: dict,
     output_dir: str,
     stream: str,
+    regions: list[str],
     run_id: str,
     samples: dict,
     channels: dict,
@@ -659,11 +660,13 @@ def _dispatch_timeseries_plots(
             "channel": str(channel),
             "sample": sample,
             "stream": stream,
+            "region": region,
             "ens": ens,
         }
         for channel in channels
         for sample in samples
         for ens in ens_members
+        for region in regions
     ]
     calls = [delayed(data_ts.plot_single_timeseries)(**t) for t in ts_tasks]
     dispatch_parallel(
@@ -1005,6 +1008,7 @@ def plot_data(
             da_tars=da_tars,
             output_dir=output_dir,
             stream=stream,
+            regions=plotter.regions,
             run_id=run_id,
             samples=plot_sample_set,
             channels=plot_channel_set,

--- a/packages/evaluate/src/weathergen/evaluate/plotting/timeseries.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/timeseries.py
@@ -55,8 +55,8 @@ class Timeseries:
             preds_steps.append(da_p.mean(dim="ipoint").assign_coords(valid_time=vt))
             tars_steps.append(da_t.mean(dim="ipoint").assign_coords(valid_time=vt))
         da_preds_ts, da_tars_ts = (
-            xr.concat(preds_steps, dim="forecast_step"),
-            xr.concat(tars_steps, dim="forecast_step"),
+            xr.concat(preds_steps, dim="forecast_step", coords="different", compat="equals"),
+            xr.concat(tars_steps, dim="forecast_step", coords="different", compat="equals"),
         )
         return da_preds_ts, da_tars_ts
 

--- a/packages/evaluate/src/weathergen/evaluate/plotting/timeseries.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/timeseries.py
@@ -4,6 +4,8 @@ import matplotlib
 import matplotlib.pyplot as plt
 import xarray as xr
 
+from weathergen.evaluate.utils.regions import RegionBoundingBox
+
 
 class Timeseries:
     """
@@ -21,22 +23,14 @@ class Timeseries:
         self.da_preds = da_preds
         self.da_tars = da_tars
 
-        preds_steps, tars_steps = [], []
-        for da_p, da_t in zip(self.da_preds.values(), self.da_tars.values(), strict=False):
-            vt = da_p.valid_time.isel(ipoint=0).drop_vars("ipoint")
-            preds_steps.append(da_p.mean(dim="ipoint").assign_coords(valid_time=vt))
-            tars_steps.append(da_t.mean(dim="ipoint").assign_coords(valid_time=vt))
-        self.da_preds_ts, self.da_tars_ts = (
-            xr.concat(preds_steps, dim="forecast_step"),
-            xr.concat(tars_steps, dim="forecast_step"),
-        )
-
-    def get_preds_tars_per_sample_channel(
-        self, sample: int | str, channel: str
+    def get_preds_tars_per_region_sample_channel(
+        self, region: str, sample: int | str, channel: str
     ) -> tuple[xr.Dataset, xr.Dataset]:
         """Get preds/tars for the given sample/channel from the timeseries data.
         Parameters
         ----------
+        region: str
+            The region for which to extract data.
         sample: int | str
             The sample for which to extract data.
         channel: str
@@ -47,11 +41,24 @@ class Timeseries:
         tuple[xr.Dataset, xr.Dataset]
             The prediction and target datasets for the given sample and channel.
         """
-        da_preds_slice, da_tars_slice = (
-            self.da_preds_ts.sel(sample=sample, channel=channel),
-            self.da_tars_ts.sel(sample=sample, channel=channel),
+
+        preds_steps, tars_steps = [], []
+        for da_p, da_t in zip(self.da_preds.values(), self.da_tars.values(), strict=False):
+            # Select sample and channel first so lat/lon become 1D (ipoint,)
+            da_p = da_p.sel(sample=sample, channel=channel)
+            da_t = da_t.sel(sample=sample, channel=channel)
+            if region != "global":
+                bbox = RegionBoundingBox.from_region_name(region)
+                da_p = bbox.apply_mask(da_p)
+                da_t = bbox.apply_mask(da_t)
+            vt = da_p.valid_time.isel(ipoint=0).drop_vars("ipoint")
+            preds_steps.append(da_p.mean(dim="ipoint").assign_coords(valid_time=vt))
+            tars_steps.append(da_t.mean(dim="ipoint").assign_coords(valid_time=vt))
+        da_preds_ts, da_tars_ts = (
+            xr.concat(preds_steps, dim="forecast_step"),
+            xr.concat(tars_steps, dim="forecast_step"),
         )
-        return da_preds_slice, da_tars_slice
+        return da_preds_ts, da_tars_ts
 
     def plot_single_timeseries(
         self,
@@ -59,23 +66,27 @@ class Timeseries:
         channel: str,
         sample: int | str,
         stream: str,
+        region: str,
         ens: str | int | None = None,
     ) -> None:
         """Plot and save a timeseries figure for one (channel, sample[, ens]) triple."""
-        da_preds_slice, da_tars_slice = self.get_preds_tars_per_sample_channel(sample, channel)
-        has_ens = ens is not None and "ens" in da_preds_slice.dims and ens != "mean"
+
+        da_preds_ts, da_tars_ts = self.get_preds_tars_per_region_sample_channel(
+            region, sample, channel
+        )
+        has_ens = ens is not None and "ens" in da_preds_ts.dims and ens != "mean"
         if has_ens:
-            da_preds_slice = da_preds_slice.sel(ens=ens)
-        valid_times = self.da_tars_ts.sel(sample=sample, channel=channel).valid_time.values
+            da_preds_ts = da_preds_ts.sel(ens=ens)
+        valid_times = da_tars_ts.valid_time.values
 
         pred_label = "Prediction" if not has_ens else f"Prediction (ens {ens})"
 
         matplotlib.use("Agg")
         fig, ax = plt.subplots(figsize=(15, 7))
-        ax.plot(valid_times, da_preds_slice.values, label=pred_label)
-        ax.plot(valid_times, da_tars_slice.values, label=stream, linestyle="--")
+        ax.plot(valid_times, da_preds_ts.values, label=pred_label)
+        ax.plot(valid_times, da_tars_ts.values, label=stream, linestyle="--")
         fig.suptitle(
-            f"Timeseries Average \u2013 {self.region_label()}",
+            f"Timeseries Average - {region.capitalize()}",
             fontsize=13,
             fontweight="bold",
         )
@@ -90,23 +101,8 @@ class Timeseries:
         fig.autofmt_xdate()
         out_path = Path(output_dir) / "plots" / stream / "timeseries"
         out_path.mkdir(parents=True, exist_ok=True)
-        fname = f"timeseries_{channel}_sample_{sample}"
+        fname = f"timeseries_{region}_{channel}_sample_{sample}"
         if has_ens:
             fname += f"_ens_{ens}"
         fig.savefig(out_path / f"{fname}.png", bbox_inches="tight")
         plt.close(fig)
-
-    def region_label(self) -> str:
-        """Get a human-readable label for the region based on the lat/lon bounds."""
-
-        _first_da = next(iter(self.da_tars.values()))
-        lat_min = float(_first_da.lat.min())
-        lat_max = float(_first_da.lat.max())
-        lon_min = float(_first_da.lon.min())
-        lon_max = float(_first_da.lon.max())
-        region_label = (
-            f"({lat_min:.2f}\u00b0 \u2013 {lat_max:.2f}\u00b0 N, "
-            f"{lon_min:.2f}\u00b0 \u2013 {lon_max:.2f}\u00b0 E)"
-        )
-
-        return region_label

--- a/packages/evaluate/src/weathergen/evaluate/plotting/timeseries.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/timeseries.py
@@ -2,8 +2,6 @@ from pathlib import Path
 
 import matplotlib
 import matplotlib.pyplot as plt
-import numpy as np
-import numpy.typing as npt
 import xarray as xr
 
 
@@ -55,34 +53,6 @@ class Timeseries:
         )
         return da_preds_slice, da_tars_slice
 
-    def get_valid_times_per_sample_channel(
-        self, sample: int | str, channel: str
-    ) -> npt.NDArray[np.datetime64]:
-        """Get valid times for the given sample/channel from the timeseries data.
-        Parameters
-        ----------
-        sample: int | str
-            The sample for which to extract data.
-        channel: str
-            The channel for which to extract data.
-
-        Returns
-        -------
-        npt.NDArray[np.datetime64]
-            The array of valid times for the given sample and channel.
-        """
-        return self.da_tars_ts.sel(sample=sample, channel=channel).valid_time.values
-
-    def get_channels(self) -> list[str]:
-        """Get the list of channels from the timeseries data."""
-        da_tmp = next(iter(self.da_tars.values()))
-        return da_tmp.channel.values
-
-    def get_samples(self) -> list[str]:
-        """Get the list of samples from the timeseries data."""
-        da_tmp = next(iter(self.da_tars.values()))
-        return da_tmp.sample.values
-
     def plot_single_timeseries(
         self,
         output_dir: str,
@@ -96,7 +66,7 @@ class Timeseries:
         has_ens = ens is not None and "ens" in da_preds_slice.dims and ens != "mean"
         if has_ens:
             da_preds_slice = da_preds_slice.sel(ens=ens)
-        valid_times = self.get_valid_times_per_sample_channel(sample, channel)
+        valid_times = self.da_tars_ts.sel(sample=sample, channel=channel).valid_time.values
 
         pred_label = "Prediction" if not has_ens else f"Prediction (ens {ens})"
 
@@ -112,7 +82,7 @@ class Timeseries:
         ax.set_ylabel(channel)
         ax.set_xlabel("Valid Time")
         ax.legend()
-        max_ticks = max(4, 15)
+        max_ticks = 20
         day_interval = max(1, len(valid_times) // max_ticks)
         ax.xaxis.set_major_locator(matplotlib.dates.DayLocator(interval=day_interval))
         ax.xaxis.set_major_formatter(matplotlib.dates.DateFormatter("%Y-%m-%d"))

--- a/packages/evaluate/src/weathergen/evaluate/plotting/timeseries.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/timeseries.py
@@ -84,15 +84,25 @@ class Timeseries:
         return da_tmp.sample.values
 
     def plot_single_timeseries(
-        self, output_dir: str, channel: str, sample: int | str, stream: str
+        self,
+        output_dir: str,
+        channel: str,
+        sample: int | str,
+        stream: str,
+        ens: str | int | None = None,
     ) -> None:
-        """Plot and save a timeseries figure for one (channel, sample) pair."""
+        """Plot and save a timeseries figure for one (channel, sample[, ens]) triple."""
         da_preds_slice, da_tars_slice = self.get_preds_tars_per_sample_channel(sample, channel)
+        has_ens = ens is not None and "ens" in da_preds_slice.dims and ens != "mean"
+        if has_ens:
+            da_preds_slice = da_preds_slice.sel(ens=ens)
         valid_times = self.get_valid_times_per_sample_channel(sample, channel)
+
+        pred_label = "Prediction" if not has_ens else f"Prediction (ens {ens})"
 
         matplotlib.use("Agg")
         fig, ax = plt.subplots(figsize=(15, 7))
-        ax.plot(valid_times, da_preds_slice.values, label="Prediction")
+        ax.plot(valid_times, da_preds_slice.values, label=pred_label)
         ax.plot(valid_times, da_tars_slice.values, label=stream, linestyle="--")
         fig.suptitle(
             f"Timeseries Average \u2013 {self.region_label()}",
@@ -110,10 +120,10 @@ class Timeseries:
         fig.autofmt_xdate()
         out_path = Path(output_dir) / "plots" / stream / "timeseries"
         out_path.mkdir(parents=True, exist_ok=True)
-        fig.savefig(
-            out_path / f"timeseries_{channel}_sample_{sample}.png",
-            bbox_inches="tight",
-        )
+        fname = f"timeseries_{channel}_sample_{sample}"
+        if has_ens:
+            fname += f"_ens_{ens}"
+        fig.savefig(out_path / f"{fname}.png", bbox_inches="tight")
         plt.close(fig)
 
     def region_label(self) -> str:

--- a/packages/evaluate/src/weathergen/evaluate/plotting/timeseries.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/timeseries.py
@@ -1,0 +1,132 @@
+from pathlib import Path
+
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+import numpy.typing as npt
+import xarray as xr
+
+
+class Timeseries:
+    """
+    Initialize the Timeseries class.
+
+    Parameters
+    ----------
+    da_preds:
+        Dictionary of prediction datasets.
+    da_tars:
+        Dictionary of target datasets.
+    """
+
+    def __init__(self, da_preds: dict[str, xr.Dataset], da_tars: dict[str, xr.Dataset]):
+        self.da_preds = da_preds
+        self.da_tars = da_tars
+
+        preds_steps, tars_steps = [], []
+        for da_p, da_t in zip(self.da_preds.values(), self.da_tars.values(), strict=False):
+            vt = da_p.valid_time.isel(ipoint=0).drop_vars("ipoint")
+            preds_steps.append(da_p.mean(dim="ipoint").assign_coords(valid_time=vt))
+            tars_steps.append(da_t.mean(dim="ipoint").assign_coords(valid_time=vt))
+        self.da_preds_ts, self.da_tars_ts = (
+            xr.concat(preds_steps, dim="forecast_step"),
+            xr.concat(tars_steps, dim="forecast_step"),
+        )
+
+    def get_preds_tars_per_sample_channel(
+        self, sample: int | str, channel: str
+    ) -> tuple[xr.Dataset, xr.Dataset]:
+        """Get preds/tars for the given sample/channel from the timeseries data.
+        Parameters
+        ----------
+        sample: int | str
+            The sample for which to extract data.
+        channel: str
+            The channel for which to extract data.
+
+        Returns
+        -------
+        tuple[xr.Dataset, xr.Dataset]
+            The prediction and target datasets for the given sample and channel.
+        """
+        da_preds_slice, da_tars_slice = (
+            self.da_preds_ts.sel(sample=sample, channel=channel),
+            self.da_tars_ts.sel(sample=sample, channel=channel),
+        )
+        return da_preds_slice, da_tars_slice
+
+    def get_valid_times_per_sample_channel(
+        self, sample: int | str, channel: str
+    ) -> npt.NDArray[np.datetime64]:
+        """Get valid times for the given sample/channel from the timeseries data.
+        Parameters
+        ----------
+        sample: int | str
+            The sample for which to extract data.
+        channel: str
+            The channel for which to extract data.
+
+        Returns
+        -------
+        npt.NDArray[np.datetime64]
+            The array of valid times for the given sample and channel.
+        """
+        return self.da_tars_ts.sel(sample=sample, channel=channel).valid_time.values
+
+    def get_channels(self) -> list[str]:
+        """Get the list of channels from the timeseries data."""
+        da_tmp = next(iter(self.da_tars.values()))
+        return da_tmp.channel.values
+
+    def get_samples(self) -> list[str]:
+        """Get the list of samples from the timeseries data."""
+        da_tmp = next(iter(self.da_tars.values()))
+        return da_tmp.sample.values
+
+    def plot_single_timeseries(
+        self, output_dir: str, channel: str, sample: int | str, stream: str
+    ) -> None:
+        """Plot and save a timeseries figure for one (channel, sample) pair."""
+        da_preds_slice, da_tars_slice = self.get_preds_tars_per_sample_channel(sample, channel)
+        valid_times = self.get_valid_times_per_sample_channel(sample, channel)
+
+        matplotlib.use("Agg")
+        fig, ax = plt.subplots(figsize=(15, 7))
+        ax.plot(valid_times, da_preds_slice.values, label="Prediction")
+        ax.plot(valid_times, da_tars_slice.values, label=stream, linestyle="--")
+        fig.suptitle(
+            f"Timeseries Average \u2013 {self.region_label()}",
+            fontsize=13,
+            fontweight="bold",
+        )
+        ax.set_ylabel(channel)
+        ax.set_xlabel("Valid Time")
+        ax.legend()
+        max_ticks = max(4, 15)
+        day_interval = max(1, len(valid_times) // max_ticks)
+        ax.xaxis.set_major_locator(matplotlib.dates.DayLocator(interval=day_interval))
+        ax.xaxis.set_major_formatter(matplotlib.dates.DateFormatter("%Y-%m-%d"))
+        ax.grid(True, linestyle="--", alpha=0.5)
+        fig.autofmt_xdate()
+        out_path = Path(output_dir) / "plots" / stream / "timeseries"
+        out_path.mkdir(parents=True, exist_ok=True)
+        fig.savefig(
+            out_path / f"timeseries_{channel}_sample_{sample}.png",
+            bbox_inches="tight",
+        )
+        plt.close(fig)
+
+    def region_label(self) -> str:
+        """Get a human-readable label for the region based on the lat/lon bounds."""
+
+        _first_da = next(iter(self.da_tars.values()))
+        lat_min = float(_first_da.lat.min())
+        lat_max = float(_first_da.lat.max())
+        lon_min = float(_first_da.lon.min())
+        lon_max = float(_first_da.lon.max())
+        region_label = (
+            f"({lat_min:.2f}\u00b0 \u2013 {lat_max:.2f}\u00b0 N, "
+            f"{lon_min:.2f}\u00b0 \u2013 {lon_max:.2f}\u00b0 E)"
+        )
+
+        return region_label

--- a/src/weathergen/datasets/batch.py
+++ b/src/weathergen/datasets/batch.py
@@ -157,7 +157,6 @@ class Sample:
         return min(lens) if len(lens) > 0 else 0
 
 
-
 class BatchSamples:
     """
     Container for source or target samples
@@ -219,7 +218,6 @@ class BatchSamples:
         Get number of target steps from smallest of all available streams
         """
         return self.samples[0].get_num_target_steps()
-
 
     def get_output_idxs(self) -> int:
         """
@@ -506,4 +504,3 @@ class ModelBatch:
         Get number of target steps from smallest of all available streams
         """
         return self.target_samples.get_num_target_steps()
-

--- a/src/weathergen/datasets/stream_data.py
+++ b/src/weathergen/datasets/stream_data.py
@@ -459,7 +459,6 @@ class StreamData:
         return len(self.target_tokens)
 
 
-
 def spoof(healpix_level: int, datetime, geoinfo_size, num_channels) -> IOReaderData:
     """
     Spoof an instance from data_reader_base.ReaderData instance.


### PR DESCRIPTION
## Description

With this PR, we allow plotting of timeseries per variable and sample. Example use:

```
default_streams:
  ERA5:
    regions: ["global"]
    channels: ["2t", "10u"] #, "10v", "z_500", "t_850", "u_850", "v_850", "q_850", ]
    evaluation:
      forecast_step: "all"
      sample: "all"
    plotting:
      sample: "all"
      forecast_step: "all" #supported: "all", [1,2,3,...], "1-50" (equivalent of [1,2,3,...50])
      plot_maps: false
      plot_bias: false
      plot_target: false
      plot_histograms: false
      plot_animations: false
      plot_timeseries: true        <--------------------------

```

## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/1933

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [X] I have performed a self-review of my code
-   [X] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [X] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
