### PR TITLE
integrate plot as a function of initialization time into FastEvaluation

### DIFF
--- a/config/evaluate/eval_config.yml
+++ b/config/evaluate/eval_config.yml
@@ -40,6 +40,7 @@ evaluation:
   plot_ensemble: "members" #supported: false, "std", "minmax", "members"
   plot_score_maps: false #plot scores on a 2D maps. it slows down score computation
   plot_score_animations: false #plot animations of score maps across forecast steps. it slows down score computation
+  plot_score_timeseries: true #plot timeseries of scores across forecast steps. 
   print_summary: false #print out score values on screen. it can be verbose
   log_scale: false
   add_grid: false
@@ -51,6 +52,7 @@ evaluation:
 
 default_streams:
   ERA5:
+    #offset: "1h" #optional: specify a timedelta offset to infer init_time when source_interval is missing. Format examples: "1h", "30m", "2h30m".
     regions: ["global"]
     channels: ["2t", "10u"] #, "10v", "z_500", "t_850", "u_850", "v_850", "q_850", ]
     evaluation:

--- a/config/evaluate/eval_config.yml
+++ b/config/evaluate/eval_config.yml
@@ -46,7 +46,6 @@ evaluation:
   add_grid: false
   score_cards: false
   bar_plots: false
-  num_processes: 0  #options: int, "auto", 0 means no parallelism (default)
   # baseline: "ar40mckx"
 
 

--- a/packages/evaluate/src/weathergen/evaluate/export/export_inference.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/export_inference.py
@@ -104,7 +104,7 @@ def parse_args(args: list) -> argparse.Namespace:
     parser.add_argument(
         "--stream",
         type=str,
-        choices=["ERA5", "CERRA", "MEPS", "NORA3", "IMERG_ANEMOI"],
+        choices=["N320", "ERA5", "CERRA", "MEPS", "NORA3", "IMERG_ANEMOI"],
         help="Stream name to retrieve data for",
     )
 

--- a/packages/evaluate/src/weathergen/evaluate/io/data/dataarray_builders.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/data/dataarray_builders.py
@@ -139,7 +139,7 @@ def build_gridded_dataarrays(
         "lat": ("ipoint", sub_lat),
         "lon": ("ipoint", sub_lon),
         "valid_time": (("sample", "ipoint"), valid_time_2d),
-        "source_interval_end": ("sample", init_times.copy()),
+        "init_times": ("sample", init_times.copy()),
         "forecast_step": forecast_step_val,
     }
 
@@ -231,7 +231,6 @@ def build_scatter_dataarrays(
             if per_sample_obs_times is not None and si < len(per_sample_obs_times)
             else np.full(n_ip, per_sample_valid_times[si], dtype="datetime64[ns]")
         )
-        si_start = init_times[si]
 
         sample_coords = {
             "ipoint": np.arange(n_ip),
@@ -239,7 +238,7 @@ def build_scatter_dataarrays(
             "lat": ("ipoint", sample_lat),
             "lon": ("ipoint", sample_lon),
             "valid_time": ("ipoint", vt_arr),
-            "source_interval_end": si_start,
+            "init_times": init_times[si],
             "forecast_step": forecast_step_val,
             "sample": sample,
         }

--- a/packages/evaluate/src/weathergen/evaluate/io/data/dataarray_builders.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/data/dataarray_builders.py
@@ -139,7 +139,7 @@ def build_gridded_dataarrays(
         "lat": ("ipoint", sub_lat),
         "lon": ("ipoint", sub_lon),
         "valid_time": (("sample", "ipoint"), valid_time_2d),
-        "source_interval_start": ("sample", init_times.copy()),
+        "source_interval_end": ("sample", init_times.copy()),
         "forecast_step": forecast_step_val,
     }
 
@@ -239,7 +239,7 @@ def build_scatter_dataarrays(
             "lat": ("ipoint", sample_lat),
             "lon": ("ipoint", sample_lon),
             "valid_time": ("ipoint", vt_arr),
-            "source_interval_start": si_start,
+            "source_interval_end": si_start,
             "forecast_step": forecast_step_val,
             "sample": sample,
         }

--- a/packages/evaluate/src/weathergen/evaluate/io/data/dataarray_postprocessing.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/data/dataarray_postprocessing.py
@@ -88,7 +88,7 @@ def _select_channels(
 def _add_lead_time_coord(da: xr.DataArray, sample_dim="sample") -> xr.DataArray:
     """
     Add lead_time coordinate computed as:
-    valid_time - source_interval_end
+    valid_time - init_times
 
     lead_time has dims (sample, ipoint) and dtype timedelta64[ns].
 
@@ -109,8 +109,8 @@ def _add_lead_time_coord(da: xr.DataArray, sample_dim="sample") -> xr.DataArray:
 
     """
     vt = da["valid_time"].values
-    sis = da["source_interval_end"].values
-    # Compute lead_time: valid_time - source_interval_end
+    sis = da["init_times"].values
+    # Compute lead_time: valid_time - init_times
 
     if vt.ndim > 1:
         sis_expanded = sis[:, np.newaxis] if sis.ndim == 1 else sis

--- a/packages/evaluate/src/weathergen/evaluate/io/data/dataarray_postprocessing.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/data/dataarray_postprocessing.py
@@ -88,7 +88,7 @@ def _select_channels(
 def _add_lead_time_coord(da: xr.DataArray, sample_dim="sample") -> xr.DataArray:
     """
     Add lead_time coordinate computed as:
-    valid_time - source_interval_start
+    valid_time - source_interval_end
 
     lead_time has dims (sample, ipoint) and dtype timedelta64[ns].
 
@@ -109,8 +109,8 @@ def _add_lead_time_coord(da: xr.DataArray, sample_dim="sample") -> xr.DataArray:
 
     """
     vt = da["valid_time"].values
-    sis = da["source_interval_start"].values
-    # Compute lead_time: valid_time - source_interval_start
+    sis = da["source_interval_end"].values
+    # Compute lead_time: valid_time - source_interval_end
 
     if vt.ndim > 1:
         sis_expanded = sis[:, np.newaxis] if sis.ndim == 1 else sis

--- a/packages/evaluate/src/weathergen/evaluate/io/data/dataarray_postprocessing.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/data/dataarray_postprocessing.py
@@ -109,12 +109,12 @@ def _add_lead_time_coord(da: xr.DataArray, sample_dim="sample") -> xr.DataArray:
 
     """
     vt = da["valid_time"].values
-    sis = da["init_times"].values
+    it = da["init_times"].values
     # Compute lead_time: valid_time - init_times
 
     if vt.ndim > 1:
-        sis_expanded = sis[:, np.newaxis] if sis.ndim == 1 else sis
-        lead_time_values = vt - sis_expanded
+        it_expanded = it[:, np.newaxis] if it.ndim == 1 else it
+        lead_time_values = vt - it_expanded
         # Get unique lead_time per sample, verify consistency
         lead_times = [
             np.unique(lead_time_values[i][~np.isnat(lead_time_values[i])])
@@ -127,7 +127,7 @@ def _add_lead_time_coord(da: xr.DataArray, sample_dim="sample") -> xr.DataArray:
             )
         lead_time_per_sample = np.array([lt[0] for lt in lead_times])
     else:
-        lead_time_values = vt - sis
+        lead_time_values = vt - it
         lead_time_per_sample = np.unique(lead_time_values[~np.isnat(lead_time_values)])
 
     # Verify all samples have same lead_time for this forecast_step

--- a/packages/evaluate/src/weathergen/evaluate/io/data/io_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/data/io_orchestration.py
@@ -361,7 +361,7 @@ def _extract_init_times(
     si_list = []
     for i in range(len(samples)):
         si = results[i][3].get("source_interval", {})
-        last_str = si.get("end", si.get("start", None))
+        last_str = si.get("end", None)
         if last_str is not None:
             si_list.append(np.datetime64(last_str, "ns"))
         elif offset is not None:

--- a/packages/evaluate/src/weathergen/evaluate/io/data/io_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/data/io_orchestration.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import xarray as xr
 from joblib import Parallel, delayed
 from joblib.externals.loky import get_reusable_executor
@@ -78,6 +79,9 @@ class IOState:
     n_workers: int
     backend: str = "loky"
     rank: str = "0000"
+    offset: np.timedelta64 | None = (
+        None  # fallback offset in hours for init_time when source_interval is missing
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -258,7 +262,9 @@ def _build_io_state(
     coords, zarr_channels, _ = _read_coords_and_meta(zarr_path, stream, fsteps[0], is_zip)
     read_channels: list[str] = zarr_channels if zarr_channels else all_channels
     channel_idxs: list[int] | None = None if zarr_channels else list(range(len(all_channels)))
-
+    offset = stream_cfg.get("offset")
+    if offset is not None:
+        offset = np.timedelta64(pd.Timedelta(offset).value, "h")
     # ---- Early channel selection (skip unrequested channels at numpy level) ----
     channel_idxs, read_channels = _compute_early_channel_selection(
         read_channels, channels, stream_cfg
@@ -286,6 +292,7 @@ def _build_io_state(
         lon=lon,
         n_workers=n_io_workers,
         rank=rank,
+        offset=offset,
     )
 
 
@@ -343,15 +350,28 @@ def _parallel_read(
         return results, True
 
 
-def _extract_init_times(results: list, samples: list[int]) -> NDArray:
-    """Build a (n_samples,) datetime64[ns] array of initialisation times (last source time)."""
+def _extract_init_times(
+    results: list, samples: list[int], offset: np.timedelta64 | None = None
+) -> NDArray:
+    """Build a (n_samples,) datetime64[ns] array of initialisation times (last source time).
+
+    If source_interval is empty, fall back to first_valid_time - offset so that
+    lead_time for the first sub-step of fstep 1 equals offset.
+    """
     si_list = []
     for i in range(len(samples)):
         si = results[i][3].get("source_interval", {})
         last_str = si.get("end", si.get("start", None))
-        si_list.append(
-            np.datetime64(last_str, "ns") if last_str is not None else np.datetime64("NaT", "ns")
-        )
+        if last_str is not None:
+            si_list.append(np.datetime64(last_str, "ns"))
+        elif offset is not None:
+            # Fallback: infer init_time from the first valid_time minus 1h
+            time_entry = results[i][2][0] if results[i][2] else []
+            if len(time_entry) > 0:
+                first_vt = np.datetime64(time_entry[0], "ns")
+                si_list.append(first_vt - offset)
+        else:
+            si_list.append(np.datetime64("NaT", "ns"))
     return np.array(si_list)
 
 
@@ -498,7 +518,7 @@ def get_data_dirstore(state: IOState) -> ReaderOutput:
             n_workers = 1
 
         if init_times is None:
-            init_times = _extract_init_times(results, state.samples)
+            init_times = _extract_init_times(results, state.samples, state.offset)
 
         n_sub = results[0][3]["n_substeps"][0]
 
@@ -584,6 +604,7 @@ def get_data_zipstore(state: IOState) -> ReaderOutput:
     init_times = _extract_init_times(
         [flat_results[si * n_fsteps] for si in range(len(state.samples))],
         state.samples,
+        state.offset,
     )
 
     da_tars_dict: dict = {}

--- a/packages/evaluate/src/weathergen/evaluate/io/data/io_workers.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/data/io_workers.py
@@ -146,7 +146,9 @@ def _read_sample(
     n_substeps = []  # track how many sub-steps per fstep
     source_interval = None
 
-    # Derive source interval from the source group's times at fstep 0.
+    # Recover the source interval once per sample. Older outputs store source
+    # timestamps under ``.../0/source/times``; newer ones persist the same
+    # metadata in the target/prediction group attrs.
     try:
         source_times = np.asarray(ds[f"{sample}/{stream}/0/source/times"])
         source_window_start = str(np.min(source_times))
@@ -154,6 +156,20 @@ def _read_sample(
         source_interval = {"start": source_window_start, "end": source_window_end}
     except (KeyError, AttributeError):
         source_interval = {}
+        for fs in fsteps:
+            base = f"{sample}/{stream}/{fs}"
+            for group_name in ("target", "prediction"):
+                try:
+                    group = ds[f"{base}/{group_name}"]
+                except KeyError:
+                    continue
+
+                source_interval_attr = group.attrs.get("source_interval")
+                if source_interval_attr:
+                    source_interval = dict(source_interval_attr)
+                    break
+            if source_interval:
+                break
 
     for fs in fsteps:
         base = f"{sample}/{stream}/{fs}"

--- a/packages/evaluate/src/weathergen/evaluate/plotting/line_plots.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/line_plots.py
@@ -338,13 +338,14 @@ class LinePlots:
         # TODO: generalise this for other x_dims by introducing a "units"
         # entry in the function if needed
         xunits = "hr" if x_dim == "lead_time" else None
+        y_dim_opts = (y_dim, "ratio", None) if y_dim == "value" else y_dim
+        x_dim_opts = (x_dim, xunits, None) if xunits else x_dim
         self._plot_base(
             fig,
             name,
-            x_dim,
-            y_dim,
+            x_dim_opts,
+            y_dim_opts,
             print_summary,
-            xunits=xunits,
             title=title,
             out_plot_dir=self.out_plot_dir_lines,
         )
@@ -353,14 +354,12 @@ class LinePlots:
         self,
         fig: plt.Figure,
         name: str,
-        x_dim: str,
-        y_dim: str,
+        x_dim: tuple[str, ...],
+        y_dim: tuple[str, ...],
         print_summary: bool = False,
         line: float | None = None,
         vlines: bool = False,
         title: str | None = None,
-        xunits: str | None = None,
-        yunits: str | None = None,
         out_plot_dir: Path = None,
         range: tuple[float, float] | None = None,
     ) -> None:
@@ -373,9 +372,13 @@ class LinePlots:
         name:
             Name of the plot file
         x_dim:
-            Label for the x-axis
+            Label for the x-axis, can be a tuple if the x-axis has units and/or
+            a description is needed (e.g. ("improvement"))
+            syntax: (label, units, description)
         y_dim:
-            Label for the y-axis
+            Label for the y-axis, can be a tuple if the y-axis has units and/or
+            a description is needed (e.g. ("improvement"))
+            syntax: (label, units, description)
         print_summary:
             If True, print a summary of the values from the graph.
         line:
@@ -384,10 +387,6 @@ class LinePlots:
             If True, draw vertical lines to separate each group of variables.
         title:
             Title for the plot.
-        xunits:
-            Units for the x-axis.
-        yunits:
-            Units for the y-axis.
         out_plot_dir:
             Directory where the plot will be saved.
         range:
@@ -396,9 +395,19 @@ class LinePlots:
         -------
             None
         """
+        x_dim, xunits, x_dim_descr = x_dim if isinstance(x_dim, tuple) else (x_dim, None, None)
+        y_dim, yunits, y_dim_descr = y_dim if isinstance(y_dim, tuple) else (y_dim, None, None)
 
-        xlabel = clean_label(x_dim) + (f" [{xunits}]" if xunits else "")
-        ylabel = clean_label(y_dim).upper() + (f" [{yunits}]" if yunits else "")
+        xlabel = (
+            clean_label(x_dim)
+            + (f" [{xunits}]" if xunits else "")
+            + (f" ({x_dim_descr})" if x_dim_descr else "")
+        )
+        ylabel = (
+            clean_label(y_dim).upper()
+            + (f" [{yunits}]" if yunits else "")
+            + (f" ({y_dim_descr})" if y_dim_descr else "")
+        )
 
         ax = fig.gca()
 
@@ -525,7 +534,6 @@ class LinePlots:
                 if c is not None:
                     color_map[rid] = c
 
-
         # Pre-compute all ratios and global y-axis range
         all_fsteps = sorted(data_list[min_index]["forecast_step"].values)
         # ratios_by_fstep[f_step] = [(run_id, label, ratio_values), ...]
@@ -576,11 +584,13 @@ class LinePlots:
                 f"{descr.replace('_', ' ')} {tag.split('_')[0]} | fstep {f_step} | "
                 f" {tag.split('_')[-1]} (baseline: {baseline_name})"
             )
+
+            y_dim_opts = (y_dim, "ratio", None) if y_dim == "value" else y_dim
             self._plot_base(
                 fig,
                 name,
                 "channel",
-                y_dim,
+                y_dim_opts,
                 print_summary,
                 line=1.0,
                 vlines=True,

--- a/packages/evaluate/src/weathergen/evaluate/plotting/line_plots.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/line_plots.py
@@ -338,13 +338,12 @@ class LinePlots:
         # TODO: generalise this for other x_dims by introducing a "units"
         # entry in the function if needed
         xunits = "hr" if x_dim == "lead_time" else None
-        y_dim_opts = (y_dim, "ratio", None) if y_dim == "value" else y_dim
-        x_dim_opts = (x_dim, xunits, None) if xunits else x_dim
+        x_dim_opts = (x_dim, None, xunits) if xunits else x_dim
         self._plot_base(
             fig,
             name,
             x_dim_opts,
-            y_dim_opts,
+            y_dim,
             print_summary,
             title=title,
             out_plot_dir=self.out_plot_dir_lines,
@@ -395,8 +394,8 @@ class LinePlots:
         -------
             None
         """
-        x_dim, xunits, x_dim_descr = x_dim if isinstance(x_dim, tuple) else (x_dim, None, None)
-        y_dim, yunits, y_dim_descr = y_dim if isinstance(y_dim, tuple) else (y_dim, None, None)
+        x_dim, x_dim_descr, xunits = x_dim if isinstance(x_dim, tuple) else (x_dim, None, None)
+        y_dim, y_dim_descr, yunits = y_dim if isinstance(y_dim, tuple) else (y_dim, None, None)
 
         xlabel = (
             clean_label(x_dim)
@@ -585,7 +584,7 @@ class LinePlots:
                 f" {tag.split('_')[-1]} (baseline: {baseline_name})"
             )
 
-            y_dim_opts = (y_dim, "ratio", None) if y_dim == "value" else y_dim
+            y_dim_opts = (y_dim, "improvement", None)
             self._plot_base(
                 fig,
                 name,

--- a/packages/evaluate/src/weathergen/evaluate/plotting/line_plots.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/line_plots.py
@@ -362,6 +362,7 @@ class LinePlots:
         xunits: str | None = None,
         yunits: str | None = None,
         out_plot_dir: Path = None,
+        range: tuple[float, float] | None = None,
     ) -> None:
         """
         Apply labels, title, legend, save and optionally print summary.
@@ -389,6 +390,8 @@ class LinePlots:
             Units for the y-axis.
         out_plot_dir:
             Directory where the plot will be saved.
+        range:
+            Tuple specifying the y-axis range (min, max).
         Returns
         -------
             None
@@ -515,37 +518,55 @@ class LinePlots:
 
         ref = align_labels(ref_raw, ref_channel_names, "channel").reindex(channel=ref_channel_names)
 
-        # Build a run_id → color map, skipping the baseline
+        # Build a run_id to color map, skipping the baseline
         color_map = {}
         if colors:
             for rid, c in zip(run_ids, colors, strict=False):
                 if c is not None:
                     color_map[rid] = c
 
-        for f_step in sorted(data_list[min_index]["forecast_step"].values):
-            # Create a new figure for each forecast step
-            fig = plt.figure(figsize=(max(12, len(ref_channel_names) * 0.25), 6))
-            for data, run_id, lbl in zip(data_list, run_ids, label_list, strict=False):
-                if run_id == baseline_name:
-                    continue
 
-                num_raw = self._preprocess_data(data, ["forecast_step", "channel"], verbose=False)
-                num = align_labels(num_raw, ref_channel_names, "channel").reindex(
-                    channel=ref_channel_names
-                )
+        # Pre-compute all ratios and global y-axis range
+        all_fsteps = sorted(data_list[min_index]["forecast_step"].values)
+        # ratios_by_fstep[f_step] = [(run_id, label, ratio_values), ...]
+        ratios_by_fstep: dict[int, list[tuple[str, str, object]]] = {f: [] for f in all_fsteps}
+        global_ymin = float("inf")
+        global_ymax = float("-inf")
+
+        for data, run_id, lbl in zip(data_list, run_ids, label_list, strict=False):
+            if run_id == baseline_name:
+                continue
+            num_raw = self._preprocess_data(data, ["forecast_step", "channel"], verbose=False)
+            num = align_labels(num_raw, ref_channel_names, "channel").reindex(
+                channel=ref_channel_names
+            )
+            for f_step in all_fsteps:
                 ratio = num.sel(channel=ref_channel_names, forecast_step=f_step) / ref.sel(
                     channel=ref_channel_names, forecast_step=f_step
                 )
+                ratios_by_fstep[f_step].append((run_id, lbl, ratio.values))
+                finite = ratio.values[~xr.DataArray(ratio).isnull().values]
+                if len(finite) > 0:
+                    global_ymin = min(global_ymin, float(finite.min()))
+                    global_ymax = max(global_ymax, float(finite.max()))
 
+        # Add a small margin (5%) around the range
+        if global_ymin != float("inf"):
+            margin = 0.05 * (global_ymax - global_ymin) if global_ymax > global_ymin else 0.1
+            global_ymin -= margin
+            global_ymax += margin
+
+        # Plot each forecast step
+        for f_step in all_fsteps:
+            fig = plt.figure(figsize=(max(12, len(ref_channel_names) * 0.25), 6))
+            for run_id, lbl, ratio_vals in ratios_by_fstep[f_step]:
                 plot_kwargs = dict(label=lbl, marker="o", linestyle="-")
                 if run_id in color_map:
                     plot_kwargs["color"] = color_map[run_id]
+                plt.plot(ref_channel_names, ratio_vals, **plot_kwargs)
 
-                plt.plot(
-                    ref_channel_names,
-                    ratio.values,
-                    **plot_kwargs,
-                )
+            if global_ymin != float("inf"):
+                plt.ylim(global_ymin, global_ymax)
 
             parts = [descr, f"fstep_0{f_step}", tag]
             name = "_".join(filter(None, parts))

--- a/packages/evaluate/src/weathergen/evaluate/plotting/line_plots.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/line_plots.py
@@ -552,7 +552,7 @@ class LinePlots:
             plt.xticks(rotation=90, ha="right")
             plt.grid(True, linestyle="--", color="gray", alpha=0.2)
             title = (
-                f"{descr.replace('_', ' ')} {tag.split('_')[0]} -"
+                f"{descr.replace('_', ' ')} {tag.split('_')[0]} | fstep {f_step} | "
                 f" {tag.split('_')[-1]} (baseline: {baseline_name})"
             )
             self._plot_base(

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import imageio
 import matplotlib
+import matplotlib.pyplot as plt
 import numpy as np
 import omegaconf as oc
 import xarray as xr
@@ -21,11 +22,16 @@ from joblib import delayed
 from PIL import Image
 from tqdm import tqdm
 
+
 from weathergen.evaluate.io.data.io_orchestration import dispatch_parallel, get_num_workers
 from weathergen.evaluate.io.io_reader import Reader, ReaderOutput
 from weathergen.evaluate.plotting.bar_plots import BarPlots
 from weathergen.evaluate.plotting.line_plots import LinePlots
-from weathergen.evaluate.plotting.plot_orchestration_utils import _compute_ranges, _compute_scores
+from weathergen.evaluate.plotting.plot_orchestration_utils import (
+    _compute_ranges,
+    _compute_scores,
+    group_by_init_hour,
+)
 from weathergen.evaluate.plotting.plot_utils import (
     bar_plot_metric_region,
     heat_maps_metric_region,
@@ -39,8 +45,285 @@ from weathergen.evaluate.plotting.quantile_plots import QuantilePlots
 from weathergen.evaluate.plotting.score_cards import ScoreCards
 from weathergen.evaluate.utils.array_utils import bias_ranges, common_ranges
 from weathergen.evaluate.utils.clim_utils import get_climatology
+from weathergen.evaluate.scores.score import VerifiedData, get_score
 
 _logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# timeseries
+# ---------------------------------------------------------------------------
+def run_score_timeseries_pipeline(
+    reader: Reader,
+    stream: str,
+    regions: list[str],
+    metrics_dict: dict,
+    output_data: "ReaderOutput | None" = None,
+    global_plotting_options: dict | None = None,
+) -> dict[str, dict[str, dict[int, xr.DataArray]]]:
+    """Plot timeseries of score values across forecast steps for all regions.
+
+    Parameters
+    ----------
+    reader : Reader
+        Reader object containing all info about a particular run.
+    stream : str
+        Stream name to plot score timeseries for.
+    regions : list[str]
+        List of regions to plot.
+    metrics_dict : dict
+        Dictionary mapping region names to metric dicts.
+    output_data : ReaderOutput | None
+        Pre-loaded data; when provided ``reader.get_data()`` is skipped.
+    global_plotting_options : dict | None
+        Global plotting options. These can be passed to the plotter and can be used to set options.
+
+    Returns
+    -------
+    dict[str, dict[str, dict[int, xr.DataArray]]]
+        Nested dict: ``scores_by_hour[metric][region][fstep] = xr.DataArray`` with
+        dims ``(source_end_hour, channel)``.  Returns empty dict on failure.
+    """
+
+    available_data = reader.check_availability(stream, mode="evaluation")
+    if not available_data.score_availability:
+        _logger.warning(f"RUN {reader.run_id} - {stream}: No data available for score timeseries.")
+        return {}
+
+    da_tars = output_data.target
+    da_preds = output_data.prediction
+    if not da_tars:
+        return {}
+
+    # Group samples by hour of day of source_interval_end
+    hour_to_samples = group_by_init_hour(output_data)
+    if not hour_to_samples:
+        _logger.warning(f"RUN {reader.run_id} - {stream}: Could not group by init hour. Skipping.")
+        return {}
+
+    unique_hours = sorted(hour_to_samples.keys())
+    fsteps = sorted(da_preds.keys())
+
+    n_workers = get_num_workers(
+        check_process_headroom=True,
+        max_workers=reader.eval_cfg.get("max_workers", None),
+    )
+
+    # --- Parallel score computation across (region, fstep) pairs ---
+    score_tasks: list[dict] = []
+    for fstep in fsteps:
+        preds_fs = da_preds[fstep]
+        tars_fs = da_tars[fstep]
+
+        # Assign source_end_hour coordinate from the grouping
+        hour_values = np.full(len(preds_fs.sample), -1, dtype=int)
+        sample_vals = preds_fs.sample.values
+        for hour, sample_indices in hour_to_samples.items():
+            mask = np.isin(sample_vals, sample_indices)
+            hour_values[mask] = hour
+
+        source_end_hour = xr.DataArray(
+            hour_values, dims=("sample",), coords={"sample": sample_vals}
+        )
+        preds_with_hour = preds_fs.assign_coords(source_end_hour=source_end_hour)
+        tars_with_hour = tars_fs.assign_coords(source_end_hour=source_end_hour)
+
+        for region in regions:
+            region_metrics = metrics_dict.get(region)
+            metric_names = list(region_metrics.keys())
+            metric_params = list(region_metrics.values())
+            score_tasks.append(
+                dict(
+                    fstep=fstep,
+                    region=region,
+                    metric_names=metric_names,
+                    metric_params=metric_params,
+                    preds_with_hour=preds_with_hour,
+                    tars_with_hour=tars_with_hour,
+                    unique_hours=unique_hours,
+                )
+            )
+
+    _logger.info(
+        f"RUN {reader.run_id} - {stream}: Computing score timeseries for "
+        f"{len(score_tasks)} (region, fstep) tasks with up to {n_workers} worker(s)."
+    )
+
+    calls = [delayed(_compute_timeseries_scores_for_fstep)(**t) for t in score_tasks]
+    raw_results = dispatch_parallel(
+        calls, n_workers=n_workers, backend="loky", desc=f"Score timeseries {stream}"
+    )
+
+    # Accumulate results into scores_by_hour[metric][region][fstep]
+    scores_by_hour: dict[str, dict[str, dict[int, xr.DataArray]]] = {}
+    for fstep, region, metric_scores in raw_results:
+        for metric_name, score in metric_scores.items():
+            scores_by_hour.setdefault(metric_name, {}).setdefault(region, {})[fstep] = score
+
+    _logger.info(
+        f"RUN {reader.run_id} - {stream}: Score timeseries computed for "
+        f"{len(fsteps)} fsteps × {len(unique_hours)} init hours."
+    )
+
+    # --- Parallel plotting ---
+    _plot_timeseries_parallel(
+        reader, stream, scores_by_hour, unique_hours, fsteps, da_tars,
+        global_plotting_options, n_workers,
+    )
+
+    return scores_by_hour
+
+    
+def _compute_timeseries_scores_for_fstep(
+    fstep: int,
+    region: str,
+    metric_names: list[str],
+    metric_params: list,
+    preds_with_hour: xr.DataArray,
+    tars_with_hour: xr.DataArray,
+    unique_hours: list[int],
+) -> tuple[int, str, dict[str, xr.DataArray]]:
+    """Compute grouped scores for one (region, fstep) pair (parallelisable worker).
+
+    Returns ``(fstep, region, {metric_name: score_da})``.
+    """
+    group_by_coord = "source_end_hour" if len(unique_hours) > 1 else None
+    agg_dims = ["sample", "ipoint"]
+
+    metric_scores: dict[str, xr.DataArray] = {}
+    for metric_name, parameters in zip(metric_names, metric_params, strict=False):
+        score = get_score(
+            VerifiedData(preds_with_hour, tars_with_hour, None, None, None),
+            metric_name,
+            agg_dims=agg_dims,
+            group_by_coord=group_by_coord,
+            compute=True,
+            parameters=parameters,
+        )
+        if group_by_coord is None:
+            score = score.expand_dims({"source_end_hour": [int(unique_hours[0])]})
+        metric_scores[metric_name] = score
+
+    return fstep, region, metric_scores
+
+
+def _plot_single_timeseries(
+    output_dir: str,
+    run_id: str,
+    metric_name: str,
+    region: str,
+    channel: str | None,
+    fstep: int,
+    lt_label: str,
+    score: xr.DataArray,
+    unique_hours: list[int],
+    image_format: str,
+    dpi_val: int,
+) -> None:
+    """Plot a single timeseries figure (parallelisable worker)."""
+    matplotlib.use("Agg")
+
+    score_vals = score.sel(channel=channel) if channel is not None else score
+    hours = score_vals.coords["source_end_hour"].values
+    values = score_vals.values.flatten()
+
+    plt.figure(figsize=(10, 6), dpi=dpi_val)
+    plt.plot(hours, values, marker="o", linewidth=2, label=run_id)
+
+    ch_label = channel if channel is not None else "all"
+    title = (
+        f"{metric_name.upper()} vs source end hour | {ch_label} | "
+        f" {lt_label} | {region}"
+    )
+    plt.title(title)
+    plt.xlabel("Source window end hour [UTC]")
+    plt.ylabel(metric_name.upper())
+    plt.xlim(min(unique_hours) - 0.5, max(unique_hours) + 0.5)
+    plt.xticks(unique_hours)
+    plt.grid(True, alpha=0.3)
+    plt.legend()
+    plt.tight_layout()
+
+    out_dir = Path(output_dir)
+    plot_path = (
+        out_dir
+        / f"{metric_name}_{ch_label}_{region}_lead_{lt_label}"
+          f"_by_source_end_hour.{image_format}"
+    )
+    plt.savefig(plot_path, bbox_inches="tight")
+    plt.close()
+
+
+def _plot_timeseries_parallel(
+    reader: Reader,
+    stream: str,
+    scores_by_hour: dict[str, dict[str, dict[int, xr.DataArray]]],
+    unique_hours: list[int],
+    fsteps: list[int],
+    da_tars: dict[int, xr.DataArray],
+    global_plotting_options: dict | None,
+    n_workers: int | None = None,
+) -> None:
+    """Dispatch timeseries plotting tasks in parallel."""
+
+    output_dir = reader.runplot_dir / "plots" / stream / "score_timeseries"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    run_id = reader.run_id
+    plot_cfg = global_plotting_options or {}
+    image_format = plot_cfg.get("image_format", "png")
+    dpi_val = plot_cfg.get("dpi_val", 150)
+
+    # Build fstep → lead_time label mapping
+    lead_time_by_fstep: dict[int, str] = {}
+    for fstep in fsteps:
+        da = da_tars[fstep]
+        if "lead_time" in da.coords:
+            lt = da.coords["lead_time"].values
+            hours = int(lt.astype("timedelta64[h]").astype(int))
+            lead_time_by_fstep[fstep] = f"lead time {hours}h"
+        else:
+            lead_time_by_fstep[fstep] = f"fstep {fstep}"
+
+    # Build plot tasks
+    plot_tasks: list[dict] = []
+    for metric_name, region_dict in scores_by_hour.items():
+        for region, fstep_dict in region_dict.items():
+            sample_score = next(iter(fstep_dict.values()))
+            channels = (
+                list(sample_score.coords["channel"].values)
+                if "channel" in sample_score.dims
+                else [None]
+            )
+            for channel in channels:
+                for fstep, score in fstep_dict.items():
+                    plot_tasks.append(
+                        dict(
+                            output_dir=str(output_dir),
+                            run_id=run_id,
+                            metric_name=metric_name,
+                            region=region,
+                            channel=channel,
+                            fstep=fstep,
+                            lt_label=lead_time_by_fstep[fstep],
+                            score=score,
+                            unique_hours=unique_hours,
+                            image_format=image_format,
+                            dpi_val=dpi_val,
+                        )
+                    )
+
+    _logger.info(
+        f"RUN {run_id} - {stream}: Plotting {len(plot_tasks)} timeseries figures "
+        f"with up to {n_workers} worker(s)."
+    )
+
+    calls = [delayed(_plot_single_timeseries)(**t) for t in plot_tasks]
+    dispatch_parallel(
+        calls, n_workers=n_workers, backend="loky", desc=f"Timeseries plots {stream}"
+    )
+
+    _logger.info(f"RUN {run_id} - {stream}: Score timeseries plots saved to {output_dir}.")
 
 # ---------------------------------------------------------------------------
 # Score maps
@@ -54,7 +337,7 @@ def run_score_map_pipeline(
     metrics_dict: dict,
     output_data: "ReaderOutput | None" = None,
     global_plotting_options: dict | None = None,
-    plot_score_animations: bool = False,
+    plot_score_options: dict | None = None,
 ) -> None:
     """Plot spatial score maps for all regions and forecast steps.
 
@@ -72,9 +355,11 @@ def run_score_map_pipeline(
         Pre-loaded data; when provided ``reader.get_data()`` is skipped.
     global_plotting_options : dict | None
         Global plotting options. These can be passed to the plotter and can be used to set options.
-    plot_score_animations : bool
-        Whether to build animations of score maps across forecast steps.
+    plot_score_options : dict | None
+        Dictionary containing all common score calculation options.
     """
+
+
     if not reader.is_gridded_data(stream):
         _logger.debug(f"RUN {reader.run_id} - {stream}: Skipping score maps (non-gridded data).")
         return
@@ -158,8 +443,8 @@ def run_score_map_pipeline(
 
     calls = [delayed(_plot_score_maps_per_stream)(**t) for t in fstep_tasks]
     dispatch_parallel(calls, n_workers=n_plot_workers, backend="loky", desc=f"Score maps {stream}")
-
-    # Derive variables and ens_values from the computed results.
+   
+    plot_score_animations = plot_score_options.get("score_animation", False)
     if plot_score_animations:
         _dispatch_score_map_animations(
             map_dir=map_dir,
@@ -827,6 +1112,98 @@ def plot_data(
 # ---------------------------------------------------------------------------
 # Summary plots
 # ---------------------------------------------------------------------------
+
+
+def plot_timeseries_summary(
+    cfg: dict,
+    timeseries_scores: dict,
+    summary_dir: Path,
+) -> None:
+    """Plot timeseries summary comparing multiple run_ids on the same figure.
+
+    Parameters
+    ----------
+    cfg : dict
+        Configuration dictionary (used for runs, labels, colors, plotting options).
+    timeseries_scores : dict
+        Nested dict: ``timeseries_scores[metric][region][stream][run_id][fstep] = xr.DataArray``
+        where each DataArray has dims ``(source_end_hour,)`` or ``(source_end_hour, channel)``.
+    summary_dir : Path
+        Directory to write summary plots to.
+    """
+    if not timeseries_scores:
+        return
+
+    runs = cfg.run_ids
+    plt_opt = cfg.get("global_plotting_options", cfg)
+    image_format = plt_opt.get("image_format", "png")
+    dpi_val = plt_opt.get("dpi_val", 150)
+
+    ts_dir = summary_dir / "score_timeseries"
+    ts_dir.mkdir(parents=True, exist_ok=True)
+
+    for metric_name, region_dict in timeseries_scores.items():
+        for region, stream_dict in region_dict.items():
+            for stream, run_dict in stream_dict.items():
+                if not run_dict:
+                    continue
+
+                # Determine fsteps and channels from first run
+                first_run_scores = next(iter(run_dict.values()))
+                fsteps = sorted(first_run_scores.keys())
+                sample_score = first_run_scores[fsteps[0]]
+                channels = (
+                    list(sample_score.coords["channel"].values)
+                    if "channel" in sample_score.dims
+                    else [None]
+                )
+
+                for channel in channels:
+                    for fstep in fsteps:
+                        plt.figure(figsize=(10, 6), dpi=dpi_val)
+
+                        for run_id, fstep_scores in run_dict.items():
+                            if fstep not in fstep_scores:
+                                continue
+                            score = fstep_scores[fstep]
+                            score_vals = (
+                                score.sel(channel=channel)
+                                if channel is not None
+                                else score
+                            )
+                            hours = score_vals.coords["source_end_hour"].values
+                            values = score_vals.values.flatten()
+                            label = runs[run_id].get("label", run_id)
+                            color = runs[run_id].get("color", None)
+                            plt.plot(
+                                hours, values, marker="o", linewidth=2,
+                                label=label, color=color,
+                            )
+
+                        ch_label = channel if channel is not None else "all"
+                        title = (
+                            f"{metric_name.upper()} vs source end hour | "
+                            f"{ch_label} | fstep {fstep} | {region} | {stream}"
+                        )
+                        plt.title(title)
+                        plt.xlabel("Source window end hour [UTC]")
+                        plt.ylabel(metric_name.upper())
+                        if hours is not None and len(hours) > 0:
+                            plt.xlim(min(hours) - 0.5, max(hours) + 0.5)
+                            plt.xticks(sorted(hours))
+                        plt.grid(True, alpha=0.3)
+                        plt.legend()
+                        plt.tight_layout()
+
+                        plot_path = (
+                            ts_dir
+                            / f"{metric_name}_{ch_label}_{region}_{stream}"
+                              f"_fstep_{fstep}_by_source_end_hour.{image_format}"
+                        )
+                        plt.savefig(plot_path, bbox_inches="tight")
+                        plt.close()
+
+    _logger.info(f"Timeseries summary plots saved to {ts_dir}.")
 
 
 def plot_summary(cfg: dict, scores_dict: dict, summary_dir: Path):

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
@@ -22,7 +22,6 @@ from joblib import delayed
 from PIL import Image
 from tqdm import tqdm
 
-
 from weathergen.evaluate.io.data.io_orchestration import dispatch_parallel, get_num_workers
 from weathergen.evaluate.io.io_reader import Reader, ReaderOutput
 from weathergen.evaluate.plotting.bar_plots import BarPlots
@@ -43,9 +42,9 @@ from weathergen.evaluate.plotting.plot_utils import (
 from weathergen.evaluate.plotting.plotter import Plotter
 from weathergen.evaluate.plotting.quantile_plots import QuantilePlots
 from weathergen.evaluate.plotting.score_cards import ScoreCards
+from weathergen.evaluate.scores.score import VerifiedData, get_score
 from weathergen.evaluate.utils.array_utils import bias_ranges, common_ranges
 from weathergen.evaluate.utils.clim_utils import get_climatology
-from weathergen.evaluate.scores.score import VerifiedData, get_score
 
 _logger = logging.getLogger(__name__)
 
@@ -167,13 +166,19 @@ def run_score_timeseries_pipeline(
 
     # --- Parallel plotting ---
     _plot_timeseries_parallel(
-        reader, stream, scores_by_hour, unique_hours, fsteps, da_tars,
-        global_plotting_options, n_workers,
+        reader,
+        stream,
+        scores_by_hour,
+        unique_hours,
+        fsteps,
+        da_tars,
+        global_plotting_options,
+        n_workers,
     )
 
     return scores_by_hour
 
-    
+
 def _compute_timeseries_scores_for_fstep(
     fstep: int,
     region: str,
@@ -231,10 +236,7 @@ def _plot_single_timeseries(
     plt.plot(hours, values, marker="o", linewidth=2, label=run_id)
 
     ch_label = channel if channel is not None else "all"
-    title = (
-        f"{metric_name.upper()} vs source end hour | {ch_label} | "
-        f" {lt_label} | {region}"
-    )
+    title = f"{metric_name.upper()} vs source end hour | {ch_label} |  {lt_label} | {region}"
     plt.title(title)
     plt.xlabel("Source window end hour [UTC]")
     plt.ylabel(metric_name.upper())
@@ -246,9 +248,8 @@ def _plot_single_timeseries(
 
     out_dir = Path(output_dir)
     plot_path = (
-        out_dir
-        / f"{metric_name}_{ch_label}_{region}_lead_{lt_label}"
-          f"_by_source_end_hour.{image_format}"
+        out_dir / f"{metric_name}_{ch_label}_{region}_lead_{lt_label}"
+        f"_by_source_end_hour.{image_format}"
     )
     plt.savefig(plot_path, bbox_inches="tight")
     plt.close()
@@ -319,11 +320,10 @@ def _plot_timeseries_parallel(
     )
 
     calls = [delayed(_plot_single_timeseries)(**t) for t in plot_tasks]
-    dispatch_parallel(
-        calls, n_workers=n_workers, backend="loky", desc=f"Timeseries plots {stream}"
-    )
+    dispatch_parallel(calls, n_workers=n_workers, backend="loky", desc=f"Timeseries plots {stream}")
 
     _logger.info(f"RUN {run_id} - {stream}: Score timeseries plots saved to {output_dir}.")
+
 
 # ---------------------------------------------------------------------------
 # Score maps
@@ -358,7 +358,6 @@ def run_score_map_pipeline(
     plot_score_options : dict | None
         Dictionary containing all common score calculation options.
     """
-
 
     if not reader.is_gridded_data(stream):
         _logger.debug(f"RUN {reader.run_id} - {stream}: Skipping score maps (non-gridded data).")
@@ -443,7 +442,7 @@ def run_score_map_pipeline(
 
     calls = [delayed(_plot_score_maps_per_stream)(**t) for t in fstep_tasks]
     dispatch_parallel(calls, n_workers=n_plot_workers, backend="loky", desc=f"Score maps {stream}")
-   
+
     plot_score_animations = plot_score_options.get("score_animation", False)
     if plot_score_animations:
         _dispatch_score_map_animations(
@@ -1167,17 +1166,19 @@ def plot_timeseries_summary(
                                 continue
                             score = fstep_scores[fstep]
                             score_vals = (
-                                score.sel(channel=channel)
-                                if channel is not None
-                                else score
+                                score.sel(channel=channel) if channel is not None else score
                             )
                             hours = score_vals.coords["source_end_hour"].values
                             values = score_vals.values.flatten()
                             label = runs[run_id].get("label", run_id)
                             color = runs[run_id].get("color", None)
                             plt.plot(
-                                hours, values, marker="o", linewidth=2,
-                                label=label, color=color,
+                                hours,
+                                values,
+                                marker="o",
+                                linewidth=2,
+                                label=label,
+                                color=color,
                             )
 
                         ch_label = channel if channel is not None else "all"
@@ -1196,9 +1197,8 @@ def plot_timeseries_summary(
                         plt.tight_layout()
 
                         plot_path = (
-                            ts_dir
-                            / f"{metric_name}_{ch_label}_{region}_{stream}"
-                              f"_fstep_{fstep}_by_source_end_hour.{image_format}"
+                            ts_dir / f"{metric_name}_{ch_label}_{region}_{stream}"
+                            f"_fstep_{fstep}_by_source_end_hour.{image_format}"
                         )
                         plt.savefig(plot_path, bbox_inches="tight")
                         plt.close()

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration_utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration_utils.py
@@ -1,11 +1,61 @@
+import logging
+
 import numpy as np
+import pandas as pd
 import xarray as xr
 from joblib import delayed
 
 from weathergen.evaluate.io.data.io_orchestration import dispatch_parallel
+from weathergen.evaluate.io.io_reader import ReaderOutput
 from weathergen.evaluate.scores.score import VerifiedData, get_score
 from weathergen.evaluate.scores.score_orchestration import get_next_fstep_data
 from weathergen.evaluate.utils.regions import RegionBoundingBox
+
+_logger = logging.getLogger(__name__)
+
+
+def group_by_init_hour(
+    output_data: ReaderOutput,
+) -> dict[int, np.ndarray]:
+    """Group sample indices by the hour of day of the initialisation time.
+
+    The initialisation time is taken from the ``source_interval_end`` coordinate
+    on the sample dimension (which stores the end of the conditioning window, i.e.
+    the forecast reference time).
+
+    Returns only sample index arrays (no data copies) to avoid doubling memory.
+    Use ``da.sel(sample=indices)`` on the original data when processing each group.
+
+    Parameters
+    ----------
+    output_data : ReaderOutput
+        Pre-loaded data with ``target`` and ``prediction`` dicts keyed by fstep.
+
+    Returns
+    -------
+    dict[int, np.ndarray]
+        Mapping from hour (0–23) to sample indices belonging to that hour.
+    """
+    first_tar = next(iter(output_data.target.values()))
+    if "source_interval_end" not in first_tar.coords:
+        _logger.warning(
+            "Cannot group by init hour: 'source_interval_end' coordinate not found."
+        )
+        return {}
+
+    init_times = pd.DatetimeIndex(first_tar.source_interval_end.values)
+    hours = init_times.hour
+    samples = first_tar.sample.values
+
+    grouped: dict[int, np.ndarray] = {
+        int(hour): samples[hours == hour] for hour in sorted(set(hours))
+    }
+
+    _logger.info(
+        f"Grouped {len(samples)} samples into {len(grouped)} init-hour bins: "
+        f"{sorted(grouped.keys())}."
+    )
+    return grouped
 
 
 def _compute_scores_for_fstep(

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration_utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration_utils.py
@@ -20,7 +20,7 @@ def group_by_init_hour(
 ) -> dict[int, NDArray]:
     """Group sample indices by the hour of day of the initialisation time.
 
-    The initialisation time is taken from the ``source_interval_end`` coordinate
+    The initialisation time is taken from the ``init_times`` coordinate
     on the sample dimension (which stores the end of the conditioning window, i.e.
     the forecast reference time).
 
@@ -38,11 +38,11 @@ def group_by_init_hour(
         Mapping from hour (0–23) to sample indices belonging to that hour.
     """
     first_tar = next(iter(output_data.target.values()))
-    if "source_interval_end" not in first_tar.coords:
-        _logger.warning("Cannot group by init hour: 'source_interval_end' coordinate not found.")
+    if "init_times" not in first_tar.coords:
+        _logger.warning("Cannot group by init hour: 'init_times' coordinate not found.")
         return {}
 
-    init_times = pd.DatetimeIndex(first_tar.source_interval_end.values)
+    init_times = pd.DatetimeIndex(first_tar.init_times.values)
     hours = init_times.hour
     samples = first_tar.sample.values
 

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration_utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration_utils.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from joblib import delayed
+from numpy.typing import NDArray
 
 from weathergen.evaluate.io.data.io_orchestration import dispatch_parallel
 from weathergen.evaluate.io.io_reader import ReaderOutput
@@ -16,7 +17,7 @@ _logger = logging.getLogger(__name__)
 
 def group_by_init_hour(
     output_data: ReaderOutput,
-) -> dict[int, np.ndarray]:
+) -> dict[int, NDArray]:
     """Group sample indices by the hour of day of the initialisation time.
 
     The initialisation time is taken from the ``source_interval_end`` coordinate
@@ -38,18 +39,14 @@ def group_by_init_hour(
     """
     first_tar = next(iter(output_data.target.values()))
     if "source_interval_end" not in first_tar.coords:
-        _logger.warning(
-            "Cannot group by init hour: 'source_interval_end' coordinate not found."
-        )
+        _logger.warning("Cannot group by init hour: 'source_interval_end' coordinate not found.")
         return {}
 
     init_times = pd.DatetimeIndex(first_tar.source_interval_end.values)
     hours = init_times.hour
     samples = first_tar.sample.values
 
-    grouped: dict[int, np.ndarray] = {
-        int(hour): samples[hours == hour] for hour in sorted(set(hours))
-    }
+    grouped: dict[int, NDArray] = {int(hour): samples[hours == hour] for hour in sorted(set(hours))}
 
     _logger.info(
         f"Grouped {len(samples)} samples into {len(grouped)} init-hour bins: "

--- a/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
@@ -34,7 +34,9 @@ from weathergen.evaluate.io.wegen_reader import (
 from weathergen.evaluate.plotting.plot_orchestration import (
     plot_data,
     plot_summary,
+    plot_timeseries_summary,
     run_score_map_pipeline,
+    run_score_timeseries_pipeline, 
 )
 from weathergen.evaluate.plotting.plot_utils import collect_channels
 from weathergen.evaluate.scores.score_orchestration import (
@@ -185,8 +187,7 @@ def _process_stream(
     global_plotting_opts: dict[str, object],
     regions: list[str],
     metrics: dict[str, object],
-    plot_score_maps: bool,
-    plot_score_animations: bool,
+    plot_score_options: dict[str, object],
 ) -> tuple[str, str, dict[str, dict[str, dict[str, float]]]]:
     """
     Worker function for a single stream of a single run.
@@ -208,10 +209,8 @@ def _process_stream(
         List of regions to be processed.
     metrics:
         Dict of metrics to be processed and their parameters.
-    plot_score_maps:
-        Bool to define if the score maps need to be plotted or not.
-    plot_score_animations:
-        Bool to define if the score animations need to be plotted or not.
+    plot_score_options:
+        Dictionary containing all common score calculation options.
     """
     type_ = run.get("type", "zarr")
     reader = get_reader(type_, run, run_id, private_paths, regions, metrics)
@@ -219,7 +218,7 @@ def _process_stream(
     stream_dict = reader.get_stream(stream)
     if not stream_dict:
         _logger.info(f"Stream {stream} not found for run {run_id}. Skipping.")
-        return run_id, stream, {}
+        return run_id, stream, {}, {}
 
     needs_plotting = stream_dict.get("plotting") and type_ == "zarr"
     needs_scoring = stream_dict.get("evaluation", False)
@@ -246,20 +245,23 @@ def _process_stream(
 
     # Scoring per stream
     if not needs_scoring:
-        return run_id, stream, {}
+        return run_id, stream, {}, {}
 
-    score_maps = plot_score_maps and type_ == "zarr"
+    plot_score_maps = plot_score_options.get("plot_score_maps", False) and type_ == "zarr"
+    plot_score_timeseries = (
+        plot_score_options.get("plot_score_timeseries", False) and type_ == "zarr"
+    )
 
     stream_loaded_scores, recomputable_metrics = reader.load_scores(stream, regions, metrics)
     scores_dict = stream_loaded_scores
     if recomputable_metrics:
         metrics_to_compute = recomputable_metrics
         regions_to_compute = list(set(recomputable_metrics.keys()))
-    elif score_maps:
+    elif plot_score_maps or plot_score_timeseries:
         metrics_to_compute = {r: metrics for r in regions}
         regions_to_compute = regions
     else:
-        return run_id, stream, scores_dict
+        return run_id, stream, scores_dict, {}
 
     stream_computed_scores = calc_scores_per_stream(
         reader,
@@ -271,7 +273,7 @@ def _process_stream(
     metric_list_to_json(reader, stream, stream_computed_scores, regions_to_compute)
     scores_dict = merge(stream_loaded_scores, stream_computed_scores)
 
-    if score_maps:
+    if plot_score_maps:
         run_score_map_pipeline(
             reader,
             stream,
@@ -279,10 +281,22 @@ def _process_stream(
             metrics_to_compute,
             output_data=output_data,
             global_plotting_options=global_plotting_opts,
-            plot_score_animations=plot_score_animations,
+            plot_score_options=plot_score_options,
         )
 
-    return run_id, stream, scores_dict
+    if plot_score_timeseries:
+        ts_scores = run_score_timeseries_pipeline(
+            reader,
+            stream,
+            regions_to_compute,
+            metrics_to_compute,
+            output_data=output_data,
+            global_plotting_options=global_plotting_opts,
+        )
+    else:
+        ts_scores = {}
+
+    return run_id, stream, scores_dict, ts_scores
 
 
 def evaluate_from_config(cfg: dict, mlflow_client: MlflowClient | None) -> None:
@@ -302,8 +316,13 @@ def evaluate_from_config(cfg: dict, mlflow_client: MlflowClient | None) -> None:
     private_paths = cfg.get("private_paths")
     summary_dir = Path(cfg.evaluation.get("summary_dir", _DEFAULT_PLOT_DIR))
     metrics = cfg.evaluation.metrics
-    plot_score_maps = cfg.evaluation.get("plot_score_maps", False)
-    plot_score_animations = cfg.evaluation.get("plot_score_animations", False)
+
+    plot_score_options = {
+        "plot_score_maps": cfg.evaluation.get("plot_score_maps", False),
+        "plot_score_animations": cfg.evaluation.get("plot_score_animations", False),
+        "plot_score_timeseries": cfg.evaluation.get("plot_score_timeseries", False),
+    }
+
     global_plotting_opts = cfg.get("global_plotting_options", {})
     default_streams = cfg.get("default_streams", {})
     max_workers = cfg.get("max_workers")  # global hard cap for parallel workers
@@ -334,19 +353,27 @@ def evaluate_from_config(cfg: dict, mlflow_client: MlflowClient | None) -> None:
                     "global_plotting_opts": global_plotting_opts,
                     "regions": regions,
                     "metrics": metrics,
-                    "plot_score_maps": plot_score_maps,
-                    "plot_score_animations": plot_score_animations,
+                    "plot_score_options": plot_score_options
                 }
             )
 
     scores_dict = defaultdict(lambda: defaultdict(lambda: defaultdict(dict)))
+    # timeseries_scores[metric][region][stream][run_id][fstep] = xr.DataArray
+    timeseries_scores: dict = defaultdict(
+        lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(dict)))
+    )
     results = [_process_stream(**task) for task in tasks]
 
-    for _, stream, stream_scores in results:
+    for run_id, stream, stream_scores, ts_scores in results:
         for metric, regions_dict in stream_scores.items():
             for region, streams_dict in regions_dict.items():
-                for stream, runs_dict in streams_dict.items():
-                    scores_dict[metric][region][stream].update(runs_dict)
+                for stream_key, runs_dict in streams_dict.items():
+                    scores_dict[metric][region][stream_key].update(runs_dict)
+
+        # Accumulate timeseries scores: ts_scores[metric][region][fstep]
+        for metric, region_dict in ts_scores.items():
+            for region, fstep_dict in region_dict.items():
+                timeseries_scores[metric][region][stream][run_id].update(fstep_dict)
 
     # MLFlow logging
     if mlflow_client:
@@ -382,6 +409,8 @@ def evaluate_from_config(cfg: dict, mlflow_client: MlflowClient | None) -> None:
     # summary plots
     if scores_dict:
         plot_summary(cfg, scores_dict, summary_dir)
+    if timeseries_scores:
+        plot_timeseries_summary(cfg, timeseries_scores, summary_dir)
 
 
 if __name__ == "__main__":

--- a/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
@@ -36,7 +36,7 @@ from weathergen.evaluate.plotting.plot_orchestration import (
     plot_summary,
     plot_timeseries_summary,
     run_score_map_pipeline,
-    run_score_timeseries_pipeline, 
+    run_score_timeseries_pipeline,
 )
 from weathergen.evaluate.plotting.plot_utils import collect_channels
 from weathergen.evaluate.scores.score_orchestration import (
@@ -353,7 +353,7 @@ def evaluate_from_config(cfg: dict, mlflow_client: MlflowClient | None) -> None:
                     "global_plotting_opts": global_plotting_opts,
                     "regions": regions,
                     "metrics": metrics,
-                    "plot_score_options": plot_score_options
+                    "plot_score_options": plot_score_options,
                 }
             )
 


### PR DESCRIPTION
## Description

- Integrate this standalone script https://github.com/ecmwf/WeatherGenerator/blob/shmh40/dev/plot-metric-by-window-start/scripts/plot_metric_by_source_start_hour.py into FastEvaluation.  
- add small addition to ratio plot title to include fstep
- implement an `offset` parameter to artificially calculate the lead time when source interval end is not available because the stream is not used as input. 

usage:

```
evaluation:
  plot_score_timeseries: true
```

example plot:

<img width="1430" height="847" alt="image" src="https://github.com/user-attachments/assets/60264315-8c16-4fd8-aafe-b57a97508fc6" />

## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/2409

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
