### PR TITLE
Fix spoofing so that it only uses 2 tokens to avoid large memory footprint

### DIFF
--- a/src/weathergen/datasets/stream_data.py
+++ b/src/weathergen/datasets/stream_data.py
@@ -459,9 +459,12 @@ def spoof(healpix_level: int, datetime, geoinfo_size, num_channels) -> IOReaderD
     lons, lats = hp.healpix_to_lonlat(
         np.arange(0, num_healpix_cells), 2**healpix_level, dx=dx, dy=dy, order="nested"
     )
-    coords = np.stack([lats.deg, lons.deg], axis=-1, dtype=np.float32)
-    geoinfos = np.zeros((coords.shape[0], geoinfo_size), dtype=np.float32)
 
+    coords = np.stack([lats.deg, lons.deg], axis=-1, dtype=np.float32)
+    # spoof two tokens to avoid unnecessary computational load
+    coords = coords[np.random.choice(coords.shape[0], size=2, replace=False)]
+
+    geoinfos = np.zeros((coords.shape[0], geoinfo_size), dtype=np.float32)
     data = np.zeros((coords.shape[0], num_channels), dtype=np.float32)
     datetimes = np.array(datetime).repeat(coords.shape[0])
 


### PR DESCRIPTION
## Description

Fix spoofing so that it only uses 2 tokens to avoid large memory footprint
## Issue Number

Closes #2448 

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
