### PR TITLE
Fix empty first sample in inference (and also all other modes): missing offset

### DIFF
--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -25,7 +25,6 @@ from weathergen.datasets.data_reader_base import (
     TimeWindowHandler,
     TIndex,
 )
-from weathergen.datasets.data_reader_fesom import DataReaderFesom
 from weathergen.datasets.data_reader_obs import DataReaderObs
 from weathergen.datasets.masking import Masker
 from weathergen.datasets.stream_data import StreamData, spoof
@@ -131,6 +130,12 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
             self.step_timedelta,
         )
 
+        # needed as offset for permutations
+        source_cfgs = self.mode_cfg.get("model_input")
+        self.max_input_steps = np.array(
+            [sc.get("num_steps_input", 1) for _, sc in source_cfgs.items()]
+        ).max()
+
         self.time_window_handler = tw
         if is_root():
             logger.info(self.time_window_handler)
@@ -210,7 +215,7 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
         perms_len = int(self.index_range.end - self.index_range.start)
         perms_len -= (fsm + self.output_offset) * (self.time_step // self.step_timedelta)
 
-        return np.arange(perms_len)
+        return np.arange(self.max_input_steps, perms_len)
 
     def _init_stream_datasets(self, cf) -> dict[StreamName, _Stream]:
         """Load dataset readers for all streams from config."""
@@ -230,8 +235,6 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                     dataset = DataReaderObs
                 case "anemoi":
                     dataset = DataReaderAnemoi
-                case "fesom":
-                    dataset = DataReaderFesom
                 case type_name:
                     dataset = get_extra_reader(type_name)
                     if dataset is None:


### PR DESCRIPTION
## Description

Fix empty first sample in inference (and also all other modes): missing offset

## Issue Number

Closes #2468 

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
