### PR TITLE
Fix missing type of ranks when specified as list

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
@@ -12,6 +12,7 @@ import json
 import logging
 from collections import defaultdict
 from pathlib import Path
+import omegaconf
 
 # Third-party
 import numpy as np
@@ -434,7 +435,7 @@ class WeatherGenZarrReader(WeatherGenReader):
             _logger.info(f"Discovered {len(files)} rank file(s) for run {self.run_id}.")
             return self._validate_rank_files(files)
 
-        elif isinstance(rank_cfg, list | tuple):
+        elif isinstance(rank_cfg, list | tuple | omegaconf.listconfig.ListConfig):
             files = []
             for r in rank_cfg:
                 fname = self.results_dir / (

--- a/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
@@ -12,7 +12,6 @@ import json
 import logging
 from collections import defaultdict
 from pathlib import Path
-import omegaconf
 
 # Third-party
 import numpy as np
@@ -435,7 +434,7 @@ class WeatherGenZarrReader(WeatherGenReader):
             _logger.info(f"Discovered {len(files)} rank file(s) for run {self.run_id}.")
             return self._validate_rank_files(files)
 
-        elif isinstance(rank_cfg, list | tuple | omegaconf.listconfig.ListConfig):
+        elif isinstance(rank_cfg, list | tuple | oc.listconfig.ListConfig):
             files = []
             for r in rank_cfg:
                 fname = self.results_dir / (


### PR DESCRIPTION
## Description

Fix missing type of ranks when specified as list

## Issue Number

Closes #2477 

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
