### PR TITLE
[2502][evaluation] score bug fixes

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
@@ -358,6 +358,8 @@ def _plot_score_maps_per_stream(
     if not valid:
         return
 
+    ens_metrics = {m for m, r in valid if "ens" in r.dims}
+
     plot_metrics = xr.concat(
         [r for _, r in valid],
         dim="metric",
@@ -370,7 +372,7 @@ def _plot_score_maps_per_stream(
         metric=[m for m, _ in valid],
     ).compute()
 
-    if "ens" in preds.dims:
+    if "ens" in plot_metrics.dims:
         plot_metrics["ens"] = preds.ens
 
     has_ens = "ens" in plot_metrics.coords
@@ -378,13 +380,17 @@ def _plot_score_maps_per_stream(
 
     plot_tasks: list[dict] = []
     for metric in plot_metrics.coords["metric"].values:
-        for ens_val in ens_values:
+        metric_ens_values = ens_values if str(metric) in ens_metrics else [None]
+        for ens_val in metric_ens_values:
             tag = "score_maps" + (f"_ens_{ens_val}" if ens_val is not None else "") + f"_{metric}"
             for channel in plot_metrics.coords["channel"].values:
                 sel = {"metric": metric, "channel": channel}
                 if ens_val is not None:
                     sel["ens"] = ens_val
-                data = plot_metrics.sel(**sel).squeeze()
+                data = plot_metrics.sel(**sel)
+                if ens_val is None and "ens" in data.dims:
+                    data = data.isel(ens=0, drop=True)
+                data = data.squeeze()
                 title = f"{metric} - {channel}: fstep {fstep}" + (
                     f", ens {ens_val}" if ens_val is not None else ""
                 )

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
@@ -373,15 +373,15 @@ def _plot_score_maps_per_stream(
     ).compute()
 
     if "ens" in plot_metrics.dims:
-        plot_metrics["ens"] = preds.ens
+        plot_metrics = plot_metrics.assign_coords(ens=preds.ens.values)
 
-    has_ens = "ens" in plot_metrics.coords
-    ens_values = plot_metrics.coords["ens"].values if has_ens else [None]
+    all_ens = plot_metrics.coords["ens"].values if "ens" in plot_metrics.dims else [None]
 
     plot_tasks: list[dict] = []
     for metric in plot_metrics.coords["metric"].values:
-        metric_ens_values = ens_values if str(metric) in ens_metrics else [None]
-        for ens_val in metric_ens_values:
+        metric_has_ens = str(metric) in ens_metrics and "ens" in plot_metrics.dims
+        ens_values = all_ens if metric_has_ens else [None]
+        for ens_val in ens_values:
             tag = "score_maps" + (f"_ens_{ens_val}" if ens_val is not None else "") + f"_{metric}"
             for channel in plot_metrics.coords["channel"].values:
                 sel = {"metric": metric, "channel": channel}

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
@@ -351,17 +351,17 @@ def _plot_score_maps_per_stream(
 
     score_results, preds, metric_names = computed
     valid = [
-        (m, r)
-        for m, r in zip(metric_names, score_results, strict=False)
-        if r is not None and "ipoint" in r.dims
+        (metric, result)
+        for metric, result in zip(metric_names, score_results, strict=False)
+        if result is not None and "ipoint" in result.dims
     ]
     if not valid:
         return
 
-    ens_metrics = {m for m, r in valid if "ens" in r.dims}
+    ens_metrics = {metric for metric, result in valid if "ens" in result.dims}
 
     plot_metrics = xr.concat(
-        [r for _, r in valid],
+        [result for _, result in valid],
         dim="metric",
         coords="minimal",
         combine_attrs="drop_conflicts",
@@ -369,7 +369,7 @@ def _plot_score_maps_per_stream(
     plot_metrics = plot_metrics.assign_coords(
         lat=preds.lat.reset_coords(drop=True),
         lon=preds.lon.reset_coords(drop=True),
-        metric=[m for m, _ in valid],
+        metric=[metric for metric, _ in valid],
     ).compute()
 
     if "ens" in plot_metrics.dims:

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -256,12 +256,15 @@ class Scores:
             f = self.det_metrics_dict[score_name]
             _logger.debug(f"Using deterministic metric: {score_name}")
         elif score_name in self.prob_metrics_dict.keys():
-            assert self.ens_dim in data.prediction.dims, (
-                f"Probablistic score {score_name} chosen, but ensemble dimension {self.ens_dim} "
-                "not found in prediction data. Skipping score calculation."
-            )
-            return None
+            if self._ens_dim not in data.prediction.dims:
+                _logger.warning(
+                    f"Probabilistic score '{score_name}' chosen, but ensemble dimension "
+                    f"'{self._ens_dim}' not found in prediction data dims "
+                    f"{data.prediction.dims}. Skipping score calculation."
+                )
+                return None
             f = self.prob_metrics_dict[score_name]
+            _logger.debug(f"Using probabilistic metric: {score_name}")
         else:
             raise ValueError(
                 f"Unknown score chosen. Supported scores: {
@@ -1417,7 +1420,8 @@ class Scores:
         xr.DataArray
             Spread-Skill Ratio (SSR)
         """
-        ssr = self.calc_spread(p) / self.calc_rmse(p, gt)  # spread/rmse
+        ens_mean = p.mean(dim=self._ens_dim)
+        ssr = self.calc_spread(p) / self.calc_rmse(ens_mean, gt)
 
         return ssr
 


### PR DESCRIPTION
## Description

Enables the previously dead probabilistic metrics (spread, ssr, crps, rank_histogram) in the evaluation package, corrects the spread-skill ratio to the standard ensemble-mean definition, and makes the spatial score-map path robust for metrics that collapse the ensemble dimension. This unblocks GenCast-style spread-skill diagnostics over lead time and ensemble-spread maps.

**I am not very familiar with the eval pipeline, so it would be good if this could be reviewed by someone more knowledgeable**

### `scores/score.py`
- **Enable probabilistic-metric dispatch.** Replace the dead `assert self.ens_dim … / return None`
  (undefined `self.ens_dim`, unconditional return) with a real check: warn and skip when the
  ensemble dim `self._ens_dim` is absent from the predictions (e.g. deterministic runs), otherwise
  dispatch to the metric function. This activates `spread`, `ssr`, `crps`, and `rank_histogram`.
- **Correct the spread-skill ratio.** `calc_ssr` now divides the ensemble spread by the **RMSE of
  the ensemble mean** (the "skill", GenCast / WeatherBench2 convention) —
  `calc_spread(p) / calc_rmse(p.mean("ens"), gt)` — instead of the full-ensemble per-member RMSE.
  SSR is now a single value per variable/level/lead-time with the standard calibration
  interpretation (under-/over-dispersion), consistent with the already ensemble-reduced spread
  numerator.

### `plotting/plot_orchestration.py` (`_plot_score_maps_per_stream`)
- **Fix `CoordinateValidationError` crash.** Guard the ensemble-label assignment on
  `"ens" in plot_metrics.dims` (the concatenated result) rather than `preds.dims`. When every
  selected metric reduces the ensemble dim (e.g. `metrics: ["ssr"]`), `plot_metrics` has no `ens`
  dim and the previous unconditional `plot_metrics["ens"] = preds.ens` raised.
- **Avoid redundant per-member maps.** Track which metrics retain a per-member `ens` dim in their
  own result (`ens_metrics`). Iterate ensemble members only for those; ensemble-reduced metrics
  (`spread`, `crps`, `ssr`) get a single map instead of one identical map per member.
- **Collapse broadcast ensemble axis.** When `xr.concat` broadcasts a reduced metric across `ens`,
  select a single member (`isel(ens=0, drop=True)`) so the plotted field is 2-D.

## Issue Number

Closes #2502 

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
