### PR TITLE
[2507][Evaluation] Implement Adjusted SSR

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/plotting/line_plots.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/line_plots.py
@@ -278,6 +278,7 @@ class LinePlots:
         print_summary: bool = False,
         title: str | None = None,
         colors: list[str | None] | None = None,
+        line: float | None = None,
     ) -> None:
         """
         Plot a line graph comparing multiple datasets.
@@ -296,6 +297,9 @@ class LinePlots:
             Name of the dimension to be used for the y-axis.
         print_summary:
             If True, print a summary of the values from the graph.
+        line:
+            If provided, draw a horizontal reference line at the given y-value
+            (e.g. the optimal value of a metric).
         Returns
         -------
             None
@@ -350,6 +354,7 @@ class LinePlots:
             x_dim_opts,
             y_dim,
             print_summary,
+            line=line,
             title=title,
             out_plot_dir=self.out_plot_dir_lines,
         )

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
@@ -358,6 +358,8 @@ def _plot_score_maps_per_stream(
     if not valid:
         return
 
+    ens_metrics = {m for m, r in valid if "ens" in r.dims}
+
     plot_metrics = xr.concat(
         [r for _, r in valid],
         dim="metric",
@@ -370,7 +372,7 @@ def _plot_score_maps_per_stream(
         metric=[m for m, _ in valid],
     ).compute()
 
-    if "ens" in preds.dims:
+    if "ens" in plot_metrics.dims:
         plot_metrics["ens"] = preds.ens
 
     has_ens = "ens" in plot_metrics.coords
@@ -378,13 +380,17 @@ def _plot_score_maps_per_stream(
 
     plot_tasks: list[dict] = []
     for metric in plot_metrics.coords["metric"].values:
-        for ens_val in ens_values:
+        metric_ens_values = ens_values if str(metric) in ens_metrics else [None]
+        for ens_val in metric_ens_values:
             tag = "score_maps" + (f"_ens_{ens_val}" if ens_val is not None else "") + f"_{metric}"
             for channel in plot_metrics.coords["channel"].values:
                 sel = {"metric": metric, "channel": channel}
                 if ens_val is not None:
                     sel["ens"] = ens_val
-                data = plot_metrics.sel(**sel).squeeze()
+                data = plot_metrics.sel(**sel)
+                if ens_val is None and "ens" in data.dims:
+                    data = data.isel(ens=0, drop=True)
+                data = data.squeeze()
                 title = f"{metric} - {channel}: fstep {fstep}" + (
                     f", ens {ens_val}" if ens_val is not None else ""
                 )

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
@@ -373,15 +373,15 @@ def _plot_score_maps_per_stream(
     ).compute()
 
     if "ens" in plot_metrics.dims:
-        plot_metrics["ens"] = preds.ens
+        plot_metrics = plot_metrics.assign_coords(ens=preds.ens.values)
 
-    has_ens = "ens" in plot_metrics.coords
-    ens_values = plot_metrics.coords["ens"].values if has_ens else [None]
+    all_ens = plot_metrics.coords["ens"].values if "ens" in plot_metrics.dims else [None]
 
     plot_tasks: list[dict] = []
     for metric in plot_metrics.coords["metric"].values:
-        metric_ens_values = ens_values if str(metric) in ens_metrics else [None]
-        for ens_val in metric_ens_values:
+        metric_has_ens = str(metric) in ens_metrics and "ens" in plot_metrics.dims
+        ens_values = all_ens if metric_has_ens else [None]
+        for ens_val in ens_values:
             tag = "score_maps" + (f"_ens_{ens_val}" if ens_val is not None else "") + f"_{metric}"
             for channel in plot_metrics.coords["channel"].values:
                 sel = {"metric": metric, "channel": channel}

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
@@ -351,17 +351,17 @@ def _plot_score_maps_per_stream(
 
     score_results, preds, metric_names = computed
     valid = [
-        (m, r)
-        for m, r in zip(metric_names, score_results, strict=False)
-        if r is not None and "ipoint" in r.dims
+        (metric, result)
+        for metric, result in zip(metric_names, score_results, strict=False)
+        if result is not None and "ipoint" in result.dims
     ]
     if not valid:
         return
 
-    ens_metrics = {m for m, r in valid if "ens" in r.dims}
+    ens_metrics = {metric for metric, result in valid if "ens" in result.dims}
 
     plot_metrics = xr.concat(
-        [r for _, r in valid],
+        [result for _, result in valid],
         dim="metric",
         coords="minimal",
         combine_attrs="drop_conflicts",
@@ -369,7 +369,7 @@ def _plot_score_maps_per_stream(
     plot_metrics = plot_metrics.assign_coords(
         lat=preds.lat.reset_coords(drop=True),
         lon=preds.lon.reset_coords(drop=True),
-        metric=[m for m, _ in valid],
+        metric=[metric for metric, _ in valid],
     ).compute()
 
     if "ens" in plot_metrics.dims:

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_utils.py
@@ -390,6 +390,9 @@ def plot_metric_region(
 
                 title = f"{metric.upper()} | {stream} | {ch}"
 
+                ref_line_dict = {"ssr_adj": 1.0}
+                line = ref_line_dict.get(metric)
+
                 plotter.plot(
                     selected_data,
                     labels,
@@ -399,6 +402,7 @@ def plot_metric_region(
                     print_summary=print_summary,
                     title=title,
                     colors=colors,
+                    line=line,
                 )
 
 

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -1505,7 +1505,10 @@ class Scores:
         self,
         p: xr.DataArray,
         gt: xr.DataArray,
-        latitude_weights: xr.DataArray | None = None,
+        use_latitude_weights: bool = False,
+        lat_coord_name: str | None = None,
+        min_lat_weight: float = 1e-3,
+        max_lat_weight: float = 1.0,
     ) -> xr.DataArray:
         """
         Calculate the Spread-Skill Ratio (SSR) of the forecast ensemble data w.r.t. reference data
@@ -1516,9 +1519,16 @@ class Scores:
             Forecast data array with ensemble dimension
         gt: xr.DataArray
             Ground truth data array
-        latitude_weights: xr.DataArray | None
-            Optional latitude weights for area-weighted averaging.
-            If provided, both spread and RMSE (skill) will be weighted independently by these values.
+        use_latitude_weights: bool
+            If True, automatically calculate and apply latitude weights to both spread and RMSE
+            (skill) components independently. Default is False.
+        lat_coord_name: str | None
+            Name of the latitude coordinate. If None and use_latitude_weights is True, will search
+            for standard latitude coordinate names ('lat', 'latitude', 'rlat').
+        min_lat_weight: float
+            Minimum latitude weight value (at poles). Default is 1e-3.
+        max_lat_weight: float
+            Maximum latitude weight value (at equator). Default is 1.0.
             
         Returns
         -------
@@ -1526,6 +1536,13 @@ class Scores:
             Spread-Skill Ratio (SSR)
         """
         ens_mean = p.mean(dim=self._ens_dim)
+        
+        # Calculate latitude weights if requested
+        latitude_weights = None
+        if use_latitude_weights:
+            latitude_weights = self.calc_latitude_weights(
+                p, min_value=min_lat_weight, max_value=max_lat_weight, lat_coord_name=lat_coord_name
+            )
         
         # Calculate spread and skill independently with optional latitude weighting
         spread = self.calc_spread(p, latitude_weights=latitude_weights)
@@ -1539,7 +1556,10 @@ class Scores:
         self,
         p: xr.DataArray,
         gt: xr.DataArray,
-        latitude_weights: xr.DataArray | None = None,
+        use_latitude_weights: bool = False,
+        lat_coord_name: str | None = None,
+        min_lat_weight: float = 1e-3,
+        max_lat_weight: float = 1.0,
     ) -> xr.DataArray:
         """
         Calculate the ensemble-size-adjusted Spread-Skill Ratio (SSR) of the forecast ensemble
@@ -1562,9 +1582,16 @@ class Scores:
             Forecast data array with ensemble dimension
         gt: xr.DataArray
             Ground truth data array
-        latitude_weights: xr.DataArray | None
-            Optional latitude weights for area-weighted averaging.
-            If provided, both spread and RMSE (skill) will be weighted independently by these values.
+        use_latitude_weights: bool
+            If True, automatically calculate and apply latitude weights to both spread and RMSE
+            (skill) components independently. Default is False.
+        lat_coord_name: str | None
+            Name of the latitude coordinate. If None and use_latitude_weights is True, will search
+            for standard latitude coordinate names ('lat', 'latitude', 'rlat').
+        min_lat_weight: float
+            Minimum latitude weight value (at poles). Default is 1e-3.
+        max_lat_weight: float
+            Maximum latitude weight value (at equator). Default is 1.0.
             
         Returns
         -------
@@ -1574,6 +1601,13 @@ class Scores:
         ens_size = p.sizes[self._ens_dim]
         correction = np.sqrt((ens_size + 1) / ens_size)
         ens_mean = p.mean(dim=self._ens_dim)
+        
+        # Calculate latitude weights if requested
+        latitude_weights = None
+        if use_latitude_weights:
+            latitude_weights = self.calc_latitude_weights(
+                p, min_value=min_lat_weight, max_value=max_lat_weight, lat_coord_name=lat_coord_name
+            )
         
         # Calculate spread and skill independently with optional latitude weighting
         spread = self.calc_spread_adj(p, latitude_weights=latitude_weights)

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -674,7 +674,12 @@ class Scores:
 
         return self._mean(np.abs(p - gt))
 
-    def calc_mse(self, p: xr.DataArray, gt: xr.DataArray) -> xr.DataArray:
+    def calc_mse(
+        self,
+        p: xr.DataArray,
+        gt: xr.DataArray,
+        latitude_weights: xr.DataArray | None = None,
+    ) -> xr.DataArray:
         """
         Calculate mean squared error (MSE) of forecast data w.r.t. reference data.
 
@@ -684,6 +689,9 @@ class Scores:
             Forecast data array
         gt: xr.DataArray
             Ground truth data array
+        latitude_weights: xr.DataArray | None
+            Optional latitude weights for area-weighted averaging.
+            If provided, the MSE will be weighted by these values.
         Returns
         -------
         xr.DataArray
@@ -695,17 +703,37 @@ class Scores:
                 "(agg_dims=None)."
             )
 
-        return self._mean(np.square(p - gt))
+        mse = np.square(p - gt)
+        
+        # Apply latitude weighting if provided
+        if latitude_weights is not None:
+            # Broadcast weights to match data dimensions
+            _, broadcasted_weights = xr.broadcast(mse, latitude_weights)
+            # Weighted mean
+            mse_weighted = (mse * broadcasted_weights).mean(dim=self._agg_dims) / \
+                           broadcasted_weights.mean(dim=self._agg_dims)
+            return mse_weighted
+        else:
+            return self._mean(mse)
 
-    def calc_rmse(self, p: xr.DataArray, gt: xr.DataArray) -> xr.DataArray:
+    def calc_rmse(
+        self,
+        p: xr.DataArray,
+        gt: xr.DataArray,
+        latitude_weights: xr.DataArray | None = None,
+    ) -> xr.DataArray:
         """
         Calculate root mean squared error (RMSE) of forecast data w.r.t. reference data
+        
         Parameters
         ----------
         p: xr.DataArray
             Forecast data array
         gt: xr.DataArray
             Ground truth data array
+        latitude_weights: xr.DataArray | None
+            Optional latitude weights for area-weighted averaging.
+            If provided, the RMSE will be weighted by these values.
         Returns
         -------
         xr.DataArray
@@ -718,7 +746,7 @@ class Scores:
                 "(agg_dims=None)."
             )
 
-        rmse = np.sqrt(self.calc_mse(p, gt))
+        rmse = np.sqrt(self.calc_mse(p, gt, latitude_weights=latitude_weights))
 
         return rmse
 
@@ -1390,13 +1418,22 @@ class Scores:
 
     ### Probablistic scores
 
-    def calc_spread(self, p: xr.DataArray, **kwargs) -> xr.DataArray:
+    def calc_spread(
+        self,
+        p: xr.DataArray,
+        latitude_weights: xr.DataArray | None = None,
+        **kwargs,
+    ) -> xr.DataArray:
         """
         Calculate the spread of the forecast ensemble
+        
         Parameters
         ----------
         p: xr.DataArray
             Forecast data array with ensemble dimension
+        latitude_weights: xr.DataArray | None
+            Optional latitude weights for area-weighted averaging.
+            If provided, the spread will be weighted by these values.
 
         Returns
         -------
@@ -1405,9 +1442,26 @@ class Scores:
         """
         ens_std = p.std(dim=self._ens_dim)
 
-        return self._mean(np.sqrt(ens_std**2))
+        spread_squared = ens_std**2
 
-    def calc_spread_adj(self, p: xr.DataArray, **kwargs) -> xr.DataArray:
+        # Apply latitude weighting if provided
+        if latitude_weights is not None:
+            # Broadcast weights to match data dimensions
+            _, broadcasted_weights = xr.broadcast(spread_squared, latitude_weights)
+            # Weighted mean
+            spread_mean = (spread_squared * broadcasted_weights).mean(dim=self._agg_dims) / \
+                          broadcasted_weights.mean(dim=self._agg_dims)
+        else:
+            spread_mean = self._mean(spread_squared)
+
+        return np.sqrt(spread_mean)
+
+    def calc_spread_adj(
+        self,
+        p: xr.DataArray,
+        latitude_weights: xr.DataArray | None = None,
+        **kwargs,
+    ) -> xr.DataArray:
         """
         Calculate the (unbiased) ensemble spread following the GenCast convention.
 
@@ -1424,6 +1478,9 @@ class Scores:
         ----------
         p: xr.DataArray
             Forecast data array with ensemble dimension
+        latitude_weights: xr.DataArray | None
+            Optional latitude weights for area-weighted averaging.
+            If provided, the spread will be weighted by these values.
 
         Returns
         -------
@@ -1432,9 +1489,24 @@ class Scores:
         """
         ens_var = p.var(dim=self._ens_dim, ddof=1)
 
-        return np.sqrt(self._mean(ens_var))
+        # Apply latitude weighting if provided
+        if latitude_weights is not None:
+            # Broadcast weights to match data dimensions
+            _, broadcasted_weights = xr.broadcast(ens_var, latitude_weights)
+            # Weighted mean
+            var_mean = (ens_var * broadcasted_weights).mean(dim=self._agg_dims) / \
+                       broadcasted_weights.mean(dim=self._agg_dims)
+        else:
+            var_mean = self._mean(ens_var)
 
-    def calc_ssr(self, p: xr.DataArray, gt: xr.DataArray) -> xr.DataArray:
+        return np.sqrt(var_mean)
+
+    def calc_ssr(
+        self,
+        p: xr.DataArray,
+        gt: xr.DataArray,
+        latitude_weights: xr.DataArray | None = None,
+    ) -> xr.DataArray:
         """
         Calculate the Spread-Skill Ratio (SSR) of the forecast ensemble data w.r.t. reference data
 
@@ -1444,17 +1516,31 @@ class Scores:
             Forecast data array with ensemble dimension
         gt: xr.DataArray
             Ground truth data array
+        latitude_weights: xr.DataArray | None
+            Optional latitude weights for area-weighted averaging.
+            If provided, both spread and RMSE (skill) will be weighted independently by these values.
+            
         Returns
         -------
         xr.DataArray
             Spread-Skill Ratio (SSR)
         """
         ens_mean = p.mean(dim=self._ens_dim)
-        ssr = self.calc_spread(p) / self.calc_rmse(ens_mean, gt)
+        
+        # Calculate spread and skill independently with optional latitude weighting
+        spread = self.calc_spread(p, latitude_weights=latitude_weights)
+        rmse = self.calc_rmse(ens_mean, gt, latitude_weights=latitude_weights)
+        
+        ssr = spread / rmse
 
         return ssr
 
-    def calc_ssr_adj(self, p: xr.DataArray, gt: xr.DataArray) -> xr.DataArray:
+    def calc_ssr_adj(
+        self,
+        p: xr.DataArray,
+        gt: xr.DataArray,
+        latitude_weights: xr.DataArray | None = None,
+    ) -> xr.DataArray:
         """
         Calculate the ensemble-size-adjusted Spread-Skill Ratio (SSR) of the forecast ensemble
         data w.r.t. reference data.
@@ -1476,6 +1562,10 @@ class Scores:
             Forecast data array with ensemble dimension
         gt: xr.DataArray
             Ground truth data array
+        latitude_weights: xr.DataArray | None
+            Optional latitude weights for area-weighted averaging.
+            If provided, both spread and RMSE (skill) will be weighted independently by these values.
+            
         Returns
         -------
         xr.DataArray
@@ -1484,8 +1574,12 @@ class Scores:
         ens_size = p.sizes[self._ens_dim]
         correction = np.sqrt((ens_size + 1) / ens_size)
         ens_mean = p.mean(dim=self._ens_dim)
+        
+        # Calculate spread and skill independently with optional latitude weighting
+        spread = self.calc_spread_adj(p, latitude_weights=latitude_weights)
+        rmse = self.calc_rmse(ens_mean, gt, latitude_weights=latitude_weights)
 
-        return correction * self.calc_spread_adj(p) / self.calc_rmse(ens_mean, gt)
+        return correction * spread / rmse
 
     def calc_crps(
         self,
@@ -1738,6 +1832,62 @@ class Scores:
             raise ValueError(f"Second-order differentation is not implemenetd in {method} yet.")
 
         return var_diff_amplitude
+
+    def calc_latitude_weights(
+        data: xr.DataArray,
+        min_value: float = 1e-3,
+        max_value: float = 1.0,
+        lat_coord_name: str | None = None,
+    ) -> xr.DataArray:
+        """
+        Calculate latitude weights based on cosine of latitude.
+        
+        This function computes weights that account for the convergence of meridians
+        towards the poles, giving less weight to high-latitude grid points.
+        
+        Parameters
+        ----------
+        data : xr.DataArray
+            Data array with latitude coordinate
+        min_value : float
+            Minimum weight value (at poles). Default is 1e-3.
+        max_value : float
+            Maximum weight value (at equator). Default is 1.0.
+        lat_coord_name : str | None
+            Name of the latitude coordinate. If None, will search for standard
+            latitude coordinate names ('lat', 'latitude', 'rlat').
+            
+        Returns
+        -------
+        xr.DataArray
+            Latitude weights as an xarray DataArray with the same dimensions as
+            the latitude coordinate in the input data.
+            
+        Raises
+        ------
+        ValueError
+            If no latitude coordinate is found in the data.
+        """
+        # Try to find latitude coordinate if not specified
+        if lat_coord_name is None:
+            lat_names = ["lat", "latitude", "rlat"]
+            found_coords = [name for name in lat_names if name in data.coords]
+            if not found_coords:
+                raise ValueError(
+                    f"No latitude coordinate found. Please specify lat_coord_name. "
+                    f"Searched for: {lat_names}"
+                )
+            lat_coord_name = found_coords[0]
+        
+        # Extract latitude values in radians
+        lat_values = data.coords[lat_coord_name]
+        lat_radians = np.deg2rad(lat_values)
+        
+        # Calculate cosine weights
+        weights = (max_value - min_value) * np.cos(lat_radians) + min_value
+        
+        # Return as DataArray preserving coordinates
+        return xr.DataArray(weights, coords={lat_coord_name: lat_values}, dims=[lat_coord_name])
 
     def calc_quantiles(
         self,

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -201,9 +201,11 @@ class Scores:
         }
         self.prob_metrics_dict = {
             "ssr": self.calc_ssr,
+            "ssr_adj": self.calc_ssr_adj,
             "crps": self.calc_crps,
             "rank_histogram": self.calc_rank_histogram,
             "spread": self.calc_spread,
+            "spread_adj": self.calc_spread_adj,
         }
 
     def get_score(
@@ -1405,6 +1407,33 @@ class Scores:
 
         return self._mean(np.sqrt(ens_std**2))
 
+    def calc_spread_adj(self, p: xr.DataArray, **kwargs) -> xr.DataArray:
+        """
+        Calculate the (unbiased) ensemble spread following the GenCast convention.
+
+        Defined as the square root of the mean *unbiased* (``ddof=1``) ensemble variance, matching
+        the spread of GenCast (Price et al., https://arxiv.org/pdf/2312.15796, Eq. A.6). The
+        finite-ensemble inflation factor ``sqrt((M + 1) / M)`` is *not* applied here; following
+        GenCast it is applied in the spread-skill ratio instead (see ``calc_ssr_adj``).
+
+        Unlike the unadjusted ``calc_spread`` (which uses the biased ``ddof=0`` standard
+        deviation), this uses the unbiased variance, as required for the GenCast spread-skill
+        relation to hold. The unadjusted ``calc_spread`` is left unchanged.
+
+        Parameters
+        ----------
+        p: xr.DataArray
+            Forecast data array with ensemble dimension
+
+        Returns
+        -------
+        xr.DataArray
+            Unbiased ensemble spread (GenCast convention)
+        """
+        ens_var = p.var(dim=self._ens_dim, ddof=1)
+
+        return np.sqrt(self._mean(ens_var))
+
     def calc_ssr(self, p: xr.DataArray, gt: xr.DataArray) -> xr.DataArray:
         """
         Calculate the Spread-Skill Ratio (SSR) of the forecast ensemble data w.r.t. reference data
@@ -1424,6 +1453,39 @@ class Scores:
         ssr = self.calc_spread(p) / self.calc_rmse(ens_mean, gt)
 
         return ssr
+
+    def calc_ssr_adj(self, p: xr.DataArray, gt: xr.DataArray) -> xr.DataArray:
+        """
+        Calculate the ensemble-size-adjusted Spread-Skill Ratio (SSR) of the forecast ensemble
+        data w.r.t. reference data.
+
+        Following GenCast (Price et al., https://arxiv.org/pdf/2312.15796, Eq. A.9), this is
+
+            SSR_adj = sqrt((M + 1) / M) * spread / RMSE(ensemble_mean)
+
+        where ``spread`` is the unbiased ensemble spread (``calc_spread_adj``) and M is the
+        ensemble size. For a perfectly reliable ensemble of finite size M, the RMSE of the
+        ensemble mean is inflated relative to the spread by exactly ``sqrt((M + 1) / M)``
+        (Fortin et al., 2014), so the ``sqrt((M + 1) / M)`` factor applied here makes a perfectly
+        calibrated ensemble yield an adjusted SSR of exactly 1. The original ``calc_spread`` /
+        ``calc_ssr`` are left unchanged.
+
+        Parameters
+        ----------
+        p: xr.DataArray
+            Forecast data array with ensemble dimension
+        gt: xr.DataArray
+            Ground truth data array
+        Returns
+        -------
+        xr.DataArray
+            Ensemble-size-adjusted Spread-Skill Ratio (SSR). Optimal value is 1.
+        """
+        ens_size = p.sizes[self._ens_dim]
+        correction = np.sqrt((ens_size + 1) / ens_size)
+        ens_mean = p.mean(dim=self._ens_dim)
+
+        return correction * self.calc_spread_adj(p) / self.calc_rmse(ens_mean, gt)
 
     def calc_crps(
         self,

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -256,12 +256,15 @@ class Scores:
             f = self.det_metrics_dict[score_name]
             _logger.debug(f"Using deterministic metric: {score_name}")
         elif score_name in self.prob_metrics_dict.keys():
-            assert self.ens_dim in data.prediction.dims, (
-                f"Probablistic score {score_name} chosen, but ensemble dimension {self.ens_dim} "
-                "not found in prediction data. Skipping score calculation."
-            )
-            return None
+            if self._ens_dim not in data.prediction.dims:
+                _logger.warning(
+                    f"Probabilistic score '{score_name}' chosen, but ensemble dimension "
+                    f"'{self._ens_dim}' not found in prediction data dims "
+                    f"{data.prediction.dims}. Skipping score calculation."
+                )
+                return None
             f = self.prob_metrics_dict[score_name]
+            _logger.debug(f"Using probabilistic metric: {score_name}")
         else:
             raise ValueError(
                 f"Unknown score chosen. Supported scores: {
@@ -1417,7 +1420,8 @@ class Scores:
         xr.DataArray
             Spread-Skill Ratio (SSR)
         """
-        ssr = self.calc_spread(p) / self.calc_rmse(p, gt)  # spread/rmse
+        ens_mean = p.mean(dim=self._ens_dim)
+        ssr = self.calc_spread(p) / self.calc_rmse(ens_mean, gt)
 
         return ssr
 

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -1540,8 +1540,11 @@ class Scores:
         # Calculate latitude weights if requested
         latitude_weights = None
         if use_latitude_weights:
-            latitude_weights = self.calc_latitude_weights(
-                p, min_value=min_lat_weight, max_value=max_lat_weight, lat_coord_name=lat_coord_name
+            latitude_weights = Scores.calc_latitude_weights(
+                data=p, 
+                min_value=min_lat_weight, 
+                max_value=max_lat_weight, 
+                lat_coord_name=lat_coord_name
             )
         
         # Calculate spread and skill independently with optional latitude weighting
@@ -1605,8 +1608,11 @@ class Scores:
         # Calculate latitude weights if requested
         latitude_weights = None
         if use_latitude_weights:
-            latitude_weights = self.calc_latitude_weights(
-                p, min_value=min_lat_weight, max_value=max_lat_weight, lat_coord_name=lat_coord_name
+            latitude_weights = Scores.calc_latitude_weights(
+                data=p, 
+                min_value=min_lat_weight, 
+                max_value=max_lat_weight, 
+                lat_coord_name=lat_coord_name
             )
         
         # Calculate spread and skill independently with optional latitude weighting
@@ -1867,6 +1873,7 @@ class Scores:
 
         return var_diff_amplitude
 
+    @staticmethod
     def calc_latitude_weights(
         data: xr.DataArray,
         min_value: float = 1e-3,
@@ -1920,8 +1927,10 @@ class Scores:
         # Calculate cosine weights
         weights = (max_value - min_value) * np.cos(lat_radians) + min_value
         
-        # Return as DataArray preserving coordinates
-        return xr.DataArray(weights, coords={lat_coord_name: lat_values}, dims=[lat_coord_name])
+        # Return as DataArray preserving the coordinate and its dimension
+        # The dimension should match the coordinate's dimension (e.g., 'ipoint' not 'lat')
+        lat_dim = lat_values.dims[0] if len(lat_values.dims) > 0 else lat_coord_name
+        return xr.DataArray(weights, coords={lat_coord_name: lat_values}, dims=[lat_dim])
 
     def calc_quantiles(
         self,

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -16,7 +16,7 @@ import pandas as pd
 import xarray as xr
 from scipy.spatial import cKDTree
 
-from weathergen.evaluate.scores.score_utils import to_list
+from weathergen.evaluate.scores.score_utils import calc_latitude_weights, to_list
 
 # from common.io import MockIO
 
@@ -315,6 +315,20 @@ class Scores:
         for an in arg_names:
             if an in kwargs:
                 args[an] = kwargs[an]
+
+        # Compute and inject latitude weights if requested via parameters.
+        # Config example: {rmse: {use_latitude_weights: true, lat_coord_name: lat}}
+        # lat_coord_name is optional; auto-detected from ('lat', 'latitude', 'rlat') if omitted.
+        if "use_latitude_weights" in parameters:
+            parameters = dict(parameters)  # don't mutate caller's dict
+            use_lat_weights = parameters.pop("use_latitude_weights")
+            lat_coord_name = parameters.pop("lat_coord_name", None)
+            if use_lat_weights and "latitude_weights" in inspect.getfullargspec(f).args:
+                ref_data = args.get("p") or args.get("gt")
+                if ref_data is not None:
+                    parameters["latitude_weights"] = calc_latitude_weights(
+                        data=ref_data, lat_coord_name=lat_coord_name
+                    )
 
         if group_by_coord is not None and self._validate_groupby_coord(data, group_by_coord):
             # Apply groupby to all DataArrays in args
@@ -704,14 +718,15 @@ class Scores:
             )
 
         mse = np.square(p - gt)
-        
+
         # Apply latitude weighting if provided
         if latitude_weights is not None:
             # Broadcast weights to match data dimensions
             _, broadcasted_weights = xr.broadcast(mse, latitude_weights)
             # Weighted mean
-            mse_weighted = (mse * broadcasted_weights).mean(dim=self._agg_dims) / \
-                           broadcasted_weights.mean(dim=self._agg_dims)
+            mse_weighted = (mse * broadcasted_weights).mean(
+                dim=self._agg_dims
+            ) / broadcasted_weights.mean(dim=self._agg_dims)
             return mse_weighted
         else:
             return self._mean(mse)
@@ -724,7 +739,7 @@ class Scores:
     ) -> xr.DataArray:
         """
         Calculate root mean squared error (RMSE) of forecast data w.r.t. reference data
-        
+
         Parameters
         ----------
         p: xr.DataArray
@@ -1426,7 +1441,7 @@ class Scores:
     ) -> xr.DataArray:
         """
         Calculate the spread of the forecast ensemble
-        
+
         Parameters
         ----------
         p: xr.DataArray
@@ -1449,8 +1464,9 @@ class Scores:
             # Broadcast weights to match data dimensions
             _, broadcasted_weights = xr.broadcast(spread_squared, latitude_weights)
             # Weighted mean
-            spread_mean = (spread_squared * broadcasted_weights).mean(dim=self._agg_dims) / \
-                          broadcasted_weights.mean(dim=self._agg_dims)
+            spread_mean = (spread_squared * broadcasted_weights).mean(
+                dim=self._agg_dims
+            ) / broadcasted_weights.mean(dim=self._agg_dims)
         else:
             spread_mean = self._mean(spread_squared)
 
@@ -1494,8 +1510,9 @@ class Scores:
             # Broadcast weights to match data dimensions
             _, broadcasted_weights = xr.broadcast(ens_var, latitude_weights)
             # Weighted mean
-            var_mean = (ens_var * broadcasted_weights).mean(dim=self._agg_dims) / \
-                       broadcasted_weights.mean(dim=self._agg_dims)
+            var_mean = (ens_var * broadcasted_weights).mean(
+                dim=self._agg_dims
+            ) / broadcasted_weights.mean(dim=self._agg_dims)
         else:
             var_mean = self._mean(ens_var)
 
@@ -1505,10 +1522,7 @@ class Scores:
         self,
         p: xr.DataArray,
         gt: xr.DataArray,
-        use_latitude_weights: bool = False,
-        lat_coord_name: str | None = None,
-        min_lat_weight: float = 1e-3,
-        max_lat_weight: float = 1.0,
+        latitude_weights: xr.DataArray | None = None,
     ) -> xr.DataArray:
         """
         Calculate the Spread-Skill Ratio (SSR) of the forecast ensemble data w.r.t. reference data
@@ -1519,50 +1533,27 @@ class Scores:
             Forecast data array with ensemble dimension
         gt: xr.DataArray
             Ground truth data array
-        use_latitude_weights: bool
-            If True, automatically calculate and apply latitude weights to both spread and RMSE
-            (skill) components independently. Default is False.
-        lat_coord_name: str | None
-            Name of the latitude coordinate. If None and use_latitude_weights is True, will search
-            for standard latitude coordinate names ('lat', 'latitude', 'rlat').
-        min_lat_weight: float
-            Minimum latitude weight value (at poles). Default is 1e-3.
-        max_lat_weight: float
-            Maximum latitude weight value (at equator). Default is 1.0.
-            
+        latitude_weights: xr.DataArray | None
+            Optional latitude weights for area-weighted averaging, applied to both spread and RMSE
+            components. Can be computed via ``calc_latitude_weights`` or by passing
+            ``use_latitude_weights=True`` in the ``parameters`` dict of ``get_score``.
+            Default is None.
+
         Returns
         -------
         xr.DataArray
             Spread-Skill Ratio (SSR)
         """
         ens_mean = p.mean(dim=self._ens_dim)
-        
-        # Calculate latitude weights if requested
-        latitude_weights = None
-        if use_latitude_weights:
-            latitude_weights = Scores.calc_latitude_weights(
-                data=p, 
-                min_value=min_lat_weight, 
-                max_value=max_lat_weight, 
-                lat_coord_name=lat_coord_name
-            )
-        
-        # Calculate spread and skill independently with optional latitude weighting
         spread = self.calc_spread(p, latitude_weights=latitude_weights)
         rmse = self.calc_rmse(ens_mean, gt, latitude_weights=latitude_weights)
-        
-        ssr = spread / rmse
-
-        return ssr
+        return spread / rmse
 
     def calc_ssr_adj(
         self,
         p: xr.DataArray,
         gt: xr.DataArray,
-        use_latitude_weights: bool = False,
-        lat_coord_name: str | None = None,
-        min_lat_weight: float = 1e-3,
-        max_lat_weight: float = 1.0,
+        latitude_weights: xr.DataArray | None = None,
     ) -> xr.DataArray:
         """
         Calculate the ensemble-size-adjusted Spread-Skill Ratio (SSR) of the forecast ensemble
@@ -1585,17 +1576,12 @@ class Scores:
             Forecast data array with ensemble dimension
         gt: xr.DataArray
             Ground truth data array
-        use_latitude_weights: bool
-            If True, automatically calculate and apply latitude weights to both spread and RMSE
-            (skill) components independently. Default is False.
-        lat_coord_name: str | None
-            Name of the latitude coordinate. If None and use_latitude_weights is True, will search
-            for standard latitude coordinate names ('lat', 'latitude', 'rlat').
-        min_lat_weight: float
-            Minimum latitude weight value (at poles). Default is 1e-3.
-        max_lat_weight: float
-            Maximum latitude weight value (at equator). Default is 1.0.
-            
+        latitude_weights: xr.DataArray | None
+            Optional latitude weights for area-weighted averaging, applied to both spread and RMSE
+            components. Can be computed via ``calc_latitude_weights`` or by passing
+            ``use_latitude_weights=True`` in the ``parameters`` dict of ``get_score``.
+            Default is None.
+
         Returns
         -------
         xr.DataArray
@@ -1604,21 +1590,8 @@ class Scores:
         ens_size = p.sizes[self._ens_dim]
         correction = np.sqrt((ens_size + 1) / ens_size)
         ens_mean = p.mean(dim=self._ens_dim)
-        
-        # Calculate latitude weights if requested
-        latitude_weights = None
-        if use_latitude_weights:
-            latitude_weights = Scores.calc_latitude_weights(
-                data=p, 
-                min_value=min_lat_weight, 
-                max_value=max_lat_weight, 
-                lat_coord_name=lat_coord_name
-            )
-        
-        # Calculate spread and skill independently with optional latitude weighting
         spread = self.calc_spread_adj(p, latitude_weights=latitude_weights)
         rmse = self.calc_rmse(ens_mean, gt, latitude_weights=latitude_weights)
-
         return correction * spread / rmse
 
     def calc_crps(
@@ -1872,65 +1845,6 @@ class Scores:
             raise ValueError(f"Second-order differentation is not implemenetd in {method} yet.")
 
         return var_diff_amplitude
-
-    @staticmethod
-    def calc_latitude_weights(
-        data: xr.DataArray,
-        min_value: float = 1e-3,
-        max_value: float = 1.0,
-        lat_coord_name: str | None = None,
-    ) -> xr.DataArray:
-        """
-        Calculate latitude weights based on cosine of latitude.
-        
-        This function computes weights that account for the convergence of meridians
-        towards the poles, giving less weight to high-latitude grid points.
-        
-        Parameters
-        ----------
-        data : xr.DataArray
-            Data array with latitude coordinate
-        min_value : float
-            Minimum weight value (at poles). Default is 1e-3.
-        max_value : float
-            Maximum weight value (at equator). Default is 1.0.
-        lat_coord_name : str | None
-            Name of the latitude coordinate. If None, will search for standard
-            latitude coordinate names ('lat', 'latitude', 'rlat').
-            
-        Returns
-        -------
-        xr.DataArray
-            Latitude weights as an xarray DataArray with the same dimensions as
-            the latitude coordinate in the input data.
-            
-        Raises
-        ------
-        ValueError
-            If no latitude coordinate is found in the data.
-        """
-        # Try to find latitude coordinate if not specified
-        if lat_coord_name is None:
-            lat_names = ["lat", "latitude", "rlat"]
-            found_coords = [name for name in lat_names if name in data.coords]
-            if not found_coords:
-                raise ValueError(
-                    f"No latitude coordinate found. Please specify lat_coord_name. "
-                    f"Searched for: {lat_names}"
-                )
-            lat_coord_name = found_coords[0]
-        
-        # Extract latitude values in radians
-        lat_values = data.coords[lat_coord_name]
-        lat_radians = np.deg2rad(lat_values)
-        
-        # Calculate cosine weights
-        weights = (max_value - min_value) * np.cos(lat_radians) + min_value
-        
-        # Return as DataArray preserving the coordinate and its dimension
-        # The dimension should match the coordinate's dimension (e.g., 'ipoint' not 'lat')
-        lat_dim = lat_values.dims[0] if len(lat_values.dims) > 0 else lat_coord_name
-        return xr.DataArray(weights, coords={lat_coord_name: lat_values}, dims=[lat_dim])
 
     def calc_quantiles(
         self,

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -201,11 +201,9 @@ class Scores:
         }
         self.prob_metrics_dict = {
             "ssr": self.calc_ssr,
-            "ssr_adj": self.calc_ssr_adj,
             "crps": self.calc_crps,
             "rank_histogram": self.calc_rank_histogram,
             "spread": self.calc_spread,
-            "spread_adj": self.calc_spread_adj,
         }
 
     def get_score(
@@ -1462,10 +1460,11 @@ class Scores:
         self,
         p: xr.DataArray,
         latitude_weights: xr.DataArray | None = None,
+        adjusted: bool = False,
         **kwargs,
     ) -> xr.DataArray:
         """
-        Calculate the spread of the forecast ensemble
+        Calculate the spread of the forecast ensemble.
 
         Parameters
         ----------
@@ -1473,56 +1472,20 @@ class Scores:
             Forecast data array with ensemble dimension
         latitude_weights: xr.DataArray | None
             Optional latitude weights for area-weighted averaging.
-            If provided, the spread will be weighted by these values.
+        adjusted: bool
+            If True, use the unbiased (``ddof=1``) ensemble variance following the GenCast
+            convention (Price et al., https://arxiv.org/pdf/2312.15796, Eq. A.6). The
+            finite-ensemble inflation factor ``sqrt((M + 1) / M)`` is applied in the
+            spread-skill ratio (see ``calc_ssr``), not here.
+            If False (default), use the biased (``ddof=0``) variance.
 
         Returns
         -------
         xr.DataArray
             Spread of the forecast ensemble
         """
-        ens_std = p.std(dim=self._ens_dim)
-
-        spread_squared = ens_std**2
-
-        if latitude_weights is not None:
-            spread_mean = self._weighted_mean(spread_squared, latitude_weights)
-        else:
-            spread_mean = self._mean(spread_squared)
-
-        return np.sqrt(spread_mean)
-
-    def calc_spread_adj(
-        self,
-        p: xr.DataArray,
-        latitude_weights: xr.DataArray | None = None,
-        **kwargs,
-    ) -> xr.DataArray:
-        """
-        Calculate the (unbiased) ensemble spread following the GenCast convention.
-
-        Defined as the square root of the mean *unbiased* (``ddof=1``) ensemble variance, matching
-        the spread of GenCast (Price et al., https://arxiv.org/pdf/2312.15796, Eq. A.6). The
-        finite-ensemble inflation factor ``sqrt((M + 1) / M)`` is *not* applied here; following
-        GenCast it is applied in the spread-skill ratio instead (see ``calc_ssr_adj``).
-
-        Unlike the unadjusted ``calc_spread`` (which uses the biased ``ddof=0`` standard
-        deviation), this uses the unbiased variance, as required for the GenCast spread-skill
-        relation to hold. The unadjusted ``calc_spread`` is left unchanged.
-
-        Parameters
-        ----------
-        p: xr.DataArray
-            Forecast data array with ensemble dimension
-        latitude_weights: xr.DataArray | None
-            Optional latitude weights for area-weighted averaging.
-            If provided, the spread will be weighted by these values.
-
-        Returns
-        -------
-        xr.DataArray
-            Unbiased ensemble spread (GenCast convention)
-        """
-        ens_var = p.var(dim=self._ens_dim, ddof=1)
+        ddof = 1 if adjusted else 0
+        ens_var = p.var(dim=self._ens_dim, ddof=ddof)
 
         if latitude_weights is not None:
             var_mean = self._weighted_mean(ens_var, latitude_weights)
@@ -1536,9 +1499,10 @@ class Scores:
         p: xr.DataArray,
         gt: xr.DataArray,
         latitude_weights: xr.DataArray | None = None,
+        adjusted: bool = False,
     ) -> xr.DataArray:
         """
-        Calculate the Spread-Skill Ratio (SSR) of the forecast ensemble data w.r.t. reference data
+        Calculate the Spread-Skill Ratio (SSR) of the forecast ensemble data w.r.t. reference data.
 
         Parameters
         ----------
@@ -1551,6 +1515,11 @@ class Scores:
             components. Can be computed via ``calc_latitude_weights`` or by passing
             ``use_latitude_weights=True`` in the ``parameters`` dict of ``get_score``.
             Default is None.
+        adjusted: bool
+            If True, apply the ensemble-size correction ``sqrt((M + 1) / M)`` following GenCast
+            (Price et al., https://arxiv.org/pdf/2312.15796, Eq. A.9) and use the unbiased
+            (``ddof=1``) spread. A perfectly calibrated ensemble of size M then yields SSR = 1.
+            If False (default), use the biased spread with no correction.
 
         Returns
         -------
@@ -1558,54 +1527,12 @@ class Scores:
             Spread-Skill Ratio (SSR)
         """
         ens_mean = p.mean(dim=self._ens_dim)
-        spread = self.calc_spread(p, latitude_weights=latitude_weights)
+        spread = self.calc_spread(p, latitude_weights=latitude_weights, adjusted=adjusted)
         rmse = self.calc_rmse(ens_mean, gt, latitude_weights=latitude_weights)
+        if adjusted:
+            ens_size = p.sizes[self._ens_dim]
+            return np.sqrt((ens_size + 1) / ens_size) * spread / rmse
         return spread / rmse
-
-    def calc_ssr_adj(
-        self,
-        p: xr.DataArray,
-        gt: xr.DataArray,
-        latitude_weights: xr.DataArray | None = None,
-    ) -> xr.DataArray:
-        """
-        Calculate the ensemble-size-adjusted Spread-Skill Ratio (SSR) of the forecast ensemble
-        data w.r.t. reference data.
-
-        Following GenCast (Price et al., https://arxiv.org/pdf/2312.15796, Eq. A.9), this is
-
-            SSR_adj = sqrt((M + 1) / M) * spread / RMSE(ensemble_mean)
-
-        where ``spread`` is the unbiased ensemble spread (``calc_spread_adj``) and M is the
-        ensemble size. For a perfectly reliable ensemble of finite size M, the RMSE of the
-        ensemble mean is inflated relative to the spread by exactly ``sqrt((M + 1) / M)``
-        (Fortin et al., 2014), so the ``sqrt((M + 1) / M)`` factor applied here makes a perfectly
-        calibrated ensemble yield an adjusted SSR of exactly 1. The original ``calc_spread`` /
-        ``calc_ssr`` are left unchanged.
-
-        Parameters
-        ----------
-        p: xr.DataArray
-            Forecast data array with ensemble dimension
-        gt: xr.DataArray
-            Ground truth data array
-        latitude_weights: xr.DataArray | None
-            Optional latitude weights for area-weighted averaging, applied to both spread and RMSE
-            components. Can be computed via ``calc_latitude_weights`` or by passing
-            ``use_latitude_weights=True`` in the ``parameters`` dict of ``get_score``.
-            Default is None.
-
-        Returns
-        -------
-        xr.DataArray
-            Ensemble-size-adjusted Spread-Skill Ratio (SSR). Optimal value is 1.
-        """
-        ens_size = p.sizes[self._ens_dim]
-        correction = np.sqrt((ens_size + 1) / ens_size)
-        ens_mean = p.mean(dim=self._ens_dim)
-        spread = self.calc_spread_adj(p, latitude_weights=latitude_weights)
-        rmse = self.calc_rmse(ens_mean, gt, latitude_weights=latitude_weights)
-        return correction * spread / rmse
 
     def calc_crps(
         self,

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -1484,9 +1484,9 @@ class Scores:
         latitude_weights: xr.DataArray | None
             Optional latitude weights for area-weighted averaging.
         adjusted: bool
-            If True (default), use the unbiased (``ddof=1``) ensemble variance following the GenCast
-            convention (Price et al., https://arxiv.org/pdf/2312.15796, Eq. A.6). The
-            finite-ensemble inflation factor ``sqrt((M + 1) / M)`` is applied in the
+            If True (default), use the unbiased (``ddof=1``) ensemble variance following
+            the GenCast convention (Price et al., https://arxiv.org/pdf/2312.15796, Eq. A.6).
+            The finite-ensemble inflation factor ``sqrt((M + 1) / M)`` is applied in the
             spread-skill ratio (see ``calc_ssr``), not here.
             If False, use the biased (``ddof=0``) variance.
 
@@ -1527,8 +1527,8 @@ class Scores:
             ``latitude_weighting=True`` in the ``parameters`` dict of ``get_score``.
             Default is None.
         adjusted: bool
-            If True (default), apply the ensemble-size correction ``sqrt((M + 1) / M)`` following GenCast
-            (Price et al., https://arxiv.org/pdf/2312.15796, Eq. A.9) and use the unbiased
+            If True (default), apply the ensemble-size correction ``sqrt((M + 1) / M)`` following
+            GenCast (Price et al., https://arxiv.org/pdf/2312.15796, Eq. A.9) and use the unbiased
             (``ddof=1``) spread. A perfectly calibrated ensemble of size M then yields SSR = 1.
             If False, use the biased spread with no correction.
 
@@ -1931,3 +1931,4 @@ class Scores:
         _logger.info(f"Q-Q analysis completed with {len(overall_qq_score.attrs)} attributes")
 
         return overall_qq_score
+ 

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -332,6 +332,12 @@ class Scores:
             if use_lat_weights and "latitude_weights" in inspect.getfullargspec(f).args:
                 if data.latitude_weights is not None:
                     parameters["latitude_weights"] = data.latitude_weights
+                else:
+                    _logger.warning(
+                        "Latitude weighting was requested for score '%s', but no latitude "
+                        "coordinate was found. Proceeding without weighting.",
+                        score_name,
+                    )
 
         if group_by_coord is not None and self._validate_groupby_coord(data, group_by_coord):
             # Apply groupby to all DataArrays in args

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -1471,7 +1471,7 @@ class Scores:
         self,
         p: xr.DataArray,
         latitude_weights: xr.DataArray | None = None,
-        adjusted: bool = False,
+        adjusted: bool = True,
         **kwargs,
     ) -> xr.DataArray:
         """
@@ -1484,11 +1484,11 @@ class Scores:
         latitude_weights: xr.DataArray | None
             Optional latitude weights for area-weighted averaging.
         adjusted: bool
-            If True, use the unbiased (``ddof=1``) ensemble variance following the GenCast
+            If True (default), use the unbiased (``ddof=1``) ensemble variance following the GenCast
             convention (Price et al., https://arxiv.org/pdf/2312.15796, Eq. A.6). The
             finite-ensemble inflation factor ``sqrt((M + 1) / M)`` is applied in the
             spread-skill ratio (see ``calc_ssr``), not here.
-            If False (default), use the biased (``ddof=0``) variance.
+            If False, use the biased (``ddof=0``) variance.
 
         Returns
         -------
@@ -1510,7 +1510,7 @@ class Scores:
         p: xr.DataArray,
         gt: xr.DataArray,
         latitude_weights: xr.DataArray | None = None,
-        adjusted: bool = False,
+        adjusted: bool = True,
     ) -> xr.DataArray:
         """
         Calculate the Spread-Skill Ratio (SSR) of the forecast ensemble data w.r.t. reference data.
@@ -1527,10 +1527,10 @@ class Scores:
             ``latitude_weighting=True`` in the ``parameters`` dict of ``get_score``.
             Default is None.
         adjusted: bool
-            If True, apply the ensemble-size correction ``sqrt((M + 1) / M)`` following GenCast
+            If True (default), apply the ensemble-size correction ``sqrt((M + 1) / M)`` following GenCast
             (Price et al., https://arxiv.org/pdf/2312.15796, Eq. A.9) and use the unbiased
             (``ddof=1``) spread. A perfectly calibrated ensemble of size M then yields SSR = 1.
-            If False (default), use the biased spread with no correction.
+            If False, use the biased spread with no correction.
 
         Returns
         -------

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -76,11 +76,14 @@ class VerifiedData:
     prediction_next: xr.DataArray | None
     ground_truth_next: xr.DataArray | None
     climatology: xr.DataArray | None
+    latitude_weights: xr.DataArray | None = None
 
     def __post_init__(self):
         # Perform checks on initialization
         self._validate_dimensions()
         self._validate_broadcastability()
+        if self.latitude_weights is None:
+            object.__setattr__(self, "latitude_weights", self._compute_latitude_weights())
 
     # TODO: add checks for prediction_next, ground_truth_next, climatology
     def _validate_dimensions(self):
@@ -98,6 +101,12 @@ class VerifiedData:
             xr.broadcast(self.prediction, self.ground_truth)
         except ValueError as e:
             raise ValueError(f"Forecast and truth are not broadcastable: {e}") from e
+
+    def _compute_latitude_weights(self) -> xr.DataArray | None:
+        found = [c for c in ("lat", "latitude", "rlat", "clat") if c in self.prediction.coords]
+        if not found:
+            return None
+        return calc_latitude_weights(self.prediction, lat_coord_name=found[0])
 
 
 def get_score(
@@ -314,19 +323,15 @@ class Scores:
             if an in kwargs:
                 args[an] = kwargs[an]
 
-        # Compute and inject latitude weights if requested via parameters.
-        # Config example: {rmse: {latitude_weighting: true, lat_coord_name: lat}}
-        # lat_coord_name is optional; auto-detected from ('lat', 'latitude', 'rlat') if omitted.
+        # Inject latitude weights if requested via parameters.
+        # Config example: {rmse: {latitude_weighting: true}}
+        # Weights are pre-computed on VerifiedData construction; None if no lat coord found.
         if "latitude_weighting" in parameters:
             parameters = dict(parameters)  # don't mutate caller's dict
             use_lat_weights = parameters.pop("latitude_weighting")
-            lat_coord_name = parameters.pop("lat_coord_name", None)
             if use_lat_weights and "latitude_weights" in inspect.getfullargspec(f).args:
-                ref_data = args.get("p") or args.get("gt")
-                if ref_data is not None:
-                    parameters["latitude_weights"] = calc_latitude_weights(
-                        data=ref_data, lat_coord_name=lat_coord_name
-                    )
+                if data.latitude_weights is not None:
+                    parameters["latitude_weights"] = data.latitude_weights
 
         if group_by_coord is not None and self._validate_groupby_coord(data, group_by_coord):
             # Apply groupby to all DataArrays in args

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -449,6 +449,10 @@ class Scores:
         """
         return data.mean(dim=self._agg_dims)
 
+    def _weighted_mean(self, data: xr.DataArray, weights: xr.DataArray) -> xr.DataArray:
+        _, w = xr.broadcast(data, weights)
+        return (data * w).mean(dim=self._agg_dims) / w.mean(dim=self._agg_dims)
+
     def get_2x2_event_counts(
         self,
         p: xr.DataArray,
@@ -696,10 +700,7 @@ class Scores:
 
         mae = np.abs(p - gt)
         if latitude_weights is not None:
-            _, broadcasted_weights = xr.broadcast(mae, latitude_weights)
-            return (mae * broadcasted_weights).mean(dim=self._agg_dims) / broadcasted_weights.mean(
-                dim=self._agg_dims
-            )
+            return self._weighted_mean(mae, latitude_weights)
         return self._mean(mae)
 
     def calc_mse(
@@ -733,17 +734,9 @@ class Scores:
 
         mse = np.square(p - gt)
 
-        # Apply latitude weighting if provided
         if latitude_weights is not None:
-            # Broadcast weights to match data dimensions
-            _, broadcasted_weights = xr.broadcast(mse, latitude_weights)
-            # Weighted mean
-            mse_weighted = (mse * broadcasted_weights).mean(
-                dim=self._agg_dims
-            ) / broadcasted_weights.mean(dim=self._agg_dims)
-            return mse_weighted
-        else:
-            return self._mean(mse)
+            return self._weighted_mean(mse, latitude_weights)
+        return self._mean(mse)
 
     def calc_rmse(
         self,
@@ -1251,10 +1244,7 @@ class Scores:
         """
         bias = p - gt
         if latitude_weights is not None:
-            _, broadcasted_weights = xr.broadcast(bias, latitude_weights)
-            return (bias * broadcasted_weights).mean(dim=self._agg_dims) / broadcasted_weights.mean(
-                dim=self._agg_dims
-            )
+            return self._weighted_mean(bias, latitude_weights)
         return self._mean(bias)
 
     def calc_psnr(
@@ -1494,14 +1484,8 @@ class Scores:
 
         spread_squared = ens_std**2
 
-        # Apply latitude weighting if provided
         if latitude_weights is not None:
-            # Broadcast weights to match data dimensions
-            _, broadcasted_weights = xr.broadcast(spread_squared, latitude_weights)
-            # Weighted mean
-            spread_mean = (spread_squared * broadcasted_weights).mean(
-                dim=self._agg_dims
-            ) / broadcasted_weights.mean(dim=self._agg_dims)
+            spread_mean = self._weighted_mean(spread_squared, latitude_weights)
         else:
             spread_mean = self._mean(spread_squared)
 
@@ -1540,14 +1524,8 @@ class Scores:
         """
         ens_var = p.var(dim=self._ens_dim, ddof=1)
 
-        # Apply latitude weighting if provided
         if latitude_weights is not None:
-            # Broadcast weights to match data dimensions
-            _, broadcasted_weights = xr.broadcast(ens_var, latitude_weights)
-            # Weighted mean
-            var_mean = (ens_var * broadcasted_weights).mean(
-                dim=self._agg_dims
-            ) / broadcasted_weights.mean(dim=self._agg_dims)
+            var_mean = self._weighted_mean(ens_var, latitude_weights)
         else:
             var_mean = self._mean(ens_var)
 

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -669,7 +669,12 @@ class Scores:
 
         return l2
 
-    def calc_mae(self, p: xr.DataArray, gt: xr.DataArray) -> xr.DataArray:
+    def calc_mae(
+        self,
+        p: xr.DataArray,
+        gt: xr.DataArray,
+        latitude_weights: xr.DataArray | None = None,
+    ) -> xr.DataArray:
         """
         Calculate mean absolute error (MAE) of forecast data w.r.t. reference data.
 
@@ -679,6 +684,9 @@ class Scores:
             Forecast data array
         gt: xr.DataArray
             Ground truth data array
+        latitude_weights: xr.DataArray | None
+            Optional latitude weights for area-weighted averaging.
+            If None, unweighted mean is used.
         """
         if self._agg_dims is None:
             raise ValueError(
@@ -686,7 +694,13 @@ class Scores:
                 "(agg_dims=None)."
             )
 
-        return self._mean(np.abs(p - gt))
+        mae = np.abs(p - gt)
+        if latitude_weights is not None:
+            _, broadcasted_weights = xr.broadcast(mae, latitude_weights)
+            return (mae * broadcasted_weights).mean(dim=self._agg_dims) / broadcasted_weights.mean(
+                dim=self._agg_dims
+            )
+        return self._mean(mae)
 
     def calc_mse(
         self,
@@ -1030,6 +1044,7 @@ class Scores:
         p: xr.DataArray,
         gt: xr.DataArray,
         c: xr.DataArray,
+        latitude_weights: xr.DataArray | None = None,
     ) -> xr.DataArray:
         """
         Calculate anomaly correlation coefficient (ACC).
@@ -1046,6 +1061,9 @@ class Scores:
             Ground truth data array
         c: xr.DataArray
             Climatological mean data array, which is used to calculate anomalies
+        latitude_weights: xr.DataArray | None
+            Optional latitude weights for area-weighted summation.
+            If None, unweighted sums are used.
 
         Returns
         -------
@@ -1062,10 +1080,15 @@ class Scores:
         # Calculate anomalies
         fcst_ano, obs_ano = p - c, gt - c
 
-        # Calculate ACC over spatial dimensions (no grouping)
-        acc = (fcst_ano * obs_ano).sum(self._agg_dims) / np.sqrt(
-            (fcst_ano**2).sum(self._agg_dims) * (obs_ano**2).sum(self._agg_dims)
-        )
+        if latitude_weights is not None:
+            _, w = xr.broadcast(fcst_ano, latitude_weights)
+            acc = (w * fcst_ano * obs_ano).sum(self._agg_dims) / np.sqrt(
+                (w * fcst_ano**2).sum(self._agg_dims) * (w * obs_ano**2).sum(self._agg_dims)
+            )
+        else:
+            acc = (fcst_ano * obs_ano).sum(self._agg_dims) / np.sqrt(
+                (fcst_ano**2).sum(self._agg_dims) * (obs_ano**2).sum(self._agg_dims)
+            )
 
         return acc
 
@@ -1203,7 +1226,12 @@ class Scores:
 
         return (1.0 - rps_fcst / rps_clim).where(rps_clim != 0, np.nan)
 
-    def calc_bias(self, p: xr.DataArray, gt: xr.DataArray) -> xr.DataArray:
+    def calc_bias(
+        self,
+        p: xr.DataArray,
+        gt: xr.DataArray,
+        latitude_weights: xr.DataArray | None = None,
+    ) -> xr.DataArray:
         """
         Calculate mean bias of forecast data w.r.t. reference data
 
@@ -1213,14 +1241,21 @@ class Scores:
             Forecast data array
         gt: xr.DataArray
             Ground truth data array
+        latitude_weights: xr.DataArray | None
+            Optional latitude weights for area-weighted averaging.
+            If None, unweighted mean is used.
         Returns
         -------
         xr.DataArray
             Mean bias
         """
-        bias = self._mean(p - gt)
-
-        return bias
+        bias = p - gt
+        if latitude_weights is not None:
+            _, broadcasted_weights = xr.broadcast(bias, latitude_weights)
+            return (bias * broadcasted_weights).mean(dim=self._agg_dims) / broadcasted_weights.mean(
+                dim=self._agg_dims
+            )
+        return self._mean(bias)
 
     def calc_psnr(
         self,

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -315,11 +315,11 @@ class Scores:
                 args[an] = kwargs[an]
 
         # Compute and inject latitude weights if requested via parameters.
-        # Config example: {rmse: {use_latitude_weights: true, lat_coord_name: lat}}
+        # Config example: {rmse: {latitude_weighting: true, lat_coord_name: lat}}
         # lat_coord_name is optional; auto-detected from ('lat', 'latitude', 'rlat') if omitted.
-        if "use_latitude_weights" in parameters:
+        if "latitude_weighting" in parameters:
             parameters = dict(parameters)  # don't mutate caller's dict
-            use_lat_weights = parameters.pop("use_latitude_weights")
+            use_lat_weights = parameters.pop("latitude_weighting")
             lat_coord_name = parameters.pop("lat_coord_name", None)
             if use_lat_weights and "latitude_weights" in inspect.getfullargspec(f).args:
                 ref_data = args.get("p") or args.get("gt")
@@ -1513,7 +1513,7 @@ class Scores:
         latitude_weights: xr.DataArray | None
             Optional latitude weights for area-weighted averaging, applied to both spread and RMSE
             components. Can be computed via ``calc_latitude_weights`` or by passing
-            ``use_latitude_weights=True`` in the ``parameters`` dict of ``get_score``.
+            ``latitude_weighting=True`` in the ``parameters`` dict of ``get_score``.
             Default is None.
         adjusted: bool
             If True, apply the ensemble-size correction ``sqrt((M + 1) / M)`` following GenCast

--- a/packages/evaluate/src/weathergen/evaluate/scores/score_utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score_utils.py
@@ -62,7 +62,7 @@ def calc_latitude_weights(
         Maximum weight value (at equator). Default is 1.0.
     lat_coord_name : str | None
         Name of the latitude coordinate. If None, will search for standard
-        latitude coordinate names ('lat', 'latitude', 'rlat').
+        latitude coordinate names ('lat', 'latitude', 'rlat', 'clat').
 
     Returns
     -------
@@ -76,7 +76,7 @@ def calc_latitude_weights(
         If no latitude coordinate is found in the data.
     """
     if lat_coord_name is None:
-        lat_names = ["lat", "latitude", "rlat"]
+        lat_names = ["lat", "latitude", "rlat", "clat"]
         found_coords = [name for name in lat_names if name in data.coords]
         if not found_coords:
             raise ValueError(

--- a/packages/evaluate/src/weathergen/evaluate/scores/score_utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score_utils.py
@@ -12,6 +12,8 @@ import logging
 from typing import Any
 
 # Third-party
+import numpy as np
+import xarray as xr
 from omegaconf.listconfig import ListConfig
 
 _logger = logging.getLogger(__name__)
@@ -36,3 +38,56 @@ def to_list(obj: Any) -> list:
     elif not isinstance(obj, list):
         obj = [obj]
     return obj
+
+
+def calc_latitude_weights(
+    data: xr.DataArray,
+    min_value: float = 1e-3,
+    max_value: float = 1.0,
+    lat_coord_name: str | None = None,
+) -> xr.DataArray:
+    """
+    Calculate latitude weights based on cosine of latitude.
+
+    This function computes weights that account for the convergence of meridians
+    towards the poles, giving less weight to high-latitude grid points.
+
+    Parameters
+    ----------
+    data : xr.DataArray
+        Data array with latitude coordinate
+    min_value : float
+        Minimum weight value (at poles). Default is 1e-3.
+    max_value : float
+        Maximum weight value (at equator). Default is 1.0.
+    lat_coord_name : str | None
+        Name of the latitude coordinate. If None, will search for standard
+        latitude coordinate names ('lat', 'latitude', 'rlat').
+
+    Returns
+    -------
+    xr.DataArray
+        Latitude weights as an xarray DataArray with the same dimensions as
+        the latitude coordinate in the input data.
+
+    Raises
+    ------
+    ValueError
+        If no latitude coordinate is found in the data.
+    """
+    if lat_coord_name is None:
+        lat_names = ["lat", "latitude", "rlat"]
+        found_coords = [name for name in lat_names if name in data.coords]
+        if not found_coords:
+            raise ValueError(
+                f"No latitude coordinate found. Please specify lat_coord_name. "
+                f"Searched for: {lat_names}"
+            )
+        lat_coord_name = found_coords[0]
+
+    lat_values = data.coords[lat_coord_name]
+    lat_radians = np.deg2rad(lat_values)
+    weights = (max_value - min_value) * np.cos(lat_radians) + min_value
+
+    lat_dim = lat_values.dims[0] if len(lat_values.dims) > 0 else lat_coord_name
+    return xr.DataArray(weights, coords={lat_coord_name: lat_values}, dims=[lat_dim])


### PR DESCRIPTION
## Description

Adds two probabilistic metrics following GenCast (Price et al., 2024, App. A),
leaving the existing `spread`/`ssr` untouched.

**UPDATE: Also includes fixes to https://github.com/ecmwf/WeatherGenerator/issues/2577 as provided by this [PR](https://github.com/moritzhauschulz/WeatherGenerator/pull/4)**

## Changes
- **`spread_adj`** — unbiased ensemble spread `sqrt(mean Var_ens(ddof=1))` (GenCast Eq. A.6).
- **`ssr_adj`** — adjusted spread-skill ratio `sqrt((M+1)/M) · spread_adj / RMSE(ens_mean)`
  (GenCast Eq. A.9), where `M` is the ensemble size. The `sqrt((M+1)/M)` factor removes the
  finite-ensemble bias so a perfectly calibrated ensemble gives **SSR = 1**.
- Plotting: `ssr_adj` line plots draw a horizontal reference line at the optimal value of 1.

## Notes
- Legacy `spread` (biased `ddof=0`) and `ssr` are unchanged; GenCast has no uncorrected SSR,
  so these remain only as non-standard diagnostics.
- Use via `evaluation.metrics` in the eval config (e.g. add `ssr_adj`, `spread_adj`).

**Should be reviewed by someone from the evaluation team**

On Santis, run with `uv run evaluate --config ./config/evaluate/eval_config_test.yml -run-ids qvim6zb3` using the attached eval config. 

## Issue Number

Closes #2507 

Note this depends on #2503, which should be merged first.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel


