### PR TITLE
[2506][DRAFT] First step of publically runnable version

### DIFF
--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -195,10 +195,10 @@ def format_cf(config: Config) -> str:
     return stream.getvalue()
 
 
-def save(config: Config, mini_epoch: int | None):
+def save(config: Config, mini_epoch: int | None, private_config_path: Path | None = None):
     """Save current config into the current runs model directory."""
     # save in directory with model files
-    dirname = get_path_model(config)
+    dirname = get_path_model(config, private_config_path=private_config_path)
     dirname.mkdir(exist_ok=True, parents=True)
 
     fname = _get_model_config_file_write_name(get_run_id_from_config(config), mini_epoch)
@@ -208,7 +208,7 @@ def save(config: Config, mini_epoch: int | None):
         f.write(json_str)
 
 
-def load_run_config(run_id: str, mini_epoch: int | None, model_path: str | None, private_config_path: Path) -> Config:
+def load_run_config(run_id: str, mini_epoch: int | None, model_path: str | None, private_config_path: Path | None = None) -> Config:
     """
     Load a configuration file from a given run_id and mini_epoch.
     If run_id is a full path, loads it from the full path.

--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -208,7 +208,7 @@ def save(config: Config, mini_epoch: int | None):
         f.write(json_str)
 
 
-def load_run_config(run_id: str, mini_epoch: int | None, model_path: str | None) -> Config:
+def load_run_config(run_id: str, mini_epoch: int | None, model_path: str | None, private_config_path: Path) -> Config:
     """
     Load a configuration file from a given run_id and mini_epoch.
     If run_id is a full path, loads it from the full path.
@@ -217,6 +217,7 @@ def load_run_config(run_id: str, mini_epoch: int | None, model_path: str | None)
         run_id: Run ID of the pretrained WeatherGenerator model
         mini_epoch: Mini_epoch of the checkpoint to load. -1 indicates last checkpoint available.
         model_path: Path to the model directory. If None, uses the model_path from private config.
+        private_config_path: Path to the private configuration file.
 
     Returns:
         Configuration object loaded from the specified run and mini_epoch.
@@ -228,7 +229,7 @@ def load_run_config(run_id: str, mini_epoch: int | None, model_path: str | None)
     else:
         # Load model config here. In case model_path is not provided, get it from private conf
         if model_path is None:
-            path = get_path_model(run_id=run_id)
+            path = get_path_model(private_config_path=private_config_path, run_id=run_id)
         else:
             path = Path(model_path) / run_id
 
@@ -387,7 +388,7 @@ def merge_configs(base_config: Config, update_config: Config):
 
 
 def load_merge_configs(
-    private_home: Path | None = None,
+    private_config_path: Path | None = None,
     from_run_id: str | None = None,
     mini_epoch: int | None = None,
     base: Path | Config | None = None,
@@ -398,7 +399,7 @@ def load_merge_configs(
     private configs "secrets" section will be discarded.
 
     Args:
-        private_home: Configuration file containing platform dependent information and secrets
+        private_config_path: Path to the private configuration file containing platform dependent information and secrets
         from_run_id: Run id of the pretrained WeatherGenerator model
         to continue training or inference
         mini_epoch: Mini_epoch of the checkpoint to load. -1 indicates last checkpoint available.
@@ -413,7 +414,7 @@ def load_merge_configs(
     Returns:
         Merged configuration object.
     """
-    private_config = _load_private_conf(private_home)
+    private_config = _load_private_conf(private_config_path)
     overwrite_configs: list[Config] = []
     for overwrite in overwrites:
         if isinstance(overwrite, (str | Path)):
@@ -433,7 +434,7 @@ def load_merge_configs(
     if from_run_id is None:
         base_config = _load_base_conf(base)
     else:
-        base_config = load_run_config(from_run_id, mini_epoch, None)
+        base_config = load_run_config(from_run_id, mini_epoch, None, private_config_path=private_config_path)
         from_run_id = get_run_id_from_config(base_config)
     with open_dict(base_config):
         base_config.from_run_id = from_run_id
@@ -540,20 +541,21 @@ def _load_overwrite_conf(overwrite: Path | dict | DictConfig) -> DictConfig:
     return overwrite_config
 
 
-def _load_private_conf(private_home: Path | None = None) -> DictConfig:
+def _load_private_conf(private_config_path: Path | None = None) -> DictConfig:
     """
     Return the private configuration from file or environment variable WEATHERGEN_PRIVATE_CONF.
     """
-    env_script_path = get_wg_private_path() / "hpc" / "platform-env.py"
-
-    if private_home is not None and private_home.is_file():
-        _logger.info(f"Loading private config from {private_home}.")
-
+    try:
+        env_script_path = get_wg_private_path() / "hpc" / "platform-env.py"
+    except Exception as e:
+        _logger.warning(f"Could not determine path to platform-env.py: {e}")
+        env_script_path = None
+    if private_config_path is not None and private_config_path.is_file():
+        _logger.info(f"Loading private config from {private_config_path}.")
     elif "WEATHERGEN_PRIVATE_CONF" in os.environ:
         private_home = Path(os.environ["WEATHERGEN_PRIVATE_CONF"])
         _logger.info(f"Loading private config from WEATHERGEN_PRIVATE_CONF:{private_home}.")
-
-    elif env_script_path.is_file():
+    elif env_script_path and env_script_path.is_file():
         _logger.info(f"Loading private config from platform-env.py: {env_script_path}.")
         # This code does many checks to ensure that any error message is surfaced.
         # Since it is a process call, it can be hard to diagnose the error.
@@ -586,7 +588,7 @@ def _load_private_conf(private_home: Path | None = None) -> DictConfig:
             "Could not find private config. Please set the environment variable "
             "WEATHERGEN_PRIVATE_CONF or provide a path."
         )
-    private_cf = OmegaConf.load(private_home)
+    private_cf = OmegaConf.load(private_config_path)
 
     if "secrets" in private_cf:
         del private_cf["secrets"]
@@ -680,34 +682,34 @@ def load_streams(streams_directory: Path) -> Config:
     return OmegaConf.create(streams)
 
 
-def get_path_run(config: Config) -> Path:
+def get_path_run(config: Config, private_config_path: Path | None = None) -> Path:
     """Get the current runs results_path for storing run results and logs."""
-    return _get_shared_wg_path() / "results" / get_run_id_from_config(config)
+    return _get_shared_wg_path(private_config_path) / "results" / get_run_id_from_config(config)
 
 
-def get_path_model(config: Config | None = None, run_id: str | None = None) -> Path:
+def get_path_model(config: Config | None = None, run_id: str | None = None, private_config_path: Path | None = None) -> Path:
     """Get the current runs model_path for storing model checkpoints."""
     if config or run_id:
         run_id = run_id if run_id else get_run_id_from_config(config)
     else:
         msg = f"Missing run_id and cannot infer it from config: {config}"
         raise ValueError(msg)
-    return _get_shared_wg_path() / "models" / run_id
+    return _get_shared_wg_path(private_config_path) / "models" / run_id
 
 
-def get_path_results(config: Config, mini_epoch: int) -> Path:
+def get_path_results(config: Config, mini_epoch: int, private_config_path: Path | None = None) -> Path:
     """Get the path to validation results for a specific mini_epoch and rank."""
     ext = StoreType(config.zarr_store).value  # validate extension
-    base_path = get_path_run(config)
+    base_path = get_path_run(config, private_config_path)
     fname = f"validation_chkpt{mini_epoch:05d}_rank{config.rank:04d}.{ext}"
 
     return base_path / fname
 
 
 @functools.cache
-def _get_shared_wg_path() -> Path:
+def _get_shared_wg_path(private_config_path: Path | None = None) -> Path:
     """Get the shared working directory for WeatherGenerator."""
-    private_config = _load_private_conf()
+    private_config = _load_private_conf(private_config_path)
     return Path(private_config.get("path_shared_working_dir"))
 
 

--- a/packages/common/src/weathergen/common/logger.py
+++ b/packages/common/src/weathergen/common/logger.py
@@ -96,7 +96,7 @@ class ColoredRelPathFormatter(logging.Formatter):
 
 
 @cache
-def init_loggers(run_id=None, logging_config=None):
+def init_loggers(run_id=None, logging_config=None, private_config_path=None):
     """
     Initialize the logger for the package and set output streams/files.
 
@@ -143,7 +143,7 @@ def init_loggers(run_id=None, logging_config=None):
                 ofile = pathlib.Path(filename)
                 # make sure the path is independent of path where job is launched
                 if not ofile.is_absolute():
-                    work_dir = pathlib.Path(_load_private_conf().get("path_shared_working_dir"))
+                    work_dir = pathlib.Path(_load_private_conf(private_config_path).get("path_shared_working_dir"))
                     ofile = work_dir / ofile
                 pathlib.Path(ofile.parent).mkdir(parents=True, exist_ok=True)
                 handler[k] = ofile

--- a/private_home/private_config.yml
+++ b/private_home/private_config.yml
@@ -1,0 +1,1 @@
+path_shared_working_dir: private_home/shared_working_dir

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -220,7 +220,6 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
     def _init_stream_datasets(self, cf) -> dict[StreamName, _Stream]:
         """Load dataset readers for all streams from config."""
         streams_datasets: dict[StreamName, _Stream] = {}
-        breakpoint()
         for stream_name, stream_info in cf.streams.items():
             # list of sources for current stream
             streams_datasets[stream_name] = _Stream(stream_info, [])

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -220,6 +220,7 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
     def _init_stream_datasets(self, cf) -> dict[StreamName, _Stream]:
         """Load dataset readers for all streams from config."""
         streams_datasets: dict[StreamName, _Stream] = {}
+        breakpoint()
         for stream_name, stream_info in cf.streams.items():
             # list of sources for current stream
             streams_datasets[stream_name] = _Stream(stream_info, [])

--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -87,7 +87,7 @@ def run_inference(args):
 
     cli_overwrite = config.from_cli_arglist(args.options)
     cf = config.load_merge_configs(
-        args.private_config,
+        args.private_config_path,
         args.from_run_id,
         args.mini_epoch,
         args.base_config,
@@ -108,7 +108,7 @@ def run_inference(args):
 
     trainer = Trainer(cf.train_logging)
     try:
-        trainer.inference(cf, devices, args.from_run_id, args.mini_epoch)
+        trainer.inference(cf, devices, args.from_run_id, args.mini_epoch, args.private_config_path)
     except Exception:
         extype, value, tb = sys.exc_info()
         traceback.print_exc()
@@ -125,7 +125,7 @@ def run_continue(args):
 
     cli_overwrite = config.from_cli_arglist(args.options)
     cf = config.load_merge_configs(
-        args.private_config,
+        args.private_config_path,
         args.from_run_id,
         args.mini_epoch,
         args.base_config,
@@ -147,7 +147,7 @@ def run_continue(args):
     trainer = Trainer(cf.train_logging)
 
     try:
-        trainer.run(cf, devices, args.from_run_id, args.mini_epoch)
+        trainer.run(cf, devices, args.from_run_id, args.mini_epoch, args.private_config_path)
     except Exception:
         extype, value, tb = sys.exc_info()
         traceback.print_exc()
@@ -163,9 +163,8 @@ def run_train(args):
     """
 
     cli_overwrite = config.from_cli_arglist(args.options)
-
     cf = config.load_merge_configs(
-        args.private_config, None, None, args.base_config, *args.config, cli_overwrite
+        args.private_config_path, None, None, args.base_config, *args.config, cli_overwrite
     )
     cf = config.set_run_id(cf, args.run_id, False)
 
@@ -176,7 +175,7 @@ def run_train(args):
 
     # this line should probably come after the processes have been sorted out else we get lots
     # of duplication due to multiple process in the multiGPU case
-    init_loggers(cf.general.run_id)
+    init_loggers(cf.general.run_id, private_config_path=args.private_config_path)
 
     logger.info(f"DDP initialization: rank={cf.rank}, world_size={cf.world_size}")
 
@@ -188,7 +187,7 @@ def run_train(args):
     trainer = Trainer(cf.train_logging)
 
     try:
-        trainer.run(cf, devices)
+        trainer.run(cf, devices, private_config_path=args.private_config_path)
     except Exception:
         extype, value, tb = sys.exc_info()
         traceback.print_exc()

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -12,6 +12,7 @@ import copy
 import logging
 import time
 from math import sqrt
+from pathlib import Path
 
 import numpy as np
 import torch
@@ -93,7 +94,7 @@ class Trainer(TrainerBase):
         """
         return self.world_size_original * batch_size_per_gpu
 
-    def init(self, cf: Config, devices):
+    def init(self, cf: Config, devices, private_config_path: Path | None = None):
         # pylint: disable=attribute-defined-outside-init
         self.cf = OmegaConf.merge(
             OmegaConf.create(
@@ -152,10 +153,11 @@ class Trainer(TrainerBase):
 
         # create output directory
         if is_root():
-            config.get_path_run(cf).mkdir(exist_ok=True, parents=True)
-            config.get_path_model(cf).mkdir(exist_ok=True, parents=True)
+            print()
+            config.get_path_run(cf, private_config_path=private_config_path).mkdir(exist_ok=True, parents=True)
+            config.get_path_model(cf, private_config_path=private_config_path).mkdir(exist_ok=True, parents=True)
 
-        self.train_logger = TrainLogger(cf, config.get_path_run(self.cf))
+        self.train_logger = TrainLogger(cf, config.get_path_run(self.cf, private_config_path=private_config_path))
 
         # Initialize collapse monitor for SSL training
         collapse_config = cf.train_logging.get("collapse_monitoring", {})
@@ -184,9 +186,9 @@ class Trainer(TrainerBase):
 
         return target_and_aux_calculators
 
-    def inference(self, cf, devices, run_id_contd, mini_epoch_contd):
+    def inference(self, cf, devices, run_id_contd, mini_epoch_contd, private_config_path: Path | None = None):
         # general initalization
-        self.init(cf, devices)
+        self.init(cf, devices, private_config_path=private_config_path)
 
         cf = self.cf
         device_type = torch.accelerator.current_accelerator()
@@ -241,9 +243,9 @@ class Trainer(TrainerBase):
         self.validate(0, self.test_cfg, self.batch_size_test_per_gpu)
         logger.info(f"Finished inference run with id: {cf.general.run_id}")
 
-    def run(self, cf, devices, run_id_contd=None, mini_epoch_contd=None):
+    def run(self, cf, devices, run_id_contd=None, mini_epoch_contd=None, private_config_path: Path | None = None):
         # general initalization
-        self.init(cf, devices)
+        self.init(cf, devices, private_config_path=private_config_path)
         cf = self.cf
 
         device_type = torch.accelerator.current_accelerator()

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -157,7 +157,7 @@ class Trainer(TrainerBase):
             config.get_path_run(cf, private_config_path=private_config_path).mkdir(exist_ok=True, parents=True)
             config.get_path_model(cf, private_config_path=private_config_path).mkdir(exist_ok=True, parents=True)
 
-        self.train_logger = TrainLogger(cf, config.get_path_run(self.cf, private_config_path=private_config_path))
+        self.train_logger = TrainLogger(cf, config.get_path_run(self.cf, private_config_path=private_config_path), private_config_path=private_config_path)
 
         # Initialize collapse monitor for SSL training
         collapse_config = cf.train_logging.get("collapse_monitoring", {})
@@ -235,7 +235,7 @@ class Trainer(TrainerBase):
         self.loss_calculator_val = LossCalculator(cf, self.test_cfg, VAL, device=self.devices[0])
 
         if is_root():
-            config.save(self.cf, mini_epoch=0)
+            config.save(self.cf, mini_epoch=0, private_config_path=private_config_path)
 
         logger.info(f"Starting inference with id={self.cf.general.run_id}.")
 
@@ -374,7 +374,7 @@ class Trainer(TrainerBase):
             )
 
         if is_root():
-            config.save(self.cf, None)
+            config.save(self.cf, None, private_config_path=private_config_path)
             logger.info(config.format_cf(self.cf))
 
         # run validation before training if requested

--- a/src/weathergen/utils/cli.py
+++ b/src/weathergen/utils/cli.py
@@ -90,7 +90,7 @@ def _format_date(date: str) -> str:
 
 def _add_general_arguments(parser: argparse.ArgumentParser):
     parser.add_argument(
-        "--private-config",
+        "--private-config-path",
         type=Path,
         default=None,
         help=(

--- a/src/weathergen/utils/plot_training.py
+++ b/src/weathergen/utils/plot_training.py
@@ -891,7 +891,7 @@ def plot_train(args=None):
                 )
             else:
                 cf = config.load_merge_configs(
-                    private_home=None,
+                    private_config_path=None,
                     from_run_id=run_id,
                     mini_epoch=None,
                 )

--- a/src/weathergen/utils/train_logger.py
+++ b/src/weathergen/utils/train_logger.py
@@ -140,7 +140,7 @@ class TrainLogger:
             cf = config.load_run_config(run_id=run_id, mini_epoch=mini_epoch, model_path=model_path)
         else:
             cf = config.load_merge_configs(
-                private_home=None, from_run_id=run_id, mini_epoch=mini_epoch
+                private_config_path=None, from_run_id=run_id, mini_epoch=mini_epoch
             )
         run_id = cf.general.run_id
 

--- a/src/weathergen/utils/train_logger.py
+++ b/src/weathergen/utils/train_logger.py
@@ -58,9 +58,10 @@ class Metrics:
 
 class TrainLogger:
     #######################################
-    def __init__(self, cf, path_run: Path) -> None:
+    def __init__(self, cf, path_run: Path, private_config_path: Path | None = None) -> None:
         self.cf = cf
         self.path_run = path_run
+        self.private_config_path = private_config_path
 
     def log_metrics(self, stage: Stage, metrics: dict[str, float], step: int | None = None) -> None:
         """
@@ -86,7 +87,7 @@ class TrainLogger:
         # but we can probably do better and rely for example on the logging module.
 
         metrics_path = get_train_metrics_path(
-            base_path=config.get_path_run(self.cf), run_id=self.cf.general.run_id
+            base_path=config.get_path_run(self.cf, private_config_path=self.private_config_path), run_id=self.cf.general.run_id
         )
         with open(metrics_path, "ab") as f:
             s = json.dumps(clean_metrics) + "\n"


### PR DESCRIPTION
## Description

We make the path pointing to the private repository configurable. 

Can be tested by filling in the paths in https://github.com/florianscheidl/WeatherGenerator/blob/17f98bbe95c6eac80ac577ad950c625e3173703b/private_home/private_config.yml, see e.g. https://gitlab.jsc.fz-juelich.de/esde/WeatherGenerator-private/-/tree/74b8d193739f8cfd0874493a703112251e82e97b/hpc/jupiter/config.

Note: we probably want to redesign the functions' signature changes, this is only a minimal working example :)

## Issue Number

#2506

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
