### PR TITLE
[2304] Adjust eval for precipitations

### DIFF
--- a/config/evaluate/eval_config.yml
+++ b/config/evaluate/eval_config.yml
@@ -5,7 +5,6 @@
 #  regions: ["europe", "global"] # Have regions here, if you want for them to apply to all streams (map generation)
 #  image_format : "png" #options: "png", "pdf", "svg", "eps", "jpg" ..
 #  animation_format: "gif" #options: "mp4", "gif"
-#  log_colorbar: true
 
 #  dpi_val : 300
 #  fps: 2
@@ -26,6 +25,22 @@
 #    10u:
 #      vmin: -40
 #      vmax: 40
+#  IMERG_ANEMOI:
+#    marker_size: 1.5
+#    scale_marker_size: true
+#    marker: "o"
+#    "tp_*":
+#      colorbar_scale: "log"
+#      levels: [0.0001, 0.0005, 0.001, 0.002, 0.005, 0.01, 0.02]
+#      colors:
+#        - "none"
+#        - "#BEDAE5"
+#        - "#80B5CC"
+#        - "#5691B3"
+#        - "#4B6E9C"
+#        - "#424B83"
+#        - "#45596D"
+#        - "#5B9E4C"
 
 
 # max_workers: 36  # hard cap on parallel workers (I/O, plotting, scoring)
@@ -87,7 +102,22 @@ default_streams:
       plot_target: false
       plot_histograms: true
       plot_animations: true
-      
+  IMERG_ANEMOI:
+    channels: ["tp_imerg_0"]
+    evaluation:
+      forecast_step: "all"
+      sample: "all"
+      ensemble: [14]
+    plotting:
+      sample: [1, 3]
+      forecast_step: [1, 2, 3] #supported: "all", [1,2,3,...], "1-50" (equivalent of [1,2,3,...50])
+      ensemble: [14]
+      plot_maps: true
+      plot_bias: false
+      plot_target: false
+      plot_histograms: true
+      plot_animations: true
+
 run_ids :
   ar40mckx:
     label: "pretrained model ar40mckx"

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
@@ -402,7 +402,6 @@ def run_score_map_pipeline(
         "fig_size": cfg.get("fig_size", None),
         "animation_format": cfg.get("animation_format", "gif"),
         "fps": cfg.get("fps", 2),
-        "log_colorbar": cfg.get("log_colorbar", False),
     }
     output_basedir = str(reader.runplot_dir)
     run_id = reader.run_id

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -8,6 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 import datetime
+import fnmatch
 import logging
 import os
 import warnings
@@ -574,7 +575,7 @@ class Plotter:
                         var,
                         region,
                         tag=tag,
-                        map_kwargs=dict(map_kwargs.get(var, {})) | map_kwargs_global,
+                        map_kwargs=self._match_glob_kwargs(map_kwargs, var) | map_kwargs_global,
                         title=self.get_map_title(var, valid_time, da_t),
                     )
                     plot_names.append(name)
@@ -582,6 +583,39 @@ class Plotter:
         self.clean_data_selection()
 
         return plot_names
+
+    # glob pattern resolution
+    @staticmethod
+    def _match_glob_kwargs(map_kwargs: dict | None, var: str) -> dict:
+        """Resolve variable-specific plotting options, supporting exact and glob keys.
+
+        Keys under a stream section may be either:
+          - an exact channel name, e.g. "tp_imerg_0"
+          - a glob pattern containing one of ``* ? [ ]``, e.g. "tp_*"
+
+        All matching glob patterns are merged first (in config order), then the
+        exact channel key is merged on top, so an exact key overrides glob
+        values on key conflicts while non-conflicting keys from both are kept.
+        """
+        if map_kwargs is None:
+            return {}
+
+        resolved: dict = {}
+
+        # merge glob/pattern keys
+        for key, value in map_kwargs.items():
+            if not isinstance(value, oc.DictConfig | dict):
+                continue
+            k = str(key)
+            if any(ch in k for ch in "*?[]") and fnmatch.fnmatch(var, k):
+                resolved |= dict(value)
+
+        # override with exact key if present
+        exact = map_kwargs.get(var)
+        if isinstance(exact, oc.DictConfig | dict):
+            resolved |= dict(exact)
+
+        return resolved
 
     # map_kwargs parsing
     @staticmethod

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -707,10 +707,6 @@ class Plotter:
     def _resolve_norm(opts: dict, tag: str) -> mpl.colors.Normalize:
         """Resolve the colorbar scale and build color normalisation.
 
-        Bias maps (``tag`` starting with ``"bias"``) are signed, so a non-linear
-        scale is coerced to ``"symlog"``. Explicit ``levels`` always take
-        precedence and yield a BoundaryNorm.
-
         Parameters
         ----------
         opts : dict
@@ -724,21 +720,22 @@ class Plotter:
             LogNorm, SymLogNorm, BoundaryNorm or linear Normalize.
         """
 
+        is_bias = str(tag).startswith("bias")
+        vmin, vmax = opts["vmin"], opts["vmax"]
+
         scale = opts["colorbar_scale"]
         if scale not in {"linear", "log", "symlog"}:
             _logger.warning("Unknown colorbar_scale=%r. Falling back to linear.", scale)
             scale = "linear"
 
         # Bias maps are always signed, use symlog instead of plain log
-        if str(tag).startswith("bias") and scale != "linear":
+        if scale != "linear" and is_bias:
             scale = "symlog"
 
-        vmin, vmax = opts["vmin"], opts["vmax"]
-
-        # Explicit levels override continuous norm for preds and targets
-        if isinstance(opts["levels"], oc.listconfig.ListConfig) and not str(tag).startswith("bias"):
+        # Explicit levels override continuous norm (preds/targets only)
+        if isinstance(opts["levels"], oc.listconfig.ListConfig) and not is_bias:
             return mpl.colors.BoundaryNorm(opts["levels"], opts["cmap"].N, extend="both")
-        # Log only if vmin > 0; otherwise fall back to linear with warning
+
         if scale == "log" and vmin is not None and vmin > 0:
             return mpl.colors.LogNorm(vmin=vmin, vmax=vmax)
         elif scale == "log" and vmin is not None and vmin <= 0:
@@ -746,10 +743,13 @@ class Plotter:
                 "colorbar_scale='log' but vmin=%.3g <= 0; falling back to linear norm.",
                 vmin,
             )
+
         # Symlog (default for bias maps with non-linear scale)
         if scale == "symlog" and vmin is not None and vmax is not None:
             vmax_abs = max(abs(float(vmin)), abs(float(vmax)))
-            return mpl.colors.SymLogNorm(linthresh=max(vmax_abs * 1e-3, 1e-8), vmin=vmin, vmax=vmax)
+            linthresh = max(vmax_abs * 1e-3, 1e-8)
+            return mpl.colors.SymLogNorm(linthresh=linthresh, vmin=vmin, vmax=vmax)
+
         return mpl.colors.Normalize(vmin=vmin, vmax=vmax, clip=False)
 
     # rendering backends

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -594,7 +594,7 @@ class Plotter:
         ----------
         map_kwargs : dict or None
             Raw keyword arguments from the caller. Known keys (``marker_size``,
-            ``scale_marker_size``, ``marker``, ``vmin``, ``vmax``, ``colormap``,
+            ``scale_marker_size``, ``marker``, ``vmin``, ``vmax``, ``colormap``,``colors``,
             ``use_datashader``, ``levels``, and HEALPix-related keys) are extracted;
             remaining keys are collected under ``"extra"``.
         stream : str or None
@@ -610,6 +610,7 @@ class Plotter:
                 - marker (str)
                 - vmin, vmax (float or None)
                 - cmap (matplotlib.colors.Colormap)
+                - colors (list or None)
                 - use_datashader (bool)
                 - norm (matplotlib.colors.Normalize or BoundaryNorm)
                 - add_healpix_grid (bool) and related healpix_* keys
@@ -626,6 +627,7 @@ class Plotter:
             "vmin": kw.pop("vmin", None),
             "vmax": kw.pop("vmax", None),
             "cmap": plt.get_cmap(kw.pop("colormap", "coolwarm")),
+            "colors": kw.pop("colors", None),
             "use_datashader": kw.pop("use_datashader", False),
             "levels": kw.pop("levels", None),
             # HEALPix grid
@@ -908,6 +910,9 @@ class Plotter:
                     opts["vmin"] = float(p_lo)
                 if opts["vmax"] is None:
                     opts["vmax"] = float(p_hi)
+
+        if isinstance(opts["colors"], oc.listconfig.ListConfig):
+            opts["cmap"] = mpl.colors.ListedColormap(list(opts["colors"]))
 
         if isinstance(opts["levels"], oc.listconfig.ListConfig):
             opts["norm"] = mpl.colors.BoundaryNorm(opts["levels"], opts["cmap"].N, extend="both")

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plotter.py
@@ -138,7 +138,6 @@ class Plotter:
         self.dpi_val = plotter_cfg.get("dpi_val")
         self.fig_size = plotter_cfg.get("fig_size")
         self.fps = plotter_cfg.get("fps")
-        self.log_colorbar = plotter_cfg.get("log_colorbar", False)
         self.regions = plotter_cfg.get("regions")
         self.log_x = plotter_cfg.get("log_x", False)
         self.log_y = plotter_cfg.get("log_y", False)
@@ -518,8 +517,8 @@ class Plotter:
         """
         self.update_data_selection(select)
 
-        # copy global plotting options, not specific to any variable
-        map_kwargs_global = {
+        # copy stream plotting options, not specific to any variable
+        map_kwargs_stream = {
             key: value
             for key, value in (map_kwargs or {}).items()
             if not isinstance(value, oc.DictConfig)
@@ -575,7 +574,7 @@ class Plotter:
                         var,
                         region,
                         tag=tag,
-                        map_kwargs=self._match_glob_kwargs(map_kwargs, var) | map_kwargs_global,
+                        map_kwargs=self._match_glob_kwargs(map_kwargs, var) | map_kwargs_stream,
                         title=self.get_map_title(var, valid_time, da_t),
                     )
                     plot_names.append(name)
@@ -629,8 +628,8 @@ class Plotter:
         map_kwargs : dict or None
             Raw keyword arguments from the caller. Known keys (``marker_size``,
             ``scale_marker_size``, ``marker``, ``vmin``, ``vmax``, ``colormap``,``colors``,
-            ``use_datashader``, ``levels``, and HEALPix-related keys) are extracted;
-            remaining keys are collected under ``"extra"``.
+            ``use_datashader``, ``levels``, ``colorbar_scale`` and HEALPix-related keys) are
+            extracted; remaining keys are collected under ``"extra"``.
         stream : str or None
             Stream name used to look up the default marker size when
             ``marker_size`` is not provided in *map_kwargs*.
@@ -660,10 +659,11 @@ class Plotter:
             "marker": kw.pop("marker", "o"),
             "vmin": kw.pop("vmin", None),
             "vmax": kw.pop("vmax", None),
-            "cmap": plt.get_cmap(kw.pop("colormap", "coolwarm")),
+            "cmap": kw.pop("colormap", "coolwarm"),
             "colors": kw.pop("colors", None),
             "use_datashader": kw.pop("use_datashader", False),
             "levels": kw.pop("levels", None),
+            "colorbar_scale": kw.pop("colorbar_scale", "linear"),
             # HEALPix grid
             "add_healpix_grid": kw.pop("add_healpix_grid", False),
             "healpix_nside": kw.pop("healpix_nside", 4),
@@ -675,6 +675,82 @@ class Plotter:
 
         parsed["extra"] = kw  # remaining kwargs forwarded to scatter
         return parsed
+
+    @staticmethod
+    def _resolve_cmap(opts: dict, tag: str) -> mpl.colors.Colormap:
+        """Resolve the colormap for the plot.
+
+        Parameters
+        ----------
+        opts : dict
+            Parsed map kwargs from ``_parse_map_kwargs``.
+        tag : str
+            Plot tag (e.g. ``'targets'``, ``'preds'``, ``'bias'``).
+
+        Returns
+        -------
+        matplotlib.colors.Colormap
+            The resolved colormap.
+        """
+
+        # Bias maps always use coolwarm for visual consistency (overrides config)
+        if str(tag).startswith("bias"):
+            return plt.get_cmap("coolwarm")
+        # Explicit colors take precedence over colormap
+        elif isinstance(opts["colors"], oc.listconfig.ListConfig):
+            return mpl.colors.ListedColormap(list(opts["colors"]))
+        # Otherwise use the specified colormap (default "coolwarm")
+        else:
+            return plt.get_cmap(opts["cmap"])
+
+    @staticmethod
+    def _resolve_norm(opts: dict, tag: str) -> mpl.colors.Normalize:
+        """Resolve the colorbar scale and build color normalisation.
+
+        Bias maps (``tag`` starting with ``"bias"``) are signed, so a non-linear
+        scale is coerced to ``"symlog"``. Explicit ``levels`` always take
+        precedence and yield a BoundaryNorm.
+
+        Parameters
+        ----------
+        opts : dict
+            Parsed map kwargs from ``_parse_map_kwargs``.
+        tag : str
+            Plot tag (e.g. ``'targets'``, ``'preds'``, ``'bias'``).
+
+        Returns
+        -------
+        matplotlib.colors.Normalize
+            LogNorm, SymLogNorm, BoundaryNorm or linear Normalize.
+        """
+
+        scale = opts["colorbar_scale"]
+        if scale not in {"linear", "log", "symlog"}:
+            _logger.warning("Unknown colorbar_scale=%r. Falling back to linear.", scale)
+            scale = "linear"
+
+        # Bias maps are always signed, use symlog instead of plain log
+        if str(tag).startswith("bias") and scale != "linear":
+            scale = "symlog"
+
+        vmin, vmax = opts["vmin"], opts["vmax"]
+
+        # Explicit levels override continuous norm for preds and targets
+        if isinstance(opts["levels"], oc.listconfig.ListConfig) and not str(tag).startswith("bias"):
+            return mpl.colors.BoundaryNorm(opts["levels"], opts["cmap"].N, extend="both")
+        # Log only if vmin > 0; otherwise fall back to linear with warning
+        if scale == "log" and vmin is not None and vmin > 0:
+            return mpl.colors.LogNorm(vmin=vmin, vmax=vmax)
+        elif scale == "log" and vmin is not None and vmin <= 0:
+            _logger.warning(
+                "colorbar_scale='log' but vmin=%.3g <= 0; falling back to linear norm.",
+                vmin,
+            )
+        # Symlog (default for bias maps with non-linear scale)
+        if scale == "symlog" and vmin is not None and vmax is not None:
+            vmax_abs = max(abs(float(vmin)), abs(float(vmax)))
+            return mpl.colors.SymLogNorm(linthresh=max(vmax_abs * 1e-3, 1e-8), vmin=vmin, vmax=vmax)
+        return mpl.colors.Normalize(vmin=vmin, vmax=vmax, clip=False)
 
     # rendering backends
     @staticmethod
@@ -945,20 +1021,9 @@ class Plotter:
                 if opts["vmax"] is None:
                     opts["vmax"] = float(p_hi)
 
-        if isinstance(opts["colors"], oc.listconfig.ListConfig):
-            opts["cmap"] = mpl.colors.ListedColormap(list(opts["colors"]))
-
-        if isinstance(opts["levels"], oc.listconfig.ListConfig):
-            opts["norm"] = mpl.colors.BoundaryNorm(opts["levels"], opts["cmap"].N, extend="both")
-        elif self.log_colorbar and opts["vmin"] is not None and opts["vmin"] > 0:
-            opts["norm"] = mpl.colors.LogNorm(vmin=opts["vmin"], vmax=opts["vmax"])
-        else:
-            if self.log_colorbar:
-                _logger.warning(
-                    "log_colorbar=True but vmin=%.3g <= 0; falling back to linear norm.",
-                    opts["vmin"],
-                )
-            opts["norm"] = mpl.colors.Normalize(vmin=opts["vmin"], vmax=opts["vmax"], clip=False)
+        # resolve cmap and norm based on options and tag
+        opts["cmap"] = self._resolve_cmap(opts, tag)
+        opts["norm"] = self._resolve_norm(opts, tag)
 
         if regionname == "global":
             ax.set_global()

--- a/packages/evaluate/src/weathergen/evaluate/utils/array_utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils/array_utils.py
@@ -9,6 +9,8 @@
 
 """Array / DataArray utility functions: range computation, coordinate helpers."""
 
+import fnmatch
+
 import numpy as np
 import omegaconf as oc
 import xarray as xr
@@ -88,21 +90,27 @@ def common_ranges(
     """
     maps_config = global_plotting_opts_stream.copy()
     for var in plot_chs:
-        if var in maps_config:
-            if not isinstance(maps_config[var].get("vmax"), (int | float)):
-                list_max = calc_bounds(data_tars, data_preds, var, "max")
-                list_max = np.concatenate([arr.flatten() for arr in list_max]).tolist()
-                maps_config[var].update({"vmax": float(max(list_max))})
-            if not isinstance(maps_config[var].get("vmin"), (int | float)):
-                list_min = calc_bounds(data_tars, data_preds, var, "min")
-                list_min = np.concatenate([arr.flatten() for arr in list_min]).tolist()
-                maps_config[var].update({"vmin": float(min(list_min))})
-        else:
+        if var not in maps_config:
+            maps_config[var] = {}
+        # override empty bounds with matching glob bounds from config
+        for key, value in maps_config.items():
+            if not isinstance(value, oc.DictConfig | dict):
+                continue
+            k = str(key)
+            if any(c in k for c in "*?[]") and fnmatch.fnmatch(var, k):
+                for bound in ("vmin", "vmax"):
+                    if isinstance(value.get(bound), int | float):
+                        maps_config[var].setdefault(bound, value[bound])
+        # if vmax still missing, compute bound from data
+        if not isinstance(maps_config[var].get("vmax"), (int | float)):
             list_max = calc_bounds(data_tars, data_preds, var, "max")
             list_max = np.concatenate([arr.flatten() for arr in list_max]).tolist()
+            maps_config[var].update({"vmax": float(max(list_max))})
+        # if vmin still missing, compute bound from data
+        if not isinstance(maps_config[var].get("vmin"), (int | float)):
             list_min = calc_bounds(data_tars, data_preds, var, "min")
             list_min = np.concatenate([arr.flatten() for arr in list_min]).tolist()
-            maps_config.update({var: {"vmax": float(max(list_max)), "vmin": float(min(list_min))}})
+            maps_config[var].update({"vmin": float(min(list_min))})
     return maps_config
 
 


### PR DESCRIPTION
## Description

### Summary

Generalizes the eval/plotting pipeline with a focus on precipitation. Variable plotting options can now be matched by glob, colormaps can be discrete/custom, and per-stream/channel colorbar scaling supports log/symlog for skewed distributions.

### Changes

- **Glob-based variable selection**: plotting options can be keyed by exact channel name or a glob pattern (e.g. `tp_*`, `v_*`).
- **Custom/discrete colormaps**: added a colors option that builds discrete colormaps to match references like RAINA precipitation.
- **Per-stream/channel colorbar scaling**: replaced the boolean `log_colorbar` flag with a `colorbar_scale` option. `linear` is the default and fallback. `log` is for single-sign skewed distributions like `tp`, but requires `vmin > 0`, otherwise it warns and falls back to `linear`. `symlog` handles double-sign variables like `v` and `u` (if distribution is skewed) as well as non-linear bias plots.

### Examples

#### (1) RAINA cmap and log bias
```
  IMERG_ANEMOI:
    "tp_*":
      colorbar_scale: "log"
      levels: [0.0001, 0.0005, 0.001, 0.002, 0.005, 0.01, 0.02]
      colors:
        - "none"
        - "#BEDAE5"
        - "#80B5CC"
        - "#5691B3"
        - "#4B6E9C"
        - "#424B83"
        - "#45596D"
        - "#5B9E4C"
```

##### Target
<img width="1548" height="1019" alt="map_c2lonbt6_targets_1_2023-09-02T1200_IMERG_ANEMOI_global_tp_imerg_0_001" src="https://github.com/user-attachments/assets/d003e726-fdad-43f9-87a0-856554e4c84a" />

##### Bias
<img width="1548" height="1023" alt="map_c2lonbt6_bias_ens_14_1_2023-09-02T1200_IMERG_ANEMOI_global_tp_imerg_0_001" src="https://github.com/user-attachments/assets/81142426-eaa0-47f1-97e0-44ab412654b3" />

#### (2) Continuous and log cmap
```
  IMERG_ANEMOI:
    "tp_*":
      colorbar_scale: "log"
      vmin: 1.0e-6
      colormap: "Blues"
```

##### Target
<img width="1548" height="1023" alt="map_c2lonbt6_targets_1_2023-09-02T1200_IMERG_ANEMOI_global_tp_imerg_0_001" src="https://github.com/user-attachments/assets/0f313cf9-8b97-4097-a6fc-593b06eb0a1d" />

#### (3) ERA5 example with discrete cmap
```
  ERA5:
    "q_*":
      levels: [0.0001, 0.0005, 0.001, 0.002, 0.005, 0.015, 0.03]
```
##### Target
<img width="1548" height="1019" alt="map_ryjwbxus_targets_0_2023-10-01T1200_ERA5_global_q_850_002" src="https://github.com/user-attachments/assets/ea8b1f65-68f6-48c7-a3ed-37ba8edacc7b" />

## Issue Number

Closes #2304 

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
