### PR TITLE
eta fix in validation

### DIFF
--- a/src/weathergen/model/diffusion.py
+++ b/src/weathergen/model/diffusion.py
@@ -224,10 +224,13 @@ class DiffusionForecastEngine(torch.nn.Module):
         # Compute sigma from noise_level_rn.
         # log_normal: noise_level_rn is eta ~ N(0,1); sigma = exp(eta * p_std + p_mean)
         # log_uniform: noise_level_rn is log_sigma directly; sigma = exp(noise_level_rn)
-        if self.noise_distribution == "log_uniform":
+        # during validation, noise_level_rn is set to a fixed value (default: 0.0), so sigma = exp(0) = 1.0 (no noise) by default
+        if self.noise_distribution == "log_uniform" or not self.training:
             sigma = noise_level_rn.exp()
-        else:
+        elif self.noise_distribution == "log_normal":
             sigma = (noise_level_rn * self.p_std + self.p_mean).exp()
+        else:
+            raise ValueError(f"Unsupported noise_distribution: {self.noise_distribution}")
         n = torch.randn_like(y) * sigma
 
         self._noised_tokens = (y + n).detach()


### PR DESCRIPTION
## Description

Fixes how the fixed eta values are used in computing validation losses. Previously, `sigma = (noise_level_rn * self.p_std + self.p_mean).exp()` at validation meant that the sigma value would vary across models depending on `p_std` and `p_mean`. In this new version, the only operation is the exponential. In particular, this makes the loss curves comparable between log_normal and log_uniform.

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `cd`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
