### PR TITLE
multi_stream_data_sampler: Select existing filename from multiple options

### DIFF
--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -260,7 +260,7 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
 
                     # The same dataset can exist on different locations in the filesystem,
                     # so we need to choose here.
-                    filename = filenames[0]
+                    filename = next(f for f in filenames if f.exists())
 
                 ds_type = stream_info["type"]
                 if is_root():

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -251,16 +251,13 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                 else:
                     filenames = [pathlib.Path(path) / fname for path in cf.data_paths]
 
-                    if not any(filename.exists() for filename in filenames):  # see above
+                    filename = next((f for f in filenames if f.exists()), None)
+                    if filename is None :  
                         msg = (
                             f"Did not find input data for {stream_info['type']} "
                             f"stream '{stream_name}': {filenames}."
                         )
                         raise FileNotFoundError(msg)
-
-                    # The same dataset can exist on different locations in the filesystem,
-                    # so we need to choose here.
-                    filename = next(f for f in filenames if f.exists())
 
                 ds_type = stream_info["type"]
                 if is_root():


### PR DESCRIPTION
## Description

resolves blind choice of filename in multi_stream_data_sampler which can fail if first searched location is nonexistent


## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/2524

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
