### PR TITLE
[2548] feat(train): make gradient scaler optional

### DIFF
--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -252,7 +252,7 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                     filenames = [pathlib.Path(path) / fname for path in cf.data_paths]
 
                     filename = next((f for f in filenames if f.exists()), None)
-                    if filename is None :  
+                    if filename is None:
                         msg = (
                             f"Did not find input data for {stream_info['type']} "
                             f"stream '{stream_name}': {filenames}."

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -332,7 +332,7 @@ class Trainer(TrainerBase):
             betas=(beta1, beta2),
             eps=eps,
         )
-        if cf.get("grad_scaling", True):
+        if cf.get("grad_scaling", False):
             self.grad_scaler = torch.amp.GradScaler("cuda")
         assert len(self.dataset) > 0, f"No data found in {self.dataset}"
 

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -44,6 +44,7 @@ from weathergen.train.utils import (
     get_active_stage_config,
     get_batch_size_from_config,
     get_target_idxs_from_cfg,
+    NoOpGradScaler,
 )
 from weathergen.utils.distributed import is_root
 from weathergen.utils.performance import NullThroughputTracker, ThroughputTracker
@@ -68,7 +69,7 @@ class Trainer(TrainerBase):
         self.dataset_val: MultiStreamDataSampler | None = None
         self.device: torch.device = None
         self.ema_model = None
-        self.grad_scaler: torch.amp.GradScaler | None = None
+        self.grad_scaler: torch.amp.GradScaler | NoOpGradScaler = NoOpGradScaler()
         self.last_grad_norm = None
         self.loss_calculator: LossCalculator | None = None
         self.loss_calculator_val: LossCalculator | None = None
@@ -331,8 +332,8 @@ class Trainer(TrainerBase):
             betas=(beta1, beta2),
             eps=eps,
         )
-        self.grad_scaler = torch.amp.GradScaler("cuda")
-
+        if cf.grad_scaling:
+            self.grad_scaler = torch.amp.GradScaler("cuda")
         assert len(self.dataset) > 0, f"No data found in {self.dataset}"
 
         # lr is updated after each batch so account for this

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -332,7 +332,7 @@ class Trainer(TrainerBase):
             betas=(beta1, beta2),
             eps=eps,
         )
-        if cf.get("grad_scaling", True):
+        if cf.get("training_config").get("optimizer").get("grad_scaling", True):
             self.grad_scaler = torch.amp.GradScaler("cuda")
         assert len(self.dataset) > 0, f"No data found in {self.dataset}"
 

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -37,6 +37,7 @@ from weathergen.train.trainer_base import TrainerBase
 from weathergen.train.utils import (
     TRAIN,
     VAL,
+    NoOpGradScaler,
     Stage,
     cfg_keys_to_filter,
     extract_batch_metadata,
@@ -44,7 +45,6 @@ from weathergen.train.utils import (
     get_active_stage_config,
     get_batch_size_from_config,
     get_target_idxs_from_cfg,
-    NoOpGradScaler,
 )
 from weathergen.utils.distributed import is_root
 from weathergen.utils.performance import NullThroughputTracker, ThroughputTracker

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -332,7 +332,7 @@ class Trainer(TrainerBase):
             betas=(beta1, beta2),
             eps=eps,
         )
-        if cf.grad_scaling:
+        if cf.get("grad_scaling", True):
             self.grad_scaler = torch.amp.GradScaler("cuda")
         assert len(self.dataset) > 0, f"No data found in {self.dataset}"
 

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -332,7 +332,7 @@ class Trainer(TrainerBase):
             betas=(beta1, beta2),
             eps=eps,
         )
-        if cf.get("grad_scaling", False):
+        if cf.get("grad_scaling", True):
             self.grad_scaler = torch.amp.GradScaler("cuda")
         assert len(self.dataset) > 0, f"No data found in {self.dataset}"
 

--- a/src/weathergen/train/utils.py
+++ b/src/weathergen/train/utils.py
@@ -192,6 +192,7 @@ def filter_config_by_enabled(cfg: dict | OmegaConf, keys: list[str]):
 
     return cfg_out
 
+
 class NoOpGradScaler:
     """Drop-in replacement for torch.amp.GradScaler when gradient scaling is disabled."""
 

--- a/src/weathergen/train/utils.py
+++ b/src/weathergen/train/utils.py
@@ -191,3 +191,18 @@ def filter_config_by_enabled(cfg: dict | OmegaConf, keys: list[str]):
         cfg_out[key] = filtered
 
     return cfg_out
+
+class NoOpGradScaler:
+    """Drop-in replacement for torch.amp.GradScaler when gradient scaling is disabled."""
+
+    def scale(self, loss):
+        return loss
+
+    def unscale_(self, optimizer):
+        return None
+
+    def step(self, optimizer):
+        return optimizer.step()
+
+    def update(self):
+        return None


### PR DESCRIPTION
## Description

Gradient scaling is not needed when training bf16 or fp32 parameters. Experiments on some configs have revealed a small speed-up and no loss in accuracy, see the issue.

We add a config argument `grad_scaling` under `cf.training_config.optimizer`. When set to True in the config, gradient scaling will be done as before (implemented as a no-op dummy scaler). By default, we set grad_scaling to True.

In a few weeks, we plan to switch grad_scaling to False by default.

## Issue Number

Fixes #2548 

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
