### PR TITLE
[2520] feat(model): Refactor EMA update

### DIFF
--- a/config/config_jepa_multi_data.yml
+++ b/config/config_jepa_multi_data.yml
@@ -1,0 +1,333 @@
+# (C) Copyright 2025 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+embed_orientation: "channels"
+embed_unembed_mode: "block"
+embed_dropout_rate: 0.1
+
+ae_local_dim_embed: 1024
+ae_local_num_blocks: 4
+ae_local_num_heads: 16
+ae_local_dropout_rate: 0.1
+ae_local_with_qk_lnorm: True
+
+ae_local_num_queries: 1
+ae_local_queries_per_cell: False
+ae_adapter_num_heads: 16
+ae_adapter_embed: 128
+ae_adapter_with_qk_lnorm: True
+ae_adapter_with_residual: True
+ae_adapter_dropout_rate: 0.1
+
+ae_global_dim_embed: 2048
+ae_global_num_blocks: 5
+ae_global_num_heads: 32
+ae_global_dropout_rate: 0.1
+ae_global_with_qk_lnorm: True
+# TODO: switching to < 1 triggers triton-related issues.
+# See https://github.com/ecmwf/WeatherGenerator/issues/1050
+ae_global_att_dense_rate: 1.0
+ae_global_block_factor: 64
+ae_global_mlp_hidden_factor: 4
+ae_global_trailing_layer_norm: True
+
+ae_aggregation_num_blocks: 5
+ae_aggregation_num_heads: 32
+ae_aggregation_dropout_rate: 0.1
+ae_aggregation_with_qk_lnorm: True
+ae_aggregation_att_dense_rate: 1.0
+ae_aggregation_block_factor: 64
+ae_aggregation_mlp_hidden_factor: 2
+
+decoder_type: PerceiverIOCoordConditioning # CrossAttentionAdaNormConditioning
+pred_adapter_kv: False
+pred_self_attention: True
+pred_dyadic_dims: False
+pred_mlp_adaln: True
+num_class_tokens: 0
+num_register_tokens: 64
+
+# number of steps offset applied to first target window; if set to zero and forecast_steps=0 then
+# one is training an auto-encoder
+fe_num_blocks: 6
+fe_num_heads: 16
+fe_dropout_rate: 0.1
+fe_with_qk_lnorm: True
+fe_layer_norm_after_blocks: []  # Index starts at 0. Thus, [3] adds a LayerNorm after the fourth layer
+fe_impute_latent_noise_std: 0.0  # 1e-4
+# currently fixed to 1.0 (due to limitations with flex_attention and triton)
+forecast_att_dense_rate: 1.0
+with_step_conditioning: True # False
+
+healpix_level: 5
+# Use 2D RoPE instead of traditional global positional encoding
+# When True: uses 2D RoPE based on healpix cell coordinates (lat/lon)
+# When False: uses traditional pe_global positional encoding
+rope_2D: True 
+
+with_mixed_precision: True
+with_flash_attention: True
+compile_model: False
+with_fsdp: False
+ddp_find_unused_parameters: False
+attention_dtype: bf16
+mixed_precision_dtype: bf16
+mlp_norm_eps: 1e-5
+norm_eps: 1e-4
+
+latent_noise_kl_weight: 0.0 # 1e-5
+latent_noise_gamma: 2.0
+latent_noise_saturate_encodings: 5 
+latent_noise_use_additive_noise: False
+latent_noise_deterministic_latents: True
+
+freeze_modules: ""
+
+norm_type: "LayerNorm"
+qk_norm_type: "RMSNorm"
+# type of zarr_store
+zarr_store: "zip" # "zarr" for LocalStore, "zip" for ZipStore
+
+#####################################
+
+streams_directory: "./config/streams/era5_georing/"
+streams: ???
+
+general:
+
+  # mutable parameters
+  istep: 0
+  rank: ???
+  world_size: ???
+
+  # local_rank, 
+  # with_ddp,
+  # data_path_*, 
+  # model_path, 
+  # run_path, 
+  # path_shared_
+
+  multiprocessing_method: "fork"
+
+  desc: ""
+  run_id: ???
+  run_history: []
+
+# logging frequency in the training loop (in number of batches)
+train_logging:
+  terminal: 10
+  metrics: 20
+  checkpoint: 250
+  log_grad_norms: False
+
+  # Collapse monitoring for SSL training (JEPA/DINO/iBOT)
+  # Detects representation collapse via various metrics
+  # For forecasting, supports sequences of latents with per-step and aggregate metrics
+  collapse_monitoring:
+    enabled: true
+    compute_frequency: 100  # batches between metric computations
+    log_frequency: 100      # batches between metric logging
+    metrics:
+      effective_rank:
+        enabled: true
+        tensor_source: "both"  # "student", "teacher", or "both"
+        sample_size: 2048      # max samples for SVD (0 = no sampling)
+        # For forecasting sequences: "all" (per-step + aggregates),
+        # "aggregate_only" (mean/min/max/degradation), "per_step_only"
+        forecast_aggregation: "all"
+      singular_values:
+        enabled: true
+        tensor_source: "both"
+        sample_size: 2048
+        forecast_aggregation: "all"
+      dimension_variance:
+        enabled: true
+        tensor_source: "both"  # cheap to compute, good early indicator
+        forecast_aggregation: "all"
+      prototype_entropy:
+        enabled: true  # only applies to DINO
+      ema_beta:
+        enabled: true
+
+# parameters for data loading
+data_loading :
+
+  num_workers: 12
+  rng_seed: ???
+
+
+# config for training
+training_config:
+
+  # training_mode: "masking", "student_teacher", "latent_loss"
+  training_mode: ["student_teacher"]
+
+  # Deep self-supervision (V-JEPA 2.1 style): compute SSL loss at multiple encoder depths.
+  # When enabled, intermediate encoder representations are tapped and used as additional
+  # targets/predictions for the SSL loss. Disabled by default (empty tap_after).
+  deep_ssl:
+    enabled: true
+    tap_after:                     # named tap points (final output always included implicitly)
+      - local2global               # after local-to-global adapter, before global attention
+      - "global:0"                 # after 1st global layer (0-indexed)
+      - "global:1"                 # after 2nd global layer
+    fusion_hidden_factor: 2        # MLP hidden dim = factor * dim_embed
+    level_weights: [0.25, 0.25, 0.25, 0.25]  # per-level loss weights (len = num taps + 1)
+
+  # Context loss (V-JEPA 2.1): L1 on context (visible) tokens between student and teacher.
+  # Complements the JEPA loss which targets masked tokens.
+  context_loss:
+    enabled: true
+    weight: 0.4
+    warmup_steps: 10000             # linear warmup from 0 to weight over this many steps
+
+  num_mini_epochs: 32
+  samples_per_mini_epoch: 4096
+  shuffle: True
+
+  start_date: 1979-01-01T00:00
+  end_date: 2022-12-31T00:00
+
+  time_window_step: 06:00:00
+  time_window_len: 06:00:00
+
+  window_offset_prediction : 0
+  
+  learning_rate_scheduling :
+    lr_start: 1e-6
+    lr_max: 5e-5
+    lr_final_decay: 1e-6
+    lr_final: 0.0
+    num_steps_warmup: 512
+    num_steps_cooldown: 1024
+    policy_warmup: "cosine"
+    policy_decay: "constant"
+    policy_cooldown: "linear"
+    parallel_scaling_policy: "sqrt"
+
+  optimizer:
+    grad_clip: 0.5
+    weight_decay: 0.05
+    adamw :
+      # parameters are scaled by number of DDP workers
+      beta1 : 0.975
+      beta2 : 0.9875
+      eps : 2e-08
+
+  losses : {
+    "student-teacher": {
+        enabled: True,
+        type: LossLatentSSLStudentTeacher,
+        weight: 1.0,
+        loss_fcts : {
+          "JEPA": {
+            'weight': 4, "loss_extra_args": {}, "out_dim": 2048, "head": transformer,
+            "num_blocks": 6, "num_heads": 12, "with_qk_lnorm": True, "intermediate_dim": 768, 
+            "dropout_rate": 0.1,
+            target_source_correspondence: {0 : {0 : "subset"} },
+        },
+        },
+        target_and_aux_calc: { "EMATeacher" : 
+          { ema_ramp_up_ratio : null,
+            ema_halflife_in_thousands: 800000,
+            model_param_overrides : { 
+              training_config: { losses: { student-teacher:{ loss_fcts :{JEPA: {head: identity} }}}}
+            },
+          }
+        }
+      }
+  }
+  
+  model_input: {
+    "random_easy" : {
+      # masking strategy: "random", "forecast"
+      masking_strategy: "random",
+      num_samples: 1,
+      num_steps_input: 1,
+      masking_strategy_config : { 
+        diffusion_rn : True, 
+        rate : 0.6,
+        rate_sampling: False
+      },
+    },
+  }
+
+  target_input: {
+    "random_easy_target" : {
+      masking_strategy: "cropping_healpix",
+      num_samples: 1,
+      masking_strategy_config : { rate : 0.8, hl_mask: 3, rate_sampling: False },
+    },
+  }
+
+  forecast :
+    time_step: 00:00:00
+    num_steps: 0
+    policy: null
+
+
+# validation config; full validation config is merge of training and validation config
+validation_config: 
+
+  samples_per_mini_epoch: 256
+  shuffle: False
+
+  start_date: 2023-10-01T00:00
+  end_date: 2023-12-31T00:00
+  
+  # whether to track the exponential moving average of weights for validation
+  validate_with_ema: 
+    enabled : False
+    ema_ramp_up_ratio: 0.09
+    ema_halflife_in_thousands: 1e-3
+
+  # parameters for validation samples that are written to disk
+  output : {
+    # number of samples that are written
+    num_samples: 0,
+    # write samples in normalized model space
+    normalized_samples: False,
+    # output streams to write; default all
+    streams: null,
+  }
+
+  # run validation before training starts (mainly for model development)
+  validate_before_training: False
+  
+# test config; full test config is merge of validation and test config
+# test config is used by default when running inference
+
+# Tags for experiment tracking
+# These tags will be logged in MLFlow along with completed runs for train, eval, val
+# The tags are free-form, with the following rules:
+# - tags should be primitive types (strings, numbers, booleans). NO lists or dictionaries
+# - tags should not duplicate existing config entries.
+# - try to reuse existing tags where possible. MLFlow does not like having too many unique tags
+# - do not use long strings in values (less than 20 characters is a good rule of thumb, we may enforce this in the future)
+wgtags:
+  # The name of the organization of the person running the experiment.
+  # This may be autofilled in the future. Expected values are lowercase strings 
+  # e.g. "ecmwf", "cmcc", "metnor", "jsc", "escience"
+  org: null
+  # The Github issue corresponding to this run (number such as 1234)
+  # Github issues are the central point when running experiment and contain 
+  # links to hedgedocs, code branches, pull requests etc.
+  # It is recommended to associate a run with a Github issue.
+  issue: null
+  # The name of the experiment. This is a distinctive codename for the experiment campaign being run.
+  # This is expected to be the primary tag for comparing experiments in MLFlow, along with the
+  # issue number.
+  # Expected values are lowercase strings with no spaces, just underscores:
+  # Examples: "rollout_ablation_grid"  
+  exp: null
+  # *** Experiment-specific tags ***
+  # All extra tags (including lists, dictionaries, etc.) are treated 
+  # as strings by mlflow, so treat all extra tags as simple string key: value pairs.
+  grid: null
+

--- a/config/streams/era5_georing/era5.yml
+++ b/config/streams/era5_georing/era5.yml
@@ -1,0 +1,36 @@
+# (C) Copyright 2026 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+ERA5 :
+  type : anemoi
+  filenames : ['aifs-ea-an-oper-0001-mars-o96-1979-2023-6h-v8.zarr']
+  stream_id : 0
+  source_exclude : ['w_', 'skt', 'tcw', 'cp', 'tp']
+  target_exclude : ['w_', 'slor', 'sdor', 'tcw', 'cp', 'tp']
+  loss_weight : 1.
+  location_weight : cosine_latitude
+  token_size : 8
+  tokenize_spacetime : True
+  max_num_targets: -1 
+  embed : 
+    net : transformer
+    num_tokens : 1
+    num_heads : 8
+    dim_embed : 256
+    num_blocks : 2
+  embed_target_coords :
+    net : linear
+    dim_embed : 512
+  target_readout :
+    num_layers : 2
+    num_heads : 4
+    # sampling_rate : 0.2
+  pred_head :
+    ens_size : 1
+    num_layers : 1

--- a/config/streams/era5_georing/geos.yml
+++ b/config/streams/era5_georing/geos.yml
@@ -1,0 +1,87 @@
+# (C) Copyright 2026 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+METEOSAT_SEVIRI :
+  type : obs
+  stream_id : 2
+  filenames : ['observations-file-2014-2024-seviri-h512-v5.zarr']
+  source_exclude : ["obsvalue_rawbt_065", "obsvalue_rawbt_086", "obsvalue_rawbt_160"]
+  target_exclude : ["obsvalue_rawbt_065", "obsvalue_rawbt_086", "obsvalue_rawbt_160"]
+  loss_weight : 1.0
+  token_size : 128
+  tokenize_spacetime : True
+  max_num_targets: 65536
+  embed : 
+    net : transformer
+    num_tokens : 1
+    num_heads : 2
+    dim_embed : 256
+    num_blocks : 2
+  embed_target_coords : 
+    net : linear
+    dim_embed : 512
+  target_readout :
+    num_layers : 2
+    num_heads : 4
+  pred_head :    
+    ens_size : 1
+    num_layers : 1
+
+
+GOES_ABI :
+  type : obs
+  stream_id : 3
+  filenames : ['observations-file-2017-2024-abi-goes16-IR-h512-v2.zarr']
+  source_exclude : ["obsvalue_rawbt_086", "obsvalue_rawbt_160"]
+  target_exclude : ["obsvalue_rawbt_086", "obsvalue_rawbt_160"]
+  loss_weight : 1.0
+  token_size : 128
+  tokenize_spacetime : True
+  max_num_targets: 65536
+  embed : 
+    net : transformer
+    num_tokens : 1
+    num_heads : 2
+    dim_embed : 256
+    num_blocks : 2
+  embed_target_coords : 
+    net : linear
+    dim_embed : 512
+  target_readout :
+    num_layers : 2
+    num_heads : 4
+  pred_head : 
+    ens_size : 1
+    num_layers : 1
+
+
+HIMAWARI_AHI :
+  type : obs
+  stream_id : 4
+  filenames : ['observations-file-2015-2022-himawari8-IR-h512-v1.zarr']
+  source_exclude : ["obsvalue_rawbt_086", "obsvalue_rawbt_160"]
+  target_exclude : ["obsvalue_rawbt_086", "obsvalue_rawbt_160"]
+  loss_weight : 1.0
+  token_size : 128
+  tokenize_spacetime : True
+  max_num_targets: 65536
+  embed : 
+    net : transformer
+    num_tokens : 1
+    num_heads : 2
+    dim_embed : 256
+    num_blocks : 2
+  embed_target_coords : 
+    net : linear
+    dim_embed : 512
+  target_readout :
+    num_layers : 2
+    num_heads : 4
+  pred_head : 
+    ens_size : 1
+    num_layers : 1

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -252,7 +252,7 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                     filenames = [pathlib.Path(path) / fname for path in cf.data_paths]
 
                     filename = next((f for f in filenames if f.exists()), None)
-                    if filename is None :  
+                    if filename is None:
                         msg = (
                             f"Did not find input data for {stream_info['type']} "
                             f"stream '{stream_name}': {filenames}."

--- a/src/weathergen/model/ema.py
+++ b/src/weathergen/model/ema.py
@@ -30,10 +30,10 @@ class EMAModel:
         self.rampup_ratio = rampup_ratio
         self.ema_model = empty_model
         self.is_model_sharded = is_model_sharded
-        self.batch_size = 1
-        # Build a name → param map once
+        # Build a name → param map once; used to precompute the update pairs.
         self.src_params = dict(self.original_model.named_parameters())
-
+        self._ema_update_params: list[torch.nn.Parameter] = []
+        self._src_update_params: list[torch.nn.Parameter] = []
         self.reset()
 
     @torch.no_grad()
@@ -56,13 +56,33 @@ class EMAModel:
         if needs_strip:
             maybe_sharded_sd = {k.removeprefix("module."): v for k, v in maybe_sharded_sd.items()}
         mkeys, ukeys = self.ema_model.load_state_dict(maybe_sharded_sd, strict=False, assign=False)
+        self._rebuild_update_pairs()
         self.ema_model.eval()
 
-    def requires_grad_(self, flag: bool):
-        for p in self.ema_model.parameters():
-            p.requires_grad = flag
+    def _resolve_src_param(self, name: str):
+        p_src = self.src_params.get(name, None)
+        if p_src is None:
+            p_src = self.src_params.get("module." + name, None)
+        return p_src
 
-    def get_current_beta(self, cur_step: int) -> float:
+    def _rebuild_update_pairs(self):
+        """Precompute EMA/source parameter pairs once so update() stays branch-light."""
+        ema_params = []
+        src_params = []
+        for name, p_ema in self.ema_model.named_parameters():
+            if "identity" in name.lower() or "q_cells" in name.lower():
+                continue
+            p_src = self._resolve_src_param(name)
+            if p_src is None:
+                # EMA-only param or intentionally excluded
+                raise AssertionError(f"{name}: All parameters of the EMA model must be in the base model.")
+            ema_params.append(p_ema)
+            src_params.append(p_src)
+
+        self._ema_update_params = ema_params
+        self._src_update_params = src_params
+
+    def get_current_beta(self, cur_step: int, batch_size: int) -> float:
         """
         Get current EMA beta value for monitoring.
 
@@ -78,31 +98,21 @@ class EMAModel:
         halflife_steps = self.halflife_steps
         if self.rampup_ratio is not None:
             halflife_steps = min(halflife_steps, cur_step * self.rampup_ratio)
-        beta = 0.5 ** (self.batch_size / max(halflife_steps, 1e-6))
+        beta = 0.5 ** (batch_size / max(halflife_steps, 1e-6))
         return beta
 
     @torch.no_grad()
-    def update(self, cur_step, batch_size):
+    def update(self, cur_step: int, batch_size: int):
         # ensure model remains sharded
         if self.is_model_sharded:
-            self.ema_model.reshard()
+            self.ema_model.reshard()\
+            
         # determine correct interpolation params
-        self.batch_size = batch_size
-        beta = self.get_current_beta(cur_step)
+        beta = self.get_current_beta(cur_step, batch_size)
 
-        for name, p_ema in self.ema_model.named_parameters():
-            p_src = self.src_params.get(name, None)
-            # Due to DDP only being applied only to the student the names may missmatch
-            # Thus, we check for the alternate naming scheme
-            p_src = self.src_params.get("module." + name, None) if p_src is None else p_src
-            if "identity" in name.lower() or "q_cells" in name.lower():
-                continue
-            if p_src is None:
-                # EMA-only param or intentionally excluded
-                assert False, f"{name}: All parameters of the EMA model must be in the base model."
-
-            p_ema.lerp_(p_src, 1.0 - beta)
-
+        torch._foreach_mul_(self._ema_update_params, beta)
+        torch._foreach_add_(self._ema_update_params, self._src_update_params, alpha=1.0 - beta)
+    
     @torch.no_grad()
     def forward_eval(self, *args, **kwargs):
         self.ema_model.eval()

--- a/src/weathergen/model/ema.py
+++ b/src/weathergen/model/ema.py
@@ -75,7 +75,9 @@ class EMAModel:
             p_src = self._resolve_src_param(name)
             if p_src is None:
                 # EMA-only param or intentionally excluded
-                raise AssertionError(f"{name}: All parameters of the EMA model must be in the base model.")
+                raise AssertionError(
+                    f"{name}: All parameters of the EMA model must be in the base model."
+                )
             ema_params.append(p_ema)
             src_params.append(p_src)
 
@@ -105,14 +107,14 @@ class EMAModel:
     def update(self, cur_step: int, batch_size: int):
         # ensure model remains sharded
         if self.is_model_sharded:
-            self.ema_model.reshard()\
-            
+            self.ema_model.reshard()
+
         # determine correct interpolation params
         beta = self.get_current_beta(cur_step, batch_size)
 
         torch._foreach_mul_(self._ema_update_params, beta)
         torch._foreach_add_(self._ema_update_params, self._src_update_params, alpha=1.0 - beta)
-    
+
     @torch.no_grad()
     def forward_eval(self, *args, **kwargs):
         self.ema_model.eval()

--- a/src/weathergen/train/collapse_monitor.py
+++ b/src/weathergen/train/collapse_monitor.py
@@ -703,7 +703,7 @@ class CollapseMonitor:
         for _calc_name, calculator in target_and_aux_calculators.items():
             if isinstance(calculator, EMATeacher):
                 step = batch_size * cf.general.istep
-                ema_beta = calculator.get_current_beta(step)
+                ema_beta = calculator.get_current_beta(step, batch_size)
                 break
 
         # Debug logging

--- a/src/weathergen/train/target_and_aux_ssl_teacher.py
+++ b/src/weathergen/train/target_and_aux_ssl_teacher.py
@@ -77,8 +77,8 @@ class EncoderTeacher(TargetAndAuxModuleBase):
             module.to(device)
         return self
 
-    def get_current_beta(self, cur_step: int) -> float:
-        beta = self.ema_model.get_current_beta(cur_step)
+    def get_current_beta(self, cur_step: int, batch_size: int) -> float:
+        beta = self.ema_model.get_current_beta(cur_step, batch_size)
         return beta
 
 
@@ -104,9 +104,9 @@ class EMATeacher(EncoderTeacher):
             self.ema_model.ema_model.reshard()
         self.ema_model.update(istep, self.batch_size)
 
-    def get_current_beta(self, cur_step: int) -> float:
+    def get_current_beta(self, cur_step: int, batch_size: int) -> float:
         """Return the current EMA interpolation beta for monitoring."""
-        return self.ema_model.get_current_beta(cur_step)
+        return self.ema_model.get_current_beta(cur_step, batch_size)
 
 
 class FrozenTeacher(EncoderTeacher):


### PR DESCRIPTION
## Description

- Compute EMA param updates in place with a fused torch implementation
- Move the EMA source/parameter pair check outside the update function to reset.

We profiled the old and the new implementation. On the config_operan_georing_avhrr_forecasting_lowres, an update took:
- previously, ~100ms (oan0f4qo on Santis): <img width="753" height="444" alt="Screenshot 2026-06-24 at 15 05 51" src="https://github.com/user-attachments/assets/ccf8bd2c-eede-46e8-bf5c-df573350deaf" />
- afterwards, ~10ms (h3ofhgh5 on Santis): <img width="746" height="307" alt="Screenshot 2026-06-24 at 15 06 07" src="https://github.com/user-attachments/assets/913a3d7a-adcd-4559-b7dd-3ab84b591e99" />

## Issue Number

Fixes #2520.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
