### PR TITLE
fix sample and ipoint duplication with multiple ranks. 

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/io/data/dataarray_builders.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/data/dataarray_builders.py
@@ -271,9 +271,19 @@ def build_scatter_dataarrays(
         )
         per_sample_preds.append(da_p)
 
+    # Promote scalar 'sample' to a per-ipoint coordinate before concatenation
+    # so that groupby("sample") works downstream.
+    for i, (da_t, da_p) in enumerate(zip(per_sample_tars, per_sample_preds, strict=False)):
+        if "sample" in da_t.coords and da_t.coords["sample"].ndim == 0:
+            sample_val = da_t.coords["sample"].item()
+            n_ip = da_t.sizes["ipoint"]
+            sample_arr = ("ipoint", np.full(n_ip, sample_val))
+            per_sample_tars[i] = da_t.drop_vars("sample").assign_coords(sample=sample_arr)
+            per_sample_preds[i] = da_p.drop_vars("sample").assign_coords(sample=sample_arr)
+
     # Concatenate along ipoint (like get_data() does for non-gridded)
-    da_tar = xr.concat(per_sample_tars, dim="ipoint", coords="different", compat="equals")
-    da_pred = xr.concat(per_sample_preds, dim="ipoint", coords="different", compat="equals")
+    da_tar = xr.concat(per_sample_tars, dim="ipoint")
+    da_pred = xr.concat(per_sample_preds, dim="ipoint")
 
     return da_tar, da_pred
 

--- a/packages/evaluate/src/weathergen/evaluate/io/data/dataarray_builders.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/data/dataarray_builders.py
@@ -282,8 +282,9 @@ def build_scatter_dataarrays(
             per_sample_preds[i] = da_p.drop_vars("sample").assign_coords(sample=sample_arr)
 
     # Concatenate along ipoint (like get_data() does for non-gridded)
-    da_tar = xr.concat(per_sample_tars, dim="ipoint")
-    da_pred = xr.concat(per_sample_preds, dim="ipoint")
+    # Keep behavior stable across xarray default changes.
+    da_tar = xr.concat(per_sample_tars, dim="ipoint", coords="different", compat="equals")
+    da_pred = xr.concat(per_sample_preds, dim="ipoint", coords="different", compat="equals")
 
     return da_tar, da_pred
 

--- a/packages/evaluate/src/weathergen/evaluate/io/data/io_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/data/io_orchestration.py
@@ -83,6 +83,11 @@ class IOState:
     offset: np.timedelta64 | None = (
         None  # fallback offset in hours for init_time when source_interval is missing
     )
+    sample_labels: list[int] | None = None  # global sample indices for coordinate labeling
+
+    def get_sample_labels(self) -> list[int]:
+        """Return global sample labels (falls back to local samples if not set)."""
+        return self.sample_labels if self.sample_labels is not None else self.samples
 
 
 # ---------------------------------------------------------------------------
@@ -254,6 +259,7 @@ def _build_io_state(
     n_io_workers: int,
     ens_select: EnsembleSelect,
     rank: str = "",
+    sample_labels: list[int] | None = None,
 ) -> IOState:
     """Resolve all I/O parameters that are shared between the two impl paths."""
     zarr_path = str(fname_zarr)
@@ -299,6 +305,7 @@ def _build_io_state(
         rank=rank,
         offset=offset,
         regrid_opts=regrid_opts,
+        sample_labels=sample_labels,
     )
 
 
@@ -447,7 +454,7 @@ def _assemble_substep(
         da_tar, da_pred = build_scatter_dataarrays(
             tars_list,
             preds_list,
-            state.samples,
+            state.get_sample_labels(),
             state.read_channels,
             per_sample_valid_times,
             init_times,

--- a/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
@@ -532,20 +532,49 @@ class WeatherGenZarrReader(WeatherGenReader):
         For gridded data (dims include 'sample'), concatenates along 'sample'
         and re-indexes to global sample coordinates.
         For scatter data (no 'sample' dim), concatenates along 'ipoint'
-        and re-indexes to a contiguous range.
+        and promotes the scalar 'sample' coord to a per-ipoint coordinate
+        so that downstream groupby("sample") works correctly.
         """
         merged = {}
         for fstep, das in all_das.items():
+            concat_dim = "sample" if "sample" in das[0].dims else "ipoint"
+
             if len(das) > 1:
-                concat_dim = "sample" if "sample" in das[0].dims else "ipoint"
-                combined = xr.concat(das, dim=concat_dim)
+                if concat_dim == "ipoint":
+                    # Scatter path: promote scalar 'sample' coord to per-ipoint
+                    # so it survives concatenation and enables groupby("sample").
+                    promoted = []
+                    for da in das:
+                        if "sample" in da.coords and da.coords["sample"].ndim == 0:
+                            sample_val = da.coords["sample"].item()
+                            n_ip = da.sizes["ipoint"]
+                            da = da.drop_vars("sample").assign_coords(
+                                sample=("ipoint", np.full(n_ip, sample_val))
+                            )
+                        promoted.append(da)
+                    combined = xr.concat(promoted, dim="ipoint")
+                else:
+                    combined = xr.concat(das, dim=concat_dim)
             else:
                 combined = das[0]
+                # Single-DA scatter: also promote scalar 'sample' to per-ipoint
+                if (
+                    concat_dim == "ipoint"
+                    and "sample" in combined.coords
+                    and combined.coords["sample"].ndim == 0
+                ):
+                    sample_val = combined.coords["sample"].item()
+                    n_ip = combined.sizes["ipoint"]
+                    combined = combined.drop_vars("sample").assign_coords(
+                        sample=("ipoint", np.full(n_ip, sample_val))
+                    )
 
             if "sample" in combined.dims:
                 combined = combined.assign_coords(
                     sample=global_sample_coords[: len(combined.sample)]
                 )
+            if concat_dim == "ipoint" and "ipoint" in combined.dims:
+                combined = combined.assign_coords(ipoint=np.arange(combined.sizes["ipoint"]))
             merged[fstep] = combined
         return merged
 
@@ -602,6 +631,7 @@ class WeatherGenZarrReader(WeatherGenReader):
             rank_local_to_load = [
                 local_samples[g - global_offset] for g in sorted(rank_globals & requested_globals)
             ]
+            rank_global_labels = sorted(rank_globals & requested_globals)
 
             _logger.info(
                 f"RUN {self.run_id} [rank {rank_file.stem.split('rank')[-1]}]: "
@@ -627,6 +657,7 @@ class WeatherGenZarrReader(WeatherGenReader):
                 self._num_io_workers,
                 ens_select,
                 rank=rank_file.stem.split("rank")[-1],
+                sample_labels=rank_global_labels,
             )
             get_data_fn = get_data_zipstore if state.is_zip else get_data_dirstore
             result = get_data_fn(state)

--- a/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import numpy as np
 import omegaconf as oc
 import xarray as xr
+from numpy.typing import NDArray
 
 # Local application / package
 from weathergen.common.config import (
@@ -550,14 +551,29 @@ class WeatherGenZarrReader(WeatherGenReader):
                 else das[0]
             )
 
-            if "sample" in combined.dims:
-                combined = combined.assign_coords(
-                    sample=global_sample_coords[: len(combined.sample)]
-                )
-            if concat_dim == "ipoint" and "ipoint" in combined.dims:
-                combined = combined.assign_coords(ipoint=np.arange(combined.sizes["ipoint"]))
+            combined = self._reindex_merged_coords(combined, concat_dim, global_sample_coords)
             merged[fstep] = combined
         return merged
+
+    @staticmethod
+    def _reindex_merged_coords(
+        da: xr.DataArray, concat_dim: str, global_sample_coords: NDArray
+    ) -> xr.DataArray:
+        """Re-index coordinates after cross-rank concatenation to avoid duplicates.
+
+        Each rank file uses local indices (0, 1, 2, …) for both samples and
+        ipoints.  After concatenation these overlap, so we replace them with
+        unique global coordinates:
+        - For gridded data (concat along 'sample'): assign contiguous global
+          sample indices derived from the rank offsets.
+        - For scatter data (concat along 'ipoint'): assign a fresh 0-based
+          ipoint range covering the combined length.
+        """
+        if "sample" in da.dims:
+            da = da.assign_coords(sample=global_sample_coords[: len(da.sample)])
+        if concat_dim == "ipoint" and "ipoint" in da.dims:
+            da = da.assign_coords(ipoint=np.arange(da.sizes["ipoint"]))
+        return da
 
     @staticmethod
     def _promote_scalar_sample(da: xr.DataArray) -> xr.DataArray:

--- a/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
@@ -539,35 +539,14 @@ class WeatherGenZarrReader(WeatherGenReader):
         for fstep, das in all_das.items():
             concat_dim = "sample" if "sample" in das[0].dims else "ipoint"
 
-            if len(das) > 1:
-                if concat_dim == "ipoint":
-                    # Scatter path: promote scalar 'sample' coord to per-ipoint
-                    # so it survives concatenation and enables groupby("sample").
-                    promoted = []
-                    for da in das:
-                        if "sample" in da.coords and da.coords["sample"].ndim == 0:
-                            sample_val = da.coords["sample"].item()
-                            n_ip = da.sizes["ipoint"]
-                            da = da.drop_vars("sample").assign_coords(
-                                sample=("ipoint", np.full(n_ip, sample_val))
-                            )
-                        promoted.append(da)
-                    combined = xr.concat(promoted, dim="ipoint")
-                else:
-                    combined = xr.concat(das, dim=concat_dim)
-            else:
-                combined = das[0]
-                # Single-DA scatter: also promote scalar 'sample' to per-ipoint
-                if (
-                    concat_dim == "ipoint"
-                    and "sample" in combined.coords
-                    and combined.coords["sample"].ndim == 0
-                ):
-                    sample_val = combined.coords["sample"].item()
-                    n_ip = combined.sizes["ipoint"]
-                    combined = combined.drop_vars("sample").assign_coords(
-                        sample=("ipoint", np.full(n_ip, sample_val))
-                    )
+            if concat_dim == "ipoint":
+                # Scatter: promote scalar 'sample' to per-ipoint so it
+                # survives concatenation and enables groupby("sample").
+                das = [self._promote_scalar_sample(da) for da in das]
+
+            combined = (
+                xr.concat(das, dim=concat_dim, coords="different") if len(das) > 1 else das[0]
+            )
 
             if "sample" in combined.dims:
                 combined = combined.assign_coords(
@@ -577,6 +556,15 @@ class WeatherGenZarrReader(WeatherGenReader):
                 combined = combined.assign_coords(ipoint=np.arange(combined.sizes["ipoint"]))
             merged[fstep] = combined
         return merged
+
+    @staticmethod
+    def _promote_scalar_sample(da: xr.DataArray) -> xr.DataArray:
+        """Promote a scalar 'sample' coordinate to a per-ipoint array."""
+        if "sample" in da.coords and da.coords["sample"].ndim == 0:
+            sample_val = da.coords["sample"].item()
+            n_ip = da.sizes["ipoint"]
+            da = da.drop_vars("sample").assign_coords(sample=("ipoint", np.full(n_ip, sample_val)))
+        return da
 
     def get_data(
         self,

--- a/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
@@ -545,7 +545,9 @@ class WeatherGenZarrReader(WeatherGenReader):
                 das = [self._promote_scalar_sample(da) for da in das]
 
             combined = (
-                xr.concat(das, dim=concat_dim, coords="different") if len(das) > 1 else das[0]
+                xr.concat(das, dim=concat_dim, coords="different", compat="equals")
+                if len(das) > 1
+                else das[0]
             )
 
             if "sample" in combined.dims:

--- a/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
@@ -528,14 +528,25 @@ class WeatherGenZarrReader(WeatherGenReader):
 
     def _merge_fsteps(self, all_das: dict, global_sample_coords) -> dict:
         """Merge lists of DataArrays for each forecast step across ranks.
-        Concatenates along the sample dimension and re-indexes to global samples.
+
+        For gridded data (dims include 'sample'), concatenates along 'sample'
+        and re-indexes to global sample coordinates.
+        For scatter data (no 'sample' dim), concatenates along 'ipoint'
+        and re-indexes to a contiguous range.
         """
         merged = {}
         for fstep, das in all_das.items():
-            combined = xr.concat(das, dim="sample") if len(das) > 1 else das[0]
-            merged[fstep] = combined.assign_coords(
-                sample=global_sample_coords[: len(combined.sample)]
-            )
+            if len(das) > 1:
+                concat_dim = "sample" if "sample" in das[0].dims else "ipoint"
+                combined = xr.concat(das, dim=concat_dim)
+            else:
+                combined = das[0]
+
+            if "sample" in combined.dims:
+                combined = combined.assign_coords(
+                    sample=global_sample_coords[: len(combined.sample)]
+                )
+            merged[fstep] = combined
         return merged
 
     def get_data(
@@ -717,6 +728,14 @@ class WeatherGenZarrReader(WeatherGenReader):
     def _compute_is_gridded(self, stream: str) -> bool:
         """is_gridded_data logic, called once per stream and cached."""
         _logger.debug(f"Checking regular spacing for stream {stream}...")
+
+        max_num_target = self.get_inference_stream_attr(stream, "max_num_targets", -1)
+        if max_num_target != -1:
+            _logger.warning(
+                f"WARNING: Stream '{stream}' has max_num_targets={max_num_target} (!= -1), "
+                "indicating variable-length observations (scatter data)."
+            )
+            return False
 
         with self._open_any_rank_for_metadata() as zio:
             dummy = zio.get_data(zio.samples[0], stream, zio.forecast_steps[0])


### PR DESCRIPTION
## Description

- promote sample from scala to coords 
- avoid duplicates in sample names when merging multiple ranks for gridded data (aka when sample is the concatenation dimension)
- avoid duplicates in ipoint names when merging multiple ranks for scattered data (aka when ipoint is the concatenation dimension)
- add warning message when max_num_target != -1 and scatter mode is activated



## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/2564
Closes https://github.com/ecmwf/WeatherGenerator/issues/2528
Closes https://github.com/ecmwf/WeatherGenerator/issues/2473

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
