### PR TITLE
Fix Dynamic Loss EMA update with forecast offset

### DIFF
--- a/src/weathergen/train/loss_modules/loss_module_physical.py
+++ b/src/weathergen/train/loss_modules/loss_module_physical.py
@@ -69,7 +69,6 @@ class DynamicLossEMA:
         return weights_channels
 
     def update(self, stream_name: str, loss_lfct_chs: torch.Tensor):
-        # print(f"Updating dynamic loss EMA for stream {stream_name} with loss {loss_lfct_chs}")
         if not self.enabled:
             return
 
@@ -293,6 +292,10 @@ class LossPhysical(LossModuleBase):
             losses_all[stream_name] = defaultdict(dict)
 
             stream_loss_weight, weights_channels = self._get_weights(stream_name, stream_info)
+            if self.dynamic_loss_ema.enabled and weights_channels is not None:
+                losses_all[stream_name]["0"]["ema_weight"] = {}
+                for ch_n, w in zip(target_channels, weights_channels, strict=True):
+                    losses_all[stream_name]["0"]["ema_weight"][ch_n] = w.item()
 
             # TODO: make nicer
             output_step_loss_weights = self._get_output_step_weights(len(targets.output_idxs))

--- a/src/weathergen/train/loss_modules/loss_module_physical.py
+++ b/src/weathergen/train/loss_modules/loss_module_physical.py
@@ -293,9 +293,9 @@ class LossPhysical(LossModuleBase):
 
             stream_loss_weight, weights_channels = self._get_weights(stream_name, stream_info)
             if self.dynamic_loss_ema.enabled and weights_channels is not None:
-                losses_all[stream_name]["0"]["ema_weight"] = {}
+                losses_all[stream_name][str(self.forecast_offset)]["mse_ema_weight"] = {}
                 for ch_n, w in zip(target_channels, weights_channels, strict=True):
-                    losses_all[stream_name]["0"]["ema_weight"][ch_n] = w.item()
+                    losses_all[stream_name][str(self.forecast_offset)]["mse_ema_weight"][ch_n] = w.item()
 
             # TODO: make nicer
             output_step_loss_weights = self._get_output_step_weights(len(targets.output_idxs))

--- a/src/weathergen/train/loss_modules/loss_module_physical.py
+++ b/src/weathergen/train/loss_modules/loss_module_physical.py
@@ -69,6 +69,7 @@ class DynamicLossEMA:
         return weights_channels
 
     def update(self, stream_name: str, loss_lfct_chs: torch.Tensor):
+        # print(f"Updating dynamic loss EMA for stream {stream_name} with loss {loss_lfct_chs}")
         if not self.enabled:
             return
 
@@ -108,6 +109,7 @@ class LossPhysical(LossModuleBase):
 
         # Dynamic Loss state (extract it before parsing the actual loss functions)
         self.dynamic_loss_cfg = loss_fcts.get("dynamic_loss")
+        self.forecast_offset = self.mode_cfg.forecast.offset
 
         # dynamically load loss functions based on configuration and stage
         self.loss_fcts = [
@@ -392,7 +394,7 @@ class LossPhysical(LossModuleBase):
                         # Update EMA for dynamic loss if enabled
                         if (
                             self.dynamic_loss_ema.enabled
-                            and timestep_idx == 0
+                            and timestep_idx == self.forecast_offset
                             and loss_fct_name == "mse"
                             and not is_spoof
                         ):


### PR DESCRIPTION
## Description

Fixes updating Dynamic Loss EMA to the first forecast step with the offset value 


## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/2566

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
