### PR TITLE
[2563][model] linear probe decoder

### DIFF
--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -1150,3 +1150,33 @@ class BilinearDecoder(nn.Module):
         """
         latent_md = torch.repeat_interleave(latent_nd, tcs_lens_n1[1:], 0)
         return self.bilin(coords_md, latent_md)
+
+
+class LinearProbeDecoder(nn.Module):
+    """Linear map from latent tokens to target channels.
+
+    Same forward signature as :class:`BilinearDecoder`; ``coords_md`` is unused.
+    """
+
+    def __init__(
+        self,
+        stream_name,
+        coord_dim,
+        latent_dim,
+        out_dim,
+        with_layer_norm: bool = False,
+    ):
+        super().__init__()
+
+        self.name = f"LinearProbeDecoder_{stream_name}"
+        self.latent_dim = latent_dim
+        self.with_layer_norm = with_layer_norm
+        # Submodule name must not match ``freeze_modules`` regex patterns.
+        self.input_norm = nn.LayerNorm(latent_dim) if with_layer_norm else nn.Identity()
+        self.linear = nn.Linear(latent_dim, out_dim)
+
+    def forward(self, coords_md, latent_nd, tcs_lens_n1):
+        del coords_md
+        latent_md = torch.repeat_interleave(latent_nd, tcs_lens_n1[1:], 0)
+        latent_md = self.input_norm(latent_md)
+        return self.linear(latent_md)

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -34,6 +34,7 @@ from weathergen.model.engines import (
     LatentPredictionHeadMLP,
     LatentPredictionHeadTransformer,
     LatentState,
+    LinearProbeDecoder,
     TargetPredictionEngine,
     TargetPredictionEngineClassic,
 )
@@ -454,6 +455,22 @@ class Model(torch.nn.Module):
                             cf.ae_global_dim_embed,
                             self.targets_num_channels[i_stream],
                         )
+                    elif cf.decoder_type == "LinearProbe":
+                        tte = LinearProbeDecoder(
+                            stream_name,
+                            dims_embed[0],
+                            cf.ae_global_dim_embed,
+                            self.targets_num_channels[i_stream],
+                            with_layer_norm=False,
+                        )
+                    elif cf.decoder_type == "LinearProbeNorm":
+                        tte = LinearProbeDecoder(
+                            stream_name,
+                            dims_embed[0],
+                            cf.ae_global_dim_embed,
+                            self.targets_num_channels[i_stream],
+                            with_layer_norm=True,
+                        )
                     else:
                         # target prediction engines
                         tte_version = (
@@ -814,7 +831,7 @@ class Model(torch.nn.Module):
                 )
                 tcs_lens = torch.cat([torch.zeros(1, dtype=torch.int32, device=tcls.device), tcls])
 
-                if self.cf.decoder_type == "Linear":
+                if self.cf.decoder_type in ("Linear", "LinearProbe", "LinearProbeNorm"):
                     pred = self.target_token_engines[stream_name](
                         tc_tokens,
                         tokens.reshape(-1, s[-1]),  # collapse the batch and token dimensions


### PR DESCRIPTION
## Description

This PR adds a lightweight linear probe decoder for target prediction, useful as a simple baseline or diagnostic head.

New `LinearProbeDecoder` (`engines.py`) maps latent tokens to target channels with a single `nn.Linear` layer. It shares the same forward API as `BilinearDecoder` but ignores coordinates. An optional `LayerNorm` on the latent input is controlled by `with_layer_norm`.

Model registration (`model.py`) — Two new decoder types:

`LinearProbe` — linear map only
`LinearProbeNorm` — same, with input `LayerNorm`
Both are wired into decoder construction and the forward path alongside the existing Linear (`BilinearDecoder`) decoder.


## Issue Number

Closes #2563 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
