### PR TITLE
Efficient implementation of StreamEmbedTransformer

### DIFF
--- a/src/weathergen/model/embeddings.py
+++ b/src/weathergen/model/embeddings.py
@@ -115,24 +115,21 @@ class StreamEmbedTransformer(torch.nn.Module):
         elif self.unembed_mode == "block":
 
             B, C, D = x.shape
-            
-            # LayerNorm loop — cheap
-            x_normed = torch.stack([
-                self.ln_final[i](x[:, i]) for i in range(C)
-            ], dim=1)  # (B, C, D)
-            
-            # Stack weights ONCE per forward — then single batched matmul
-            W = torch.stack([ue.weight for ue in self.unembed])  # (C, out, D)
-            b = torch.stack([ue.bias   for ue in self.unembed])  # (C, out)
-            
+
+            ln_w = torch.stack([ln.weight for ln in self.ln_final])
+            ln_b = torch.stack([ln.bias   for ln in self.ln_final])
+            W    = torch.stack([ue.weight for ue in self.unembed])
+            b    = torch.stack([ue.bias   for ue in self.unembed])
+
+            x_normed = torch.nn.functional.layer_norm(x.reshape(B * C, D), [D], weight=None, bias=None)
+            x_normed = x_normed.reshape(B, C, D) * ln_w + ln_b
+
             out = torch.bmm(
                 x_normed.transpose(0, 1),
                 W.transpose(1, 2),
             ).transpose(0, 1)
 
-            out = out + b
-            out = out.flatten(-2, -1).to(x.dtype)
-
+            out = out.add(b).flatten(-2, -1).to(x.dtype)
             
         else:
             raise ValueError(f"Unknown unembed mode: {self.unembed_mode}")

--- a/src/weathergen/model/embeddings.py
+++ b/src/weathergen/model/embeddings.py
@@ -113,11 +113,27 @@ class StreamEmbedTransformer(torch.nn.Module):
         if self.unembed_mode == "full":
             out = self.unembed(self.ln_final(x.flatten(-2, -1)))
         elif self.unembed_mode == "block":
-            out = [
-                ue(ln(x[:, i]))
-                for i, (ue, ln) in enumerate(zip(self.unembed, self.ln_final, strict=True))
-            ]
-            out = torch.stack(out, dim=1).flatten(-2, -1)
+
+            B, C, D = x.shape
+            
+            # LayerNorm loop — cheap
+            x_normed = torch.stack([
+                self.ln_final[i](x[:, i]) for i in range(C)
+            ], dim=1)  # (B, C, D)
+            
+            # Stack weights ONCE per forward — then single batched matmul
+            W = torch.stack([ue.weight for ue in self.unembed])  # (C, out, D)
+            b = torch.stack([ue.bias   for ue in self.unembed])  # (C, out)
+            
+            out = torch.bmm(
+                x_normed.transpose(0, 1),
+                W.transpose(1, 2),
+            ).transpose(0, 1)
+
+            out = out + b
+            out = out.flatten(-2, -1).to(x.dtype)
+
+            
         else:
             raise ValueError(f"Unknown unembed mode: {self.unembed_mode}")
 

--- a/src/weathergen/model/embeddings.py
+++ b/src/weathergen/model/embeddings.py
@@ -113,24 +113,25 @@ class StreamEmbedTransformer(torch.nn.Module):
         if self.unembed_mode == "full":
             out = self.unembed(self.ln_final(x.flatten(-2, -1)))
         elif self.unembed_mode == "block":
-
-            B, C, D = x.shape
+            b, c, d = x.shape
 
             ln_w = torch.stack([ln.weight for ln in self.ln_final])
-            ln_b = torch.stack([ln.bias   for ln in self.ln_final])
-            W    = torch.stack([ue.weight for ue in self.unembed])
-            b    = torch.stack([ue.bias   for ue in self.unembed])
+            ln_b = torch.stack([ln.bias for ln in self.ln_final])
+            w = torch.stack([ue.weight for ue in self.unembed])
+            ue_bias = torch.stack([ue.bias for ue in self.unembed])
 
-            x_normed = torch.nn.functional.layer_norm(x.reshape(B * C, D), [D], weight=None, bias=None)
-            x_normed = x_normed.reshape(B, C, D) * ln_w + ln_b
+            x_normed = torch.nn.functional.layer_norm(
+                x.reshape(b * c, d), [d], weight=None, bias=None
+            )
+            x_normed = x_normed.reshape(b, c, d) * ln_w + ln_b
 
             out = torch.bmm(
                 x_normed.transpose(0, 1),
-                W.transpose(1, 2),
+                w.transpose(1, 2),
             ).transpose(0, 1)
 
-            out = out.add(b).flatten(-2, -1).to(x.dtype)
-            
+            out = out.add(ue_bias).flatten(-2, -1).to(x.dtype)
+
         else:
             raise ValueError(f"Unknown unembed mode: {self.unembed_mode}")
 


### PR DESCRIPTION
## Description
Due to the many kernel calls inside the forward function of the StreamEmbedTransformer module, it needs to be optimized. The proposed implementation is slightly more optimized.

By running this:
`../WeatherGenerator-private/hpc/launch-slurm.py --time 120 --nodes=1 --base-config ./config/config_operan_georing_avhrr_forecasting_lowres.yml`

**Baseline (develop branch):**
Run_id: gtj55ov5
Number of ingested samples: 6496
<img width="793" height="203" alt="Screenshot from 2026-06-30 09-42-03" src="https://github.com/user-attachments/assets/ed89cdd7-4475-44ec-9f87-9a312c54b705" />




**javad/dev/optimized_StreamEmbedTransformer_2557 branch**
Run_id: b04nu5cr
Number of ingested samples: 6896

<img width="793" height="203" alt="Screenshot from 2026-06-30 09-41-52" src="https://github.com/user-attachments/assets/d955897d-c7f6-476b-9d82-171f4ce9a9f1" />

The results show that performance increased by 6%.

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number
Closes #2557 
<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
