### PR TITLE
reinstating functions for power spectra

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/scores/psd.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/psd.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import logging
 
 import numpy as np
+from scipy.interpolate import griddata
 
 _logger = logging.getLogger(__name__)
 
@@ -523,6 +524,7 @@ def fft_psd(
     lats: np.typing.NDArray,
     lons: np.typing.NDArray,
     lat_range: tuple[float, float] = (-60.0, 60.0),
+    regrid_resolution: float = 1.0,
 ) -> tuple[np.typing.NDArray, np.typing.NDArray]:
     """Compute PSD using 1-D zonal FFT along the longitude dimension.
 
@@ -543,6 +545,8 @@ def fft_psd(
         Longitude values (per-point), length ``n_points``.
     lat_range : tuple[float, float]
         Latitude bounds to restrict the computation to.
+    regrid_resolution : float
+        Grid spacing in degrees for the regular target grid.
 
     Returns
     -------
@@ -551,11 +555,6 @@ def fft_psd(
     psd : np.typing.NDArray
         Power spectral density averaged over samples and latitude rows,
         shape ``(nfreq,)``.
-
-    Raises
-    ------
-    ValueError
-        If the input grid is not a regular lat-lon grid.
     """
 
     # Ensure 2-D: (n_samples, n_points)
@@ -564,24 +563,35 @@ def fft_psd(
 
     n_samples, n_points = data.shape
 
-    # Verify the grid is regular
+    # Determine if the grid is regular or unstructured
     unique_lats = np.unique(lats)
     unique_lons = np.unique(lons)
-    nlat, nlon = len(unique_lats), len(unique_lons)
+    is_regular = len(unique_lats) * len(unique_lons) == n_points
 
-    if nlat * nlon != n_points:
-        raise ValueError(
-            f"FFT PSD requires a regular lat-lon grid, but got {n_points} points "
-            f"with {nlat} unique latitudes and {nlon} unique longitudes "
-            f"(expected {nlat}×{nlon} = {nlat * nlon}). "
-            f"Use psd_method='sht' for non-regular grids."
-        )
+    if is_regular and len(lats) == len(unique_lats):
+        # lats/lons are axis arrays for a regular grid
+        lat_axis = unique_lats
+        lon_axis = unique_lons
+        nlat, nlon = len(lat_axis), len(lon_axis)
+        data_3d = data.reshape(n_samples, nlat, nlon)
+    else:
+        # Unstructured grid — regrid to regular lat-lon
+        lat_min = max(lat_range[0], lats.min())
+        lat_max = min(lat_range[1], lats.max())
+        lon_min, lon_max = lons.min(), lons.max()
 
-    # Reshape to (n_samples, nlat, nlon) — points are assumed ordered lat-major
-    data_3d = data.reshape(n_samples, nlat, nlon)
+        lat_axis = np.arange(lat_min, lat_max + regrid_resolution / 2, regrid_resolution)
+        lon_axis = np.arange(lon_min, lon_max + regrid_resolution / 2, regrid_resolution)
+        nlat, nlon = len(lat_axis), len(lon_axis)
+
+        grid_lon, grid_lat = np.meshgrid(lon_axis, lat_axis)
+        points = np.column_stack((lats, lons))
+
+        data_3d = np.empty((n_samples, nlat, nlon))
+        for s in range(n_samples):
+            data_3d[s] = griddata(points, data[s], (grid_lat, grid_lon), method="nearest")
 
     # Apply latitude mask
-    lat_axis = unique_lats
     lat_mask = (lat_axis >= lat_range[0]) & (lat_axis <= lat_range[1])
     data_3d = data_3d[:, lat_mask, :]
     nlon_sub = data_3d.shape[2]
@@ -592,7 +602,7 @@ def fft_psd(
         psds.append(_cubepsd(data_3d[s]))
     psd_result = np.mean(psds, axis=0)
 
-    spacing = 360.0 / nlon_sub if nlon_sub > 0 else 1.0
+    spacing = 360.0 / nlon_sub if nlon_sub > 0 else regrid_resolution
     frequencies = _calcposfreq(nlon_sub, spacing_deg=spacing)
     return frequencies, psd_result
 
@@ -609,6 +619,7 @@ def compute_psd_for_field(
     lats: np.typing.NDArray | None = None,
     lons: np.typing.NDArray | None = None,
     lat_range: tuple[float, float] = (-60.0, 60.0),
+    regrid_resolution: float = 1.0,
     sht_truncation: int | None = None,
     grid_type: str = "octahedral",
 ) -> tuple[np.typing.NDArray, np.typing.NDArray]:
@@ -626,6 +637,8 @@ def compute_psd_for_field(
         Latitude / longitude coordinate arrays (required for fft method).
     lat_range : tuple[float, float]
         Latitude bounds for the fft method.
+    regrid_resolution : float
+        Grid spacing in degrees for the fft method.
     sht_truncation : int | None
         Spectral truncation for SHT.
     grid_type : str
@@ -655,6 +668,7 @@ def compute_psd_for_field(
             lats=lats,
             lons=lons,
             lat_range=lat_range,
+            regrid_resolution=regrid_resolution,
         )
     else:
         raise ValueError(f"Unknown PSD method: {method!r}. Use 'sht' or 'fft'.")
@@ -668,6 +682,7 @@ def compute_psd_score(
     nlat: int | None,
     n_points: int,
     psd_method: str = "sht",
+    psd_regrid_resolution: float = 1.0,
     psd_sht_truncation: int | None = None,
     lat_range: tuple[float, float] = (-60.0, 60.0),
     grid_type: str | None = None,
@@ -690,6 +705,8 @@ def compute_psd_score(
         Original number of spatial points (before NaN masking).
     psd_method : str
         ``"sht"`` or ``"fft"``.
+    psd_regrid_resolution : float
+        Grid spacing for fft method.
     psd_sht_truncation : int | None
         Spectral truncation for SHT.
     lat_range : tuple[float, float]
@@ -749,6 +766,7 @@ def compute_psd_score(
             lats=lats_valid,
             lons=lons_valid,
             lat_range=lat_range,
+            regrid_resolution=psd_regrid_resolution,
             sht_truncation=psd_sht_truncation,
             grid_type=grid_type,
         )
@@ -759,6 +777,7 @@ def compute_psd_score(
             lats=lats_valid,
             lons=lons_valid,
             lat_range=lat_range,
+            regrid_resolution=psd_regrid_resolution,
             sht_truncation=psd_sht_truncation,
             grid_type=grid_type,
         )

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -17,6 +17,7 @@ import xarray as xr
 from scipy.spatial import cKDTree
 
 from weathergen.evaluate.scores.score_utils import to_list
+from weathergen.evaluate.scores.psd import compute_psd_score, detect_grid_type
 
 # from common.io import MockIO
 
@@ -198,6 +199,7 @@ class Scores:
             "seeps": self.calc_seeps,
             "qq_analysis": self.calc_quantiles,
             "nse": self.calc_nse,
+            "psd": self.calc_psd,
         }
         self.prob_metrics_dict = {
             "ssr": self.calc_ssr,
@@ -1807,3 +1809,189 @@ class Scores:
         _logger.info(f"Q-Q analysis completed with {len(overall_qq_score.attrs)} attributes")
 
         return overall_qq_score
+
+    def calc_psd(
+        self,
+        p: xr.DataArray,
+        gt: xr.DataArray,
+        psd_method: str = "sht",
+        psd_regrid_resolution: float = 1.0,
+        psd_sht_truncation: int | None = None,
+        lat_range: tuple[float, float] = (-60.0, 60.0),
+    ) -> xr.DataArray:
+        """Compute power spectral density for prediction and ground truth.
+
+        Returns a scalar summary score (log-spectral MSE) and stores the full
+        PSD curves in ``.attrs`` for plotting downstream.
+
+        Parameters
+        ----------
+        p: xr.DataArray
+            Forecast data array
+        gt: xr.DataArray
+            Ground truth data array
+        psd_method: str
+            Method to compute the PSD. Options: 'sht' (spherical harmonic transform),
+            'fft' (2D Fourier transform)
+        psd_regrid_resolution: float
+            Resolution in degrees to regrid data for PSD calculation. Default is 1.0 degree
+        psd_sht_truncation: int | None
+            Maximum spherical harmonic degree for truncation. If None, no truncation is applied.
+        lat_range: tuple[float, float]
+            Latitude range (min, max) to include in PSD calculation. Default is (-60,
+            60) degrees.
+
+        Returns
+        -------
+        xr.DataArray
+            Power spectral density score (log-spectral MSE) averaged over aggregation dimensions.
+
+        """
+        if self._agg_dims is None:
+            raise ValueError("Cannot calculate PSD without aggregation dimensions.")
+        if len(self._agg_dims) != 1:
+            raise ValueError(
+                f"PSD expects exactly one spatial aggregation dimension, "
+                f"got agg_dims={self._agg_dims}."
+            )
+        spatial_dim = self._agg_dims[0]
+        if spatial_dim not in gt.dims:
+            raise ValueError(
+                f"Spatial dimension '{spatial_dim}' not found in dims {list(gt.dims)}."
+            )
+
+        # PSD requires a spatial dimension with lat/lon coords (e.g. "ipoint").
+        # If the aggregation dim is "sample" or "ens" (e.g. from score map pipeline),
+        # PSD is not applicable — return NaN gracefully.
+        if spatial_dim in ("sample", "ens"):
+            _logger.debug(
+                f"PSD: aggregation dim is '{spatial_dim}' (not spatial). Skipping."
+            )
+            return xr.DataArray(np.nan)
+
+        n_points = gt.sizes[spatial_dim]
+        nlat, lats, lons = self._get_psd_grid_info(gt, spatial_dim)
+
+        if psd_method == "fft" and (lats is None or lons is None):
+            raise ValueError(f"PSD method 'fft' requires lat/lon coords on '{spatial_dim}'.")
+
+        # Detect grid type once for the entire stream (avoid repeated detection per channel)
+        grid_type = None
+        if psd_method == "sht" and lats is not None and lons is not None:
+            grid_type = detect_grid_type(lats, lons, n_points)
+
+        psd_kwargs = dict(
+            lats=lats,
+            lons=lons,
+            nlat=nlat,
+            n_points=n_points,
+            psd_method=psd_method,
+            psd_regrid_resolution=psd_regrid_resolution,
+            psd_sht_truncation=psd_sht_truncation,
+            lat_range=lat_range,
+            grid_type=grid_type,
+        )
+
+        # Dims to preserve (e.g. channel) vs batch dims (sample, ens)
+        other_dims = [d for d in gt.dims if d != spatial_dim]
+        preserve_dims = [d for d in other_dims if d not in ("sample", "ens")]
+
+        if not preserve_dims:
+            gt_np, p_np = self._stack_for_psd(gt, p, spatial_dim, n_points)
+            slice_score, slice_attrs = compute_psd_score(gt=gt_np, p=p_np, **psd_kwargs)
+            score = xr.DataArray(slice_score)
+            score.attrs.update(slice_attrs)
+            score.attrs["psd_method"] = psd_method
+            return score
+
+        # Iterate over preserved dims (typically per channel)
+        shape = tuple(gt.sizes[d] for d in preserve_dims)
+        score_values = np.empty(shape)
+        all_attrs: dict = {}
+
+        for idx in np.ndindex(*shape):
+            sel = dict(zip(preserve_dims, idx, strict=False))
+            gt_slice = gt.isel(**sel)
+            p_slice = p.isel(**sel)
+            gt_np, p_np = self._stack_for_psd(gt_slice, p_slice, spatial_dim, n_points)
+
+            slice_score, slice_attrs = compute_psd_score(gt=gt_np, p=p_np, **psd_kwargs)
+            score_values[idx] = slice_score
+
+            key = "_".join(
+                str(gt.coords[d].values[i]) if d in gt.coords else str(i) for d, i in sel.items()
+            )
+            for k, v in slice_attrs.items():
+                all_attrs[f"{key}/{k}"] = v
+
+        coords = {d: gt.coords[d] for d in preserve_dims if d in gt.coords}
+        score = xr.DataArray(score_values, dims=preserve_dims, coords=coords)
+        all_attrs["psd_method"] = psd_method
+        all_attrs["preserve_dims"] = preserve_dims
+        score.attrs.update(all_attrs)
+        return score
+
+    @staticmethod
+    def _get_psd_grid_info(
+        gt: xr.DataArray, spatial_dim: str
+    ) -> tuple[int | None, np.typing.NDArray | None, np.typing.NDArray | None]:
+        """
+        Extract nlat, lats, lons from ground-truth coords.
+
+        Parameters
+        ----------
+        gt: xr.DataArray
+            Ground truth data array with lat/lon coordinates.
+        spatial_dim: str
+            Name of the spatial dimension along which to compute the PSD.
+        Returns
+        -------
+        nlat: int | None
+            Number of latitude points, or None if lat/lon coords are not found.
+        lats: np.typing.NDArray | None
+            Latitude values, or None if lat/lon coords are not found.
+        lons: np.typing.NDArray | None
+            Longitude values, or None if lat/lon coords are not found.
+
+        """
+        if "lat" in gt.coords and "lon" in gt.coords:
+            if gt.coords["lat"].dims == (spatial_dim,) and gt.coords["lon"].dims == (spatial_dim,):
+                lats = gt.coords["lat"].values
+                lons = gt.coords["lon"].values
+                return len(np.unique(lats)), lats, lons
+        raise ValueError(f"PSD requires lat/lon coords on spatial dimension '{spatial_dim}'.")
+
+    @staticmethod
+    def _stack_for_psd(
+        gt: xr.DataArray, p: xr.DataArray, spatial_dim: str, n_points: int
+    ) -> tuple[np.typing.NDArray, np.typing.NDArray]:
+        """
+        Reshape data to (n_batch, n_points) for PSD computation.
+
+        Parameters
+        ----------
+        gt: xr.DataArray
+            Ground truth data array.
+        p: xr.DataArray
+            Forecast data array.
+        spatial_dim: str
+            Name of the spatial dimension along which to compute the PSD.
+        n_points: int
+            Number of points along the spatial dimension.
+        Returns
+        -------
+        gt_np: np.typing.NDArray
+            Reshaped ground truth data of shape (n_batch, n_points).
+        p_np: np.typing.NDArray
+            Reshaped forecast data of shape (n_batch, n_points).
+        """
+        non_spatial = [d for d in gt.dims if d != spatial_dim]
+        if non_spatial:
+            gt_np = gt.transpose(*non_spatial, spatial_dim).values.reshape(-1, n_points)
+            p_np = p.transpose(
+                *[d for d in p.dims if d != spatial_dim], spatial_dim
+            ).values.reshape(-1, n_points)
+        else:
+            gt_np = gt.values.reshape(1, -1)
+            p_np = p.values.reshape(1, -1)
+        return gt_np, p_np

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -16,8 +16,8 @@ import pandas as pd
 import xarray as xr
 from scipy.spatial import cKDTree
 
-from weathergen.evaluate.scores.score_utils import to_list
 from weathergen.evaluate.scores.psd import compute_psd_score, detect_grid_type
+from weathergen.evaluate.scores.score_utils import to_list
 
 # from common.io import MockIO
 
@@ -1864,9 +1864,7 @@ class Scores:
         # If the aggregation dim is "sample" or "ens" (e.g. from score map pipeline),
         # PSD is not applicable — return NaN gracefully.
         if spatial_dim in ("sample", "ens"):
-            _logger.debug(
-                f"PSD: aggregation dim is '{spatial_dim}' (not spatial). Skipping."
-            )
+            _logger.debug(f"PSD: aggregation dim is '{spatial_dim}' (not spatial). Skipping.")
             return xr.DataArray(np.nan)
 
         n_points = gt.sizes[spatial_dim]


### PR DESCRIPTION
## Description

`calc_psd` was removed from `iluise/develop/power_spectra` before merging this ends up raising an error for `psd`:

```
ValueError: Unknown score chosen. Supported scores: ets, pss, fbi, mae, l1, l2, mse, rmse, vrmse, bias, acc, rps, rpss, froct, troct, fact, tact, grad_amplitude, psnr, seeps, qq_analysis, nse, ssr, crps, rank_histogram, spread
````

## Issue Number

Closes #2573


## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
