### PR TITLE
Coarsens FSDP sharding granularity from individual leaf modules 

### DIFF
--- a/src/weathergen/model/model_interface.py
+++ b/src/weathergen/model/model_interface.py
@@ -41,6 +41,22 @@ logger = logging.getLogger(__name__)
 type TrainingMode = str
 
 
+def _get_transformer_blocks(module):
+    """
+    Return the top-level transformer blocks (each containing one attention + one MLP)
+    """
+    blocks = []
+    for child in module.children():
+        has_attn = any(isinstance(m, (MultiSelfAttentionHeadLocal,
+                                      MultiSelfAttentionHead,
+                                      MultiCrossAttentionHeadVarlen,
+                                      MultiCrossAttentionHeadVarlenSlicedQ,
+                                      MultiSelfAttentionHeadVarlen)) for m in child.modules())
+        has_mlp  = any(isinstance(m, MLP) for m in child.modules())
+        if has_attn and has_mlp:
+            blocks.append(child)
+    return blocks
+
 def init_model_and_shard(
     cf,
     dataset,
@@ -89,37 +105,24 @@ def init_model_and_shard(
                 else None
             ),
         }
-        modules_to_shard = (
-            MLP,
-            MultiSelfAttentionHeadLocal,
-            MultiSelfAttentionHead,
-            MultiCrossAttentionHeadVarlen,
-            MultiCrossAttentionHeadVarlenSlicedQ,
-            MultiSelfAttentionHeadVarlen,
-        )
+        
+        for block in _get_transformer_blocks(model.encoder.ae_local_engine.ae_local_blocks):
+            fully_shard(block, reshard_after_forward=False, **fsdp_kwargs)
 
-        for module in model.encoder.ae_local_engine.ae_local_blocks.modules():
-            if isinstance(module, modules_to_shard):
-                fully_shard(module, **fsdp_kwargs)
+        for block in _get_transformer_blocks(model.encoder.ae_local_global_engine.ae_adapter):
+            fully_shard(block, reshard_after_forward=False, **fsdp_kwargs)        
 
-        for module in model.encoder.ae_local_global_engine.ae_adapter.modules():
-            if isinstance(module, modules_to_shard):
-                fully_shard(module, **fsdp_kwargs)
+        for block in _get_transformer_blocks(model.encoder.ae_global_engine.ae_global_blocks):
+            fully_shard(block, **fsdp_kwargs)
 
-        for module in model.encoder.ae_global_engine.ae_global_blocks.modules():
-            if isinstance(module, modules_to_shard):
-                fully_shard(module, **fsdp_kwargs)
+        for block in _get_transformer_blocks(model.forecast_engine.fe_blocks):
+            fully_shard(block, reshard_after_forward=False, **fsdp_kwargs)
 
-        for module in model.forecast_engine.fe_blocks.modules():
-            if isinstance(module, modules_to_shard):
-                # reshard_after_forward=False keeps FE parameters unsharded
-                # during the multi-step rollout loop.
-                # Needed for pushforward trick.
-                fully_shard(module, reshard_after_forward=False, **fsdp_kwargs)
+        for block in _get_transformer_blocks(model.latent_heads):
+            fully_shard(block, **fsdp_kwargs)
 
-        for module in model.latent_heads.modules():
-            if isinstance(module, modules_to_shard):
-                fully_shard(module, **fsdp_kwargs)
+        for block in _get_transformer_blocks(model.target_token_engines):
+            fully_shard(block, **full_precision_fsdp_kwargs)
 
         full_precision_fsdp_kwargs = {
             "mp_policy": (
@@ -132,9 +135,8 @@ def init_model_and_shard(
             ),
         }
 
-        for module in model.target_token_engines.modules():
-            if isinstance(module, modules_to_shard):
-                fully_shard(module, **full_precision_fsdp_kwargs)
+        for block in _get_transformer_blocks(model.target_token_engines):
+            fully_shard(block, **full_precision_fsdp_kwargs)
 
     if with_ddp and with_fsdp:
         fully_shard(model)

--- a/src/weathergen/model/model_interface.py
+++ b/src/weathergen/model/model_interface.py
@@ -121,9 +121,6 @@ def init_model_and_shard(
         for block in _get_transformer_blocks(model.latent_heads):
             fully_shard(block, **fsdp_kwargs)
 
-        for block in _get_transformer_blocks(model.target_token_engines):
-            fully_shard(block, **full_precision_fsdp_kwargs)
-
         full_precision_fsdp_kwargs = {
             "mp_policy": (
                 MixedPrecisionPolicy(

--- a/src/weathergen/model/model_interface.py
+++ b/src/weathergen/model/model_interface.py
@@ -46,16 +46,22 @@ def _get_transformer_blocks(module):
     Return the top-level transformer blocks (each containing one attention + one MLP)
     """
     blocks = []
+    attention_types = (
+        MultiSelfAttentionHeadLocal
+        | MultiSelfAttentionHead
+        | MultiCrossAttentionHeadVarlen
+        | MultiCrossAttentionHeadVarlenSlicedQ
+        | MultiSelfAttentionHeadVarlen
+    )
+
     for child in module.children():
-        has_attn = any(isinstance(m, (MultiSelfAttentionHeadLocal,
-                                      MultiSelfAttentionHead,
-                                      MultiCrossAttentionHeadVarlen,
-                                      MultiCrossAttentionHeadVarlenSlicedQ,
-                                      MultiSelfAttentionHeadVarlen)) for m in child.modules())
-        has_mlp  = any(isinstance(m, MLP) for m in child.modules())
+        has_attn = any(isinstance(m, attention_types) for m in child.modules())
+        has_mlp = any(isinstance(m, MLP) for m in child.modules())
         if has_attn and has_mlp:
             blocks.append(child)
+
     return blocks
+
 
 def init_model_and_shard(
     cf,
@@ -105,12 +111,12 @@ def init_model_and_shard(
                 else None
             ),
         }
-        
+
         for block in _get_transformer_blocks(model.encoder.ae_local_engine.ae_local_blocks):
             fully_shard(block, reshard_after_forward=False, **fsdp_kwargs)
 
         for block in _get_transformer_blocks(model.encoder.ae_local_global_engine.ae_adapter):
-            fully_shard(block, reshard_after_forward=False, **fsdp_kwargs)        
+            fully_shard(block, reshard_after_forward=False, **fsdp_kwargs)
 
         for block in _get_transformer_blocks(model.encoder.ae_global_engine.ae_global_blocks):
             fully_shard(block, **fsdp_kwargs)


### PR DESCRIPTION
## Description
Coarsens FSDP sharding granularity from individual leaf modules (each `MLP` and attention head sharded independently) to transformer-block level (one shard unit per block containing both attention + MLP together). 

Introduce `_get_transformer_blocks()` which identifies the top-level block containers (each holding one attention + one MLP) and shards at that level instead of at the leaf. This reduces AllGather.


```
../WeatherGenerator-private/hpc/launch-slurm.py --time 120 --nodes=8 --base-config ./config/config_operan_georing_avhrr_forecasting_lowres.yml
```



#### Performance comparison

| Nodes | Baseline branch | Baseline Run ID | Baseline ingested samples per GPU | Block-sharding branch | Block-sharding Run ID | Block-sharding ingested samples per GPU | Delta | Relative change |
|---:|---|---|---:|---|---|---:|---:|---:|
| 1 | `develop` | `s9gadozy` | 1614 | `javad/dev/fsdp-block-sharding` | `zdlbz67g` | 1654 | +40 | +2.5% |
| 2 | `develop` | `t9ayt5hv` | 1294 | `javad/dev/fsdp-block-sharding` | `y3cd99cq` | 1344 | +50 | +3.9% |
| 4 | `develop` | `wc4ctyxn` | 1054 | `javad/dev/fsdp-block-sharding` | `nvwx932d` | 1174 | +120 | +11.4% |
| 8 | `develop` | `k7y45sh4` | 730 | `javad/dev/fsdp-block-sharding` | `uzfp92f8` | 760 | 30 | +3.9% |



#### Peak memory comparison

| Nodes | Baseline branch | Baseline Run ID | Baseline Peak memory | Block-sharding branch | Block-sharding Run ID | Block-sharding Peak memory | Delta | Relative change |
|---:|---|---|---:|---|---|---:|---:|---:|
| 8 | `develop` | `keqs8sy1` | 59.2 | `javad/dev/fsdp-block-sharding` | `yh78zym1` |67.8 | 8.6 | +14 |




<!--
Provide a brief summary of the changes introduced in this pull request.


Change the title of the PR to a short sentence easy to understand:

[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number

<!--
Link the Issue number this change addresses:
Closes #2579 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
