### PR TITLE
Support per-stream reconstruct:false 

### DIFF
--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -40,7 +40,7 @@ from weathergen.model.engines import (
 from weathergen.model.layers import MLP, NamedLinear
 from weathergen.model.utils import get_num_parameters
 from weathergen.utils.distributed import is_root
-from weathergen.utils.utils import get_dtype, is_stream_forcing
+from weathergen.utils.utils import get_dtype, is_stream_reconstructed
 
 logger = logging.getLogger(__name__)
 
@@ -419,8 +419,9 @@ class Model(torch.nn.Module):
             for i_stream, si in enumerate(cf.streams):
                 stream_name = self.stream_names[i_stream]
 
-                # skip decoder if channels are empty
-                if is_stream_forcing(si):
+                # skip decoder for streams that are not physically reconstructed
+                # (forcing/input-only, or explicit reconstruct: false -> JEPA-only target)
+                if not is_stream_reconstructed(si):
                     continue
 
                 # skip for the moment to ensure target embedding and tte exist (ordering of
@@ -515,8 +516,9 @@ class Model(torch.nn.Module):
             for i_stream, si in enumerate(cf.streams):
                 stream_name = self.stream_names[i_stream]
 
-                # skip decoder if channels are empty
-                if is_stream_forcing(si):
+                # skip decoder for streams that are not physically reconstructed
+                # (forcing/input-only, or explicit reconstruct: false -> JEPA-only target)
+                if not is_stream_reconstructed(si):
                     continue
 
                 pred_spatial_shared = si.get("pred_spatial_shared")
@@ -890,6 +892,12 @@ class Model(torch.nn.Module):
 
         # pair with tokens from assimilation engine to obtain target tokens
         for stream_name in self.stream_names:
+            # streams without a physical decoder (forcing, or reconstruct: false JEPA-only
+            # targets) have no embed_target_coords/target_token_engine. Skip them here even
+            # though they may still carry (unused) target coords on the student view.
+            if stream_name not in self.embed_target_coords:
+                continue
+
             # extract target coords for current stream and fstep and convert to one tensor
             t_coords = [
                 batch.samples[i_b].streams_data[stream_name].target_coords[step]

--- a/src/weathergen/utils/utils.py
+++ b/src/weathergen/utils/utils.py
@@ -49,6 +49,23 @@ def is_stream_forcing(stream_cfg: dict, stage: Stage | None = None) -> bool:
     return is_forcing
 
 
+def is_stream_reconstructed(stream_cfg: dict, stage: Stage | None = None) -> bool:
+    """
+    Determine if a stream is physically reconstructed, i.e. has a decoder and contributes
+    to the physical (decoder) reconstruction loss.
+
+    A stream is NOT reconstructed if it is forcing (input-only) or if it explicitly opts
+    out via ``reconstruct: false``. The latter lets a stream still serve as a
+    student-teacher (JEPA) target while having no physical decoder, so JEPA can be trained
+    on all streams while only a subset is reconstructed in physical space. Note that, unlike
+    forcing streams, ``reconstruct: false`` streams keep a normal (non-empty) target mask,
+    so the teacher still encodes them.
+    """
+    if is_stream_forcing(stream_cfg, stage):
+        return False
+    return stream_cfg.get("reconstruct", True)
+
+
 def is_stream_diagnostic(stream_cfg: dict, stage: Stage | None = None) -> bool:
     """
     Determine if stream is diagnostic, i.e. does not contribute to model input


### PR DESCRIPTION


(JEPA target without physical de……coder)

## Description

Add is_stream_reconstructed(stream_cfg): returns False for forcing streams, else honours a per-stream `reconstruct` flag (default True). A stream with `reconstruct: false` keeps a normal (non-empty) target mask so the EMA teacher still encodes it, but gets no physical decoder / TargetPredictionEngine.

The decoder-construction loops in model.py now skip a stream when `not is_stream_reconstructed(si)` instead of only when `is_stream_forcing(si)`, and the assimilation-token/target-token pairing loop skips streams absent from embed_target_coords (they have no decoder), preventing a lookup failure.

Cherry-picked from 5d709ed6; experiment-specific config changes excluded.