### PR TITLE
Gate latent/decoder prediction and FSDP sharding for fine-tuning

### DIFF
--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -779,10 +779,12 @@ class Model(torch.nn.Module):
 
             if self.forecast_engine:
                 tokens = self.forecast_engine(tokens, step, model_params.rope_coords)
-            # decoder predictions
-            output = self.predict_decoders(model_params, step, tokens, batch, output)
-            # latent predictions (raw and with SSL heads)
-            output = self.predict_latent(model_params, step, tokens, batch, output, intermediates)
+            if "masking" in self.cf.training_config.training_mode:
+                # decoder predictions
+                output = self.predict_decoders(model_params, step, tokens, batch, output)
+            if "student_teacher" in self.cf.training_config.training_mode:
+                # latent predictions (raw and with SSL heads)
+                output = self.predict_latent(model_params, step, tokens, batch, output, intermediates)
 
         return output
 

--- a/src/weathergen/model/model_interface.py
+++ b/src/weathergen/model/model_interface.py
@@ -40,6 +40,20 @@ logger = logging.getLogger(__name__)
 type TrainingMode = str
 
 
+def _has_trainable_params(module: torch.nn.Module) -> bool:
+    """True if the module has at least one parameter with requires_grad=True.
+
+    FSDP2 raises "RuntimeError: _chunk_cat expects non-empty tensor" in the
+    backward reduce-scatter (foreach_reduce) when a fully_shard group contains
+    only frozen parameters, since there are no gradients to reduce. This happens
+    during fine-tuning (e.g. forecast fine-tuning freezes the encoder and
+    latent_heads). Skipping fully_shard for fully-frozen modules leaves their
+    parameters in the root FSDP group, which still has trainable parameters, so
+    they remain sharded without triggering the empty-gradient reduce.
+    """
+    return any(p.requires_grad for p in module.parameters())
+
+
 def init_model_and_shard(
     cf,
     dataset,
@@ -96,36 +110,36 @@ def init_model_and_shard(
         )
 
         for module in model.encoder.ae_local_engine.ae_local_blocks.modules():
-            if isinstance(module, modules_to_shard):
+            if isinstance(module, modules_to_shard) and _has_trainable_params(module):
                 fully_shard(module, **fsdp_kwargs)
 
         for module in model.encoder.ae_local_global_engine.ae_adapter.modules():
-            if isinstance(module, modules_to_shard):
+            if isinstance(module, modules_to_shard) and _has_trainable_params(module):
                 fully_shard(module, **fsdp_kwargs)
 
         for module in model.encoder.ae_global_engine.ae_global_blocks.modules():
-            if isinstance(module, modules_to_shard):
+            if isinstance(module, modules_to_shard) and _has_trainable_params(module):
                 fully_shard(module, **fsdp_kwargs)
 
         for module in model.forecast_engine.fe_blocks.modules():
-            if isinstance(module, modules_to_shard):
+            if isinstance(module, modules_to_shard) and _has_trainable_params(module):
                 # reshard_after_forward=False keeps FE parameters unsharded
                 # during the multi-step rollout loop.
                 # Needed for pushforward trick.
                 fully_shard(module, reshard_after_forward=False, **fsdp_kwargs)
 
         for module in model.latent_heads.modules():
-            if isinstance(module, modules_to_shard):
+            if isinstance(module, modules_to_shard) and _has_trainable_params(module):
                 fully_shard(module, **fsdp_kwargs)
 
         if model.deep_ssl_fusion is not None:
             for module in model.deep_ssl_fusion.modules():
-                if isinstance(module, modules_to_shard):
+                if isinstance(module, modules_to_shard) and _has_trainable_params(module):
                     fully_shard(module, **fsdp_kwargs)
 
         if model.deep_ssl_level_projections is not None:
             for module in model.deep_ssl_level_projections.modules():
-                if isinstance(module, modules_to_shard):
+                if isinstance(module, modules_to_shard) and _has_trainable_params(module):
                     fully_shard(module, **fsdp_kwargs)
 
         full_precision_fsdp_kwargs = {
@@ -140,7 +154,7 @@ def init_model_and_shard(
         }
 
         for module in model.target_token_engines.modules():
-            if isinstance(module, modules_to_shard):
+            if isinstance(module, modules_to_shard) and _has_trainable_params(module):
                 fully_shard(module, **full_precision_fsdp_kwargs)
 
     if with_ddp and with_fsdp:

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -374,7 +374,7 @@ class Trainer(TrainerBase):
         )
 
         # Restore optimizer momentum buffers when continuing from a checkpoint
-        if run_id_contd is not None:
+        if run_id_contd is not None and self.cf.general.istep != 0:
             self._load_optimizer_state(run_id_contd, mini_epoch_contd)
 
         if self.cf.general.istep > 0 and is_root():


### PR DESCRIPTION
## Description

- Only run predict_decoders when 'masking' is in training_mode, and predict_latent when 'student_teacher' is in training_mode, so forecast-only fine-tuning no longer calls predict_latent (cherry-picked from ac535218).
- Skip fully_shard() on submodules with no trainable params, so FSDP2 does not raise "_chunk_cat expects a non-empty tensor" in backward when a shard group is fully frozen during fine-tuning (from ac535218).
- Skip restoring optimizer momentum buffers when istep == 0, so a checkpoint can be used as an initialization for fine-tuning without loading stale optimizer state (from 1a0b7213).

Config changes from the source commits are intentionally excluded.