### PR TITLE
Add cloud cover and radiation variables to config

### DIFF
--- a/config/evaluate/config_zarr2cf.yaml
+++ b/config/evaluate/config_zarr2cf.yaml
@@ -96,6 +96,48 @@ variables:
     wg_unit: m
     std_unit: m
     level_type: sfc
+   hcc:
+    var: hcc
+    long: high_cloud_cover
+    std: cloud_area_fraction_high
+    wg_unit: 1
+    std_unit: 1
+    level_type: sfc
+  mcc:
+    var: mcc
+    long: medium_cloud_cover
+    std: cloud_area_fraction_medium
+    wg_unit: 1
+    std_unit: 1
+    level_type: sfc
+  lcc:
+    var: lcc
+    long: low_cloud_cover
+    std: cloud_area_fraction_low
+    wg_unit: 1
+    std_unit: 1
+    level_type: sfc
+  tcc:
+    var: tcc
+    long: total_cloud_cover
+    std: cloud_area_fraction
+    wg_unit: 1
+    std_unit: 1
+    level_type: sfc
+  strd:
+    var: strd
+    long: surface_thermal_radiation_downwards
+    std: surface_downwelling_longwave_flux_in_air
+    wg_unit: J m**-2
+    std_unit: J m-2
+    level_type: sfc
+  ssrd:
+    var: ssrd
+    long: surface_solar_radiation_downwards
+    std: surface_downwelling_shortwave_flux_in_air
+    wg_unit: J m**-2
+    std_unit: J m-2
+    level_type: sfc
   
 
 coordinates:


### PR DESCRIPTION
add missing variables to export config to enable export of N320 data.

## Description

Add missing variables to enable export of N320 data to grib file.  


## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/2595

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
