### PR TITLE
avoid score computation when unnecessary and trigger json recompilation when config settings change 

### DIFF
--- a/docs/evaluate_config_reference.md
+++ b/docs/evaluate_config_reference.md
@@ -735,11 +735,23 @@ At runtime, the code checks whether a JSON file already exists for the requested
 combination. If it does, the stored scores are loaded; otherwise they are computed and
 saved for future use.
 
-> **Known limitation:** The cache does **not** check whether configuration parameters have
-> changed since the JSON was written. If you change anything that affects score values —
-> such as `rank`, `regrid` settings, metric thresholds, or the set of ensemble members —
-> you must **manually delete the relevant JSON files** to force recomputation. Stale cached
-> scores will otherwise be silently reused.
+### Cache invalidation
+
+The evaluation code automatically detects configuration changes and forces recomputation
+when necessary. Cached scores are **automatically invalidated** when any of the following
+change:
+
+**Configuration parameters:**
+- `regrid`, `ensemble`, `rank`, `agg_dims`, `derived_channels`, `forecast_steps`, `channels`, `sample`
+
+**Manual cache invalidation required:**
+The cache does **not** track changes to other parameters, so you must manually delete
+the relevant JSON files, e.g. if any of these change:
+- Metric parameters
+- Region definitions
+- Channel definitions
+- Climatology files
+- Underlying Zarr data content (without forecast step changes)
 
 ---
 

--- a/docs/evaluate_config_reference.md
+++ b/docs/evaluate_config_reference.md
@@ -738,18 +738,16 @@ saved for future use.
 ### Cache invalidation
 
 The evaluation code automatically detects configuration changes and forces recomputation
-when necessary. Cached scores are **automatically invalidated** when any of the following
+when necessary. Cached scores are **automatically recomputed** when any of the following
 change:
+- `regrid`, `ensemble`, `rank`, `agg_dims`,
 
-**Configuration parameters:**
-- `regrid`, `ensemble`, `rank`, `agg_dims`, `derived_channels`, `forecast_steps`, `channels`, `sample`
+They are **recomputed only for the missing values** when the following parameters change:
+- `derived_channels`, `forecast_steps`, `channels`, `sample`
 
 **Manual cache invalidation required:**
 The cache does **not** track changes to other parameters, so you must manually delete
 the relevant JSON files, e.g. if any of these change:
-- Metric parameters
-- Region definitions
-- Channel definitions
 - Climatology files
 - Underlying Zarr data content (without forecast step changes)
 

--- a/packages/evaluate/src/weathergen/evaluate/io/csv_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/csv_reader.py
@@ -84,6 +84,7 @@ class CsvReader(Reader):
         self.samples = [0]
         self.forecast_steps = sorted(self.data["step"].dropna().unique().tolist())
         self.epoch = [0]
+        self.ensemble = [0]
 
     def get_samples(self) -> set[int]:
         """
@@ -123,6 +124,10 @@ class CsvReader(Reader):
         """
         assert stream == self.stream, "streams do not match in CSVReader."
         return list(self.channels)  # Placeholder implementation
+
+    def get_ensemble(self, stream: str | None = None) -> list[str]:
+        """Get ensembles for a given stream."""
+        return self.ensemble  # Placeholder implementation
 
     def get_values(
         self, region: str, metric: str, forecast_steps: list[int], channels: list[str]

--- a/packages/evaluate/src/weathergen/evaluate/io/io_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/io_reader.py
@@ -129,6 +129,11 @@ class Reader(ABC):
             settings[key] = (
                 oc.OmegaConf.to_container(val, resolve=True) if oc.OmegaConf.is_config(val) else val
             )
+
+        # Store the source (zarr) forecast steps so the cache is invalidated
+        # when the underlying data changes (e.g. new rollout length).
+        settings["forecast_steps"] = sorted(int(f) for f in self.get_forecast_steps())
+
         return settings
 
     def get_stream(self, stream: str):
@@ -268,18 +273,20 @@ class Reader(ABC):
 
         for name in ["channel", "fstep", "sample", "ensemble"]:
             if requested[name] is None:
-                # Default to all in Zarr
-                requested[name] = reader_data[name]
-                # If file with metrics exists, must exactly match
-                if available_data is not None and reader_data[name] != available[name]:
-                    _logger.info(
-                        f"Requested all {name}s for {mode}, but previous config "
-                        "was a strict subset. Recomputation required."
-                    )
-                    check_score = False
+                # Default to all in Zarr (or to cached score coords if available)
+                if available_data is not None and available[name]:
+                    # Trust the cached score's coordinates (may include expanded
+                    # sub-steps beyond zarr base fsteps).  Validity is guaranteed
+                    # by the eval_settings check in load_single_score.
+                    requested[name] = available[name]
+                else:
+                    requested[name] = reader_data[name]
 
-            # Must be subset of Zarr
-            if not requested[name] <= reader_data[name]:
+            # Must be subset of source data (skip when validating a cached score,
+            # since scores may contain expanded sub-steps beyond zarr base fsteps)
+            if available_data is not None:
+                pass
+            elif not requested[name] <= reader_data[name]:
                 missing = requested[name] - reader_data[name]
 
                 # Special handling for ensemble mean

--- a/packages/evaluate/src/weathergen/evaluate/io/io_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/io_reader.py
@@ -88,6 +88,62 @@ class Reader(ABC):
         self.model_base_dir = eval_cfg.get("model_base_dir")
         self.results_base_dir = eval_cfg.get("results_base_dir")
 
+    def get_eval_settings(self, stream: str) -> dict:
+        """Extract evaluation settings that affect score computation for a stream.
+
+        These settings are saved into JSON score files so that cached scores can
+        be invalidated when settings change (e.g. regridding, ensemble selection,
+        rank files, aggregation dimensions).
+
+        Parameters
+        ----------
+        stream : str
+            The stream name.
+
+        Returns
+        -------
+        dict
+            A dictionary of plain Python types (JSON-serializable).  Only
+            non-default / non-empty values are included to keep the JSON compact
+            and avoid spurious mismatches.
+        """
+        import omegaconf as oc
+
+        stream_cfg = self.get_stream(stream)
+        settings: dict = {}
+
+        # Regridding
+        regrid = stream_cfg.get("regrid")
+        if regrid:
+            # Normalise to dict (bool True → default grid)
+            if isinstance(regrid, bool):
+                regrid = {"target_grid": [1.5, 1.5]}
+            settings["regrid"] = oc.OmegaConf.to_container(regrid, resolve=True) if oc.OmegaConf.is_config(regrid) else dict(regrid)
+
+        # Ensemble selection
+        ensemble_cfg = stream_cfg.get("evaluation", {}).get("ensemble")
+        if ensemble_cfg and ensemble_cfg != "all":
+            val = oc.OmegaConf.to_container(ensemble_cfg, resolve=True) if oc.OmegaConf.is_config(ensemble_cfg) else ensemble_cfg
+            settings["ensemble"] = val if isinstance(val, list) else str(val)
+
+        # Rank selection
+        rank_cfg = self.eval_cfg.get("rank")
+        if rank_cfg is not None and rank_cfg != "all":
+            val = oc.OmegaConf.to_container(rank_cfg, resolve=True) if oc.OmegaConf.is_config(rank_cfg) else rank_cfg
+            settings["rank"] = val if isinstance(val, list) else str(val)
+
+        # Aggregation dimensions (default is "ipoint")
+        agg_dims = self.eval_cfg.get("agg_dims")
+        if agg_dims and agg_dims != "ipoint":
+            settings["agg_dims"] = oc.OmegaConf.to_container(agg_dims, resolve=True) if oc.OmegaConf.is_config(agg_dims) else agg_dims
+
+        # Derived channels / z-scaling (if explicitly configured)
+        derived = stream_cfg.get("derived_channels")
+        if derived:
+            settings["derived_channels"] = oc.OmegaConf.to_container(derived, resolve=True) if oc.OmegaConf.is_config(derived) else derived
+
+        return settings
+
     def get_stream(self, stream: str):
         """
         returns the dictionary associated to a particular stream

--- a/packages/evaluate/src/weathergen/evaluate/io/io_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/io_reader.py
@@ -12,6 +12,7 @@ import logging
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+import omegaconf as oc
 
 # Third-party
 import xarray as xr
@@ -107,41 +108,28 @@ class Reader(ABC):
             non-default / non-empty values are included to keep the JSON compact
             and avoid spurious mismatches.
         """
-        import omegaconf as oc
-
         stream_cfg = self.get_stream(stream)
+
+        # Collect raw config values; skip falsy / default entries
+        entries = {
+            "regrid": stream_cfg.get("regrid"),
+            "ensemble": stream_cfg.get("evaluation", {}).get("ensemble"),
+            "rank": self.eval_cfg.get("rank"),
+            "agg_dims": self.eval_cfg.get("agg_dims"),
+            "derived_channels": stream_cfg.get("derived_channels"),
+        }
+        # Defaults that should not trigger cache invalidation
+        defaults = {"ensemble": "all", "rank": "all", "agg_dims": "ipoint"}
+
         settings: dict = {}
-
-        # Regridding
-        regrid = stream_cfg.get("regrid")
-        if regrid:
-            # Normalise to dict (bool True → default grid)
-            if isinstance(regrid, bool):
-                regrid = {"target_grid": [1.5, 1.5]}
-            settings["regrid"] = oc.OmegaConf.to_container(regrid, resolve=True) if oc.OmegaConf.is_config(regrid) else dict(regrid)
-
-        # Ensemble selection
-        ensemble_cfg = stream_cfg.get("evaluation", {}).get("ensemble")
-        if ensemble_cfg and ensemble_cfg != "all":
-            val = oc.OmegaConf.to_container(ensemble_cfg, resolve=True) if oc.OmegaConf.is_config(ensemble_cfg) else ensemble_cfg
-            settings["ensemble"] = val if isinstance(val, list) else str(val)
-
-        # Rank selection
-        rank_cfg = self.eval_cfg.get("rank")
-        if rank_cfg is not None and rank_cfg != "all":
-            val = oc.OmegaConf.to_container(rank_cfg, resolve=True) if oc.OmegaConf.is_config(rank_cfg) else rank_cfg
-            settings["rank"] = val if isinstance(val, list) else str(val)
-
-        # Aggregation dimensions (default is "ipoint")
-        agg_dims = self.eval_cfg.get("agg_dims")
-        if agg_dims and agg_dims != "ipoint":
-            settings["agg_dims"] = oc.OmegaConf.to_container(agg_dims, resolve=True) if oc.OmegaConf.is_config(agg_dims) else agg_dims
-
-        # Derived channels / z-scaling (if explicitly configured)
-        derived = stream_cfg.get("derived_channels")
-        if derived:
-            settings["derived_channels"] = oc.OmegaConf.to_container(derived, resolve=True) if oc.OmegaConf.is_config(derived) else derived
-
+        for key, val in entries.items():
+            if not val or val == defaults.get(key):
+                continue
+            settings[key] = (
+                oc.OmegaConf.to_container(val, resolve=True)
+                if oc.OmegaConf.is_config(val)
+                else val
+            )
         return settings
 
     def get_stream(self, stream: str):

--- a/packages/evaluate/src/weathergen/evaluate/io/io_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/io_reader.py
@@ -12,6 +12,7 @@ import logging
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+
 import omegaconf as oc
 
 # Third-party
@@ -126,9 +127,7 @@ class Reader(ABC):
             if not val or val == defaults.get(key):
                 continue
             settings[key] = (
-                oc.OmegaConf.to_container(val, resolve=True)
-                if oc.OmegaConf.is_config(val)
-                else val
+                oc.OmegaConf.to_container(val, resolve=True) if oc.OmegaConf.is_config(val) else val
             )
         return settings
 

--- a/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/wegen_reader.py
@@ -244,10 +244,14 @@ class WeatherGenReader(Reader):
         """
         Load a single pre-computed score for a given run, stream and metric.
 
+        Also checks that the stored ``eval_settings`` (regrid, rank, ensemble, etc.)
+        match the current configuration.  Returns None (forcing recomputation) if
+        settings have changed.
+
         Returns
         -------
         score: xr.DataArray or None
-            DataArray of the score if found, else None.
+            DataArray of the score if found and settings match, else None.
         """
         if parameters is None:
             parameters = {}
@@ -259,14 +263,34 @@ class WeatherGenReader(Reader):
 
         score = None
         if score_path.exists():
-            with open(score_path) as f:
-                data_dict = json.load(f)
-                if "scores" not in data_dict:
-                    data_dict = {"scores": [data_dict]}
-                for score_version in data_dict["scores"]:
-                    if score_version["attrs"] == parameters:
-                        score = xr.DataArray.from_dict(score_version)
-                        break
+            try:
+                with open(score_path) as f:
+                    data_dict = json.load(f)
+            except (json.JSONDecodeError, OSError) as exc:
+                _logger.warning(
+                    f"Corrupted or unreadable score file {score_path.name} "
+                    f"({type(exc).__name__}). Forcing recomputation."
+                )
+                return None
+
+            if "scores" not in data_dict:
+                data_dict = {"scores": [data_dict]}
+
+            # Check eval_settings match current config
+            stored_settings = data_dict.get("eval_settings", {})
+            current_settings = self.get_eval_settings(stream)
+            if stored_settings != current_settings:
+                _logger.info(
+                    f"Eval settings changed for {score_path.name}: "
+                    f"stored={stored_settings}, current={current_settings}. "
+                    f"Forcing recomputation."
+                )
+                return None
+
+            for score_version in data_dict["scores"]:
+                if score_version["attrs"] == parameters:
+                    score = xr.DataArray.from_dict(score_version)
+                    break
         return score
 
     def get_recomputable_metrics(self, metrics: dict) -> dict:

--- a/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
@@ -223,11 +223,27 @@ def _process_stream(
     needs_plotting = stream_dict.get("plotting") and type_ == "zarr"
     needs_scoring = stream_dict.get("evaluation", False)
 
-    output_data = None
-    if (needs_plotting or needs_scoring) and type_ == "zarr":
-        available_data = reader.check_availability(stream, mode="evaluation")
+    # --- Determine scoring state before loading any data ---
+    plot_score_maps = plot_score_options.get("plot_score_maps", False) and type_ == "zarr"
+    plot_score_init_time_series = (
+        plot_score_options.get("plot_score_init_time_series", False) and type_ == "zarr"
+    )
 
-        output_data = None
+    recomputable_metrics = {}
+    stream_loaded_scores: dict = {}
+    needs_score_recomputation = False
+
+    if needs_scoring:
+        stream_loaded_scores, recomputable_metrics = reader.load_scores(stream, regions, metrics)
+        needs_score_recomputation = bool(recomputable_metrics)
+
+    # Whether we need full evaluation data (all samples/fsteps)
+    needs_full_data = needs_score_recomputation or plot_score_maps or plot_score_init_time_series
+
+    # --- Load data only when necessary ---
+    output_data = None
+    if needs_full_data and type_ == "zarr":
+        available_data = reader.check_availability(stream, mode="evaluation")
         if available_data.score_availability:
             output_data = reader.get_data(
                 stream,
@@ -236,10 +252,9 @@ def _process_stream(
                 channels=available_data.channels,
                 ensemble=available_data.ensemble,
             )
-
             _logger.info(f"RUN {run_id} - {stream}: Data loaded successfully.")
 
-    # Plotting (pass pre-loaded data)
+    # Plotting: pass pre-loaded data if available, otherwise plot_data loads its own subset
     if needs_plotting:
         plot_data(reader, stream, global_plotting_opts, output_data=output_data)
 
@@ -247,12 +262,6 @@ def _process_stream(
     if not needs_scoring:
         return run_id, stream, {}, {}
 
-    plot_score_maps = plot_score_options.get("plot_score_maps", False) and type_ == "zarr"
-    plot_score_init_time_series = (
-        plot_score_options.get("plot_score_init_time_series", False) and type_ == "zarr"
-    )
-
-    stream_loaded_scores, recomputable_metrics = reader.load_scores(stream, regions, metrics)
     scores_dict = stream_loaded_scores
     if recomputable_metrics:
         metrics_to_compute = recomputable_metrics

--- a/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
@@ -235,8 +235,9 @@ def _process_stream(
 
     if needs_scoring:
         stream_loaded_scores, recomputable_metrics = reader.load_scores(stream, regions, metrics)
-        needs_score_recomputation = (plot_score_maps or plot_score_init_time_series or bool(recomputable_metrics))  and type_ == "zarr"
-
+        needs_score_recomputation = (
+            plot_score_maps or plot_score_init_time_series or bool(recomputable_metrics)
+        ) and type_ == "zarr"
 
     # --- Load data only when necessary ---
     output_data = None

--- a/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
+++ b/packages/evaluate/src/weathergen/evaluate/run_evaluation.py
@@ -235,14 +235,12 @@ def _process_stream(
 
     if needs_scoring:
         stream_loaded_scores, recomputable_metrics = reader.load_scores(stream, regions, metrics)
-        needs_score_recomputation = bool(recomputable_metrics)
+        needs_score_recomputation = (plot_score_maps or plot_score_init_time_series or bool(recomputable_metrics))  and type_ == "zarr"
 
-    # Whether we need full evaluation data (all samples/fsteps)
-    needs_full_data = needs_score_recomputation or plot_score_maps or plot_score_init_time_series
 
     # --- Load data only when necessary ---
     output_data = None
-    if needs_full_data and type_ == "zarr":
+    if needs_score_recomputation:
         available_data = reader.check_availability(stream, mode="evaluation")
         if available_data.score_availability:
             output_data = reader.get_data(

--- a/packages/evaluate/src/weathergen/evaluate/scores/score_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score_orchestration.py
@@ -465,6 +465,7 @@ def metric_list_to_json(
         Region names.
     """
     reader.metrics_dir.mkdir(parents=True, exist_ok=True)
+    eval_settings = reader.get_eval_settings(stream)
 
     for metric, metric_stream in metrics_dict.items():
         for region in regions:
@@ -481,6 +482,10 @@ def metric_list_to_json(
                         data_dict = json.load(f)
                     if "scores" not in data_dict:
                         data_dict = {"scores": [data_dict]}
+
+                    # Update eval_settings to current values
+                    data_dict["eval_settings"] = eval_settings
+
                     scores = data_dict.get("scores")
                     for i, existing_score in enumerate(scores):
                         if existing_score["attrs"] == metric_data.attrs:
@@ -492,7 +497,7 @@ def metric_list_to_json(
                         _logger.debug(f"Appending results to {save_path}")
                 else:
                     _logger.debug(f"Saving results to new file {save_path}")
-                    data_dict = {"scores": [metric_data_dict]}
+                    data_dict = {"eval_settings": eval_settings, "scores": [metric_data_dict]}
 
                 with open(save_path, "w") as f:
                     json.dump(data_dict, f, indent=4)


### PR DESCRIPTION
## Description

Add a dictionary to the json file to store the following fields:

- rank
- ensemble
- regrid
- agg_dims
- derived_channels
- forecast_steps (this refers to the forecast "windows" not the substeps.) -> this is useful to avoid recomputation in case of outputs with substeps. 

the score computation is triggered when one of these settings is different wrt to the json. 
A warning is displayed to announce it. 

Also, the json loading was triggered only after the dat loading, which was suboptimal, so it has not been moved before the data loading part and only the necessary data are loaded. 

## Issue Number

Closes https://github.com/ecmwf/WeatherGenerator/issues/2582
Closes https://github.com/ecmwf/WeatherGenerator/issues/2218

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
