### PR TITLE
re-enable q cells in ema

### DIFF
--- a/src/weathergen/model/ema.py
+++ b/src/weathergen/model/ema.py
@@ -70,11 +70,8 @@ class EMAModel:
         ema_params = []
         src_params = []
         for name, p_ema in self.ema_model.named_parameters():
-            if "identity" in name.lower() or "q_cells" in name.lower():
-                continue
             p_src = self._resolve_src_param(name)
             if p_src is None:
-                # EMA-only param or intentionally excluded
                 raise AssertionError(
                     f"{name}: All parameters of the EMA model must be in the base model."
                 )


### PR DESCRIPTION
## Description

Re-enable q_cells included in the EMA calculation in ema.py. These were previously excluded due to code breaking -- however now with no FSDP it works for me on santis across 2 nodes.


## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
