### PR TITLE
Remove filtering of q_cells and identity in ema calculation

### DIFF
--- a/src/weathergen/model/ema.py
+++ b/src/weathergen/model/ema.py
@@ -95,10 +95,7 @@ class EMAModel:
             # Due to DDP only being applied only to the student the names may missmatch
             # Thus, we check for the alternate naming scheme
             p_src = self.src_params.get("module." + name, None) if p_src is None else p_src
-            if "identity" in name.lower() or "q_cells" in name.lower():
-                continue
             if p_src is None:
-                # EMA-only param or intentionally excluded
                 assert False, f"{name}: All parameters of the EMA model must be in the base model."
 
             p_ema.lerp_(p_src, 1.0 - beta)


### PR DESCRIPTION
Removed condition to skip parameters containing 'identity' or 'q_cells' in ema calculation. 

Only tested for JEPA without FSDP, not tested in any other contexts.

## Description

See above.


## Issue Number

Closes #2601 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ x My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
