### PR TITLE
Correct latent target to correspond to input streams

### DIFF
--- a/config/streams/era5_georing_avhrr_synop_lowres/avhrr.yml
+++ b/config/streams/era5_georing_avhrr_synop_lowres/avhrr.yml
@@ -18,7 +18,7 @@ METOP_ABC_AVHRR_IASI :
   #     masking_strategy_config :
   #       rate: 1.0
   token_size : 512 # 256
-  forcing: True
+  # forcing: True
   embed : 
     net : transformer
     num_tokens : 1

--- a/config/streams/era5_georing_avhrr_synop_lowres/era5.yml
+++ b/config/streams/era5_georing_avhrr_synop_lowres/era5.yml
@@ -24,7 +24,7 @@ ERA5_in :
   token_size : 8 # 512
   tokenize_spacetime : True
   max_num_targets: -1
-  forcing: True
+  # forcing: True
   frequency : 06:00:00
   nominal_time_mapping :
     "0" : 5

--- a/config/streams/era5_georing_avhrr_synop_lowres/era5_out.yml
+++ b/config/streams/era5_georing_avhrr_synop_lowres/era5_out.yml
@@ -1,117 +1,117 @@
-# (C) Copyright 2024 WeatherGenerator contributors.
-#
-# This software is licensed under the terms of the Apache Licence Version 2.0
-# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-#
-# In applying this licence, ECMWF does not waive the privileges and immunities
-# granted to it by virtue of its status as an intergovernmental organisation
-# nor does it submit to any jurisdiction.
+# # (C) Copyright 2024 WeatherGenerator contributors.
+# #
+# # This software is licensed under the terms of the Apache Licence Version 2.0
+# # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# #
+# # In applying this licence, ECMWF does not waive the privileges and immunities
+# # granted to it by virtue of its status as an intergovernmental organisation
+# # nor does it submit to any jurisdiction.
 
-ERA5 :
-  type : anemoi
-  filenames : ['aifs-ea-an-oper-0001-mars-o96-1979-2024-1h-v3-with-era51.zarr']
-  # filenames : ['aifs-ea-an-oper-0001-mars-n320-1979-2023-1h-v1-with-ERA51.zarr']
-  stream_id : 1
-  source : [ ]
-  target_exclude : ['z', 'w_10', 'w_50', 'w_100', 'w_150', 'w_200', 'w_250', 'w_300', 'w_400', 'w_500', 'w_600', 'w_700', 'w_850', 'w_925', 'w_1000', 'slor', 'sdor', 'tcw', 'cp', 'tp', 'q_50', 'q_100']
-  geoinfo_channels : ['z', 'lsm', 'slor', 'sdor', 'insolation', 'cos_local_time', 'sin_local_time', 'cos_julian_day', 'sin_julian_day']
-  loss_weight : 1.
-  location_weight : cosine_latitude
-  # masking_override :
-  #   target_input :
-  #     masking_strategy_config :
-  #       rate: 1.0
-  token_size : 8
-  tokenize_spacetime : True
-  max_num_targets: -1 # 131072
-  diagnostic: True
-  frequency : 06:00:00
-  embed : 
-    net : transformer
-    num_tokens : 1
-    num_heads : 4
-    dim_embed : 256
-    num_blocks : 2
-  embed_target_coords :
-    net : linear
-    dim_embed : 512
-  target_readout :
-    num_layers : 2
-    num_heads : 4
-  pred_head :
-    ens_size : 1
-    num_layers : 1
-  # channel_weights :
-  #   # q_10: 0.2
-  #   # q_50: 0.2
-  #   # q_100: 0.23
-  #   # q_150: 0.26
-  #   # q_200: 0.29
-  #   # q_250: 0.33
-  #   # q_300: 0.36
-  #   # q_400: 0.42
-  #   # q_500: 0.48
-  #   # q_600: 0.55
-  #   # q_700: 0.61
-  #   # q_850: 0.71
-  #   # q_925: 0.75
-  #   # q_1000: 0.8
-  #   t_10: 0.2
-  #   t_50: 0.2
-  #   t_100: 0.23
-  #   t_150: 0.26
-  #   t_200: 0.29
-  #   t_250: 0.33
-  #   t_300: 0.36
-  #   t_400: 0.42
-  #   t_500: 0.48
-  #   t_600: 0.55
-  #   t_700: 0.61
-  #   t_850: 1.0
-  #   t_925: 0.75
-  #   t_1000: 0.8
-  #   u_10: 0.2
-  #   u_50: 0.2
-  #   u_100: 0.23
-  #   u_150: 0.26
-  #   u_200: 0.29
-  #   u_250: 0.33
-  #   u_300: 0.36
-  #   u_400: 0.42
-  #   u_500: 0.48
-  #   u_600: 0.55
-  #   u_700: 0.61
-  #   u_850: 1.0
-  #   u_925: 0.75
-  #   u_1000: 0.8
-  #   v_10: 0.2
-  #   v_50: 0.2
-  #   v_100: 0.23
-  #   v_150: 0.26
-  #   v_200: 0.29
-  #   v_250: 0.33
-  #   v_300: 0.36
-  #   v_400: 0.42
-  #   v_500: 0.48
-  #   v_600: 0.55
-  #   v_700: 0.61
-  #   v_850: 1.0
-  #   v_925: 0.75
-  #   v_1000: 0.8
-  #   z_10: 0.2
-  #   z_50: 0.2
-  #   z_100: 0.23
-  #   z_150: 0.26
-  #   z_200: 0.29
-  #   z_250: 0.33
-  #   z_300: 0.36
-  #   z_400: 0.42
-  #   z_500: 1.0
-  #   z_600: 0.55
-  #   z_700: 0.61
-  #   z_850: 0.71
-  #   z_925: 0.75
-  #   z_1000: 0.8
-  #   2t : 2.0
-  #   10u : 2.0
-  #   10v : 2.0
+# ERA5 :
+#   type : anemoi
+#   filenames : ['aifs-ea-an-oper-0001-mars-o96-1979-2024-1h-v3-with-era51.zarr']
+#   # filenames : ['aifs-ea-an-oper-0001-mars-n320-1979-2023-1h-v1-with-ERA51.zarr']
+#   stream_id : 1
+#   source : [ ]
+#   target_exclude : ['z', 'w_10', 'w_50', 'w_100', 'w_150', 'w_200', 'w_250', 'w_300', 'w_400', 'w_500', 'w_600', 'w_700', 'w_850', 'w_925', 'w_1000', 'slor', 'sdor', 'tcw', 'cp', 'tp', 'q_50', 'q_100']
+#   geoinfo_channels : ['z', 'lsm', 'slor', 'sdor', 'insolation', 'cos_local_time', 'sin_local_time', 'cos_julian_day', 'sin_julian_day']
+#   loss_weight : 1.
+#   location_weight : cosine_latitude
+#   # masking_override :
+#   #   target_input :
+#   #     masking_strategy_config :
+#   #       rate: 1.0
+#   token_size : 8
+#   tokenize_spacetime : True
+#   max_num_targets: -1 # 131072
+#   diagnostic: True
+#   frequency : 06:00:00
+#   embed : 
+#     net : transformer
+#     num_tokens : 1
+#     num_heads : 4
+#     dim_embed : 256
+#     num_blocks : 2
+#   embed_target_coords :
+#     net : linear
+#     dim_embed : 512
+#   target_readout :
+#     num_layers : 2
+#     num_heads : 4
+#   pred_head :
+#     ens_size : 1
+#     num_layers : 1
+#   # channel_weights :
+#   #   # q_10: 0.2
+#   #   # q_50: 0.2
+#   #   # q_100: 0.23
+#   #   # q_150: 0.26
+#   #   # q_200: 0.29
+#   #   # q_250: 0.33
+#   #   # q_300: 0.36
+#   #   # q_400: 0.42
+#   #   # q_500: 0.48
+#   #   # q_600: 0.55
+#   #   # q_700: 0.61
+#   #   # q_850: 0.71
+#   #   # q_925: 0.75
+#   #   # q_1000: 0.8
+#   #   t_10: 0.2
+#   #   t_50: 0.2
+#   #   t_100: 0.23
+#   #   t_150: 0.26
+#   #   t_200: 0.29
+#   #   t_250: 0.33
+#   #   t_300: 0.36
+#   #   t_400: 0.42
+#   #   t_500: 0.48
+#   #   t_600: 0.55
+#   #   t_700: 0.61
+#   #   t_850: 1.0
+#   #   t_925: 0.75
+#   #   t_1000: 0.8
+#   #   u_10: 0.2
+#   #   u_50: 0.2
+#   #   u_100: 0.23
+#   #   u_150: 0.26
+#   #   u_200: 0.29
+#   #   u_250: 0.33
+#   #   u_300: 0.36
+#   #   u_400: 0.42
+#   #   u_500: 0.48
+#   #   u_600: 0.55
+#   #   u_700: 0.61
+#   #   u_850: 1.0
+#   #   u_925: 0.75
+#   #   u_1000: 0.8
+#   #   v_10: 0.2
+#   #   v_50: 0.2
+#   #   v_100: 0.23
+#   #   v_150: 0.26
+#   #   v_200: 0.29
+#   #   v_250: 0.33
+#   #   v_300: 0.36
+#   #   v_400: 0.42
+#   #   v_500: 0.48
+#   #   v_600: 0.55
+#   #   v_700: 0.61
+#   #   v_850: 1.0
+#   #   v_925: 0.75
+#   #   v_1000: 0.8
+#   #   z_10: 0.2
+#   #   z_50: 0.2
+#   #   z_100: 0.23
+#   #   z_150: 0.26
+#   #   z_200: 0.29
+#   #   z_250: 0.33
+#   #   z_300: 0.36
+#   #   z_400: 0.42
+#   #   z_500: 1.0
+#   #   z_600: 0.55
+#   #   z_700: 0.61
+#   #   z_850: 0.71
+#   #   z_925: 0.75
+#   #   z_1000: 0.8
+#   #   2t : 2.0
+#   #   10u : 2.0
+#   #   10v : 2.0

--- a/config/streams/era5_georing_avhrr_synop_lowres/geos.yml
+++ b/config/streams/era5_georing_avhrr_synop_lowres/geos.yml
@@ -22,7 +22,7 @@ METEOSAT_SEVIRI_IR :
   token_size : 1024
   tokenize_spacetime : False
   max_num_targets: 131072
-  forcing: True
+  # forcing: True
   embed : 
     net : transformer
     num_tokens : 1
@@ -55,7 +55,7 @@ GOES_ABI_IR :
   token_size : 1024
   tokenize_spacetime : False
   max_num_targets: 131072
-  forcing: True
+  # forcing: True
   embed : 
     net : transformer
     num_tokens : 1
@@ -88,7 +88,7 @@ HIMAWARI_AHI_IR :
   token_size : 1024
   tokenize_spacetime : False
   max_num_targets: 131072
-  forcing: True
+  # forcing: True
   embed : 
     net : transformer
     num_tokens : 1
@@ -122,7 +122,7 @@ GOES_ABI_VIS :
   token_size : 1024
   tokenize_spacetime : False
   max_num_targets: 131072
-  forcing: True
+  # forcing: True
   embed : 
     net : transformer
     num_tokens : 1
@@ -156,7 +156,7 @@ HIMAWARI_AHI_VIS :
   token_size : 1024
   tokenize_spacetime : False
   max_num_targets: 131072
-  forcing: True
+  # forcing: True
   embed :
     net : transformer
     num_tokens : 1

--- a/src/weathergen/model/diffusion.py
+++ b/src/weathergen/model/diffusion.py
@@ -268,11 +268,11 @@ class DiffusionForecastEngine(torch.nn.Module):
         if self.conditioning in ["date_time", "date", "time"]:
             c = meta_info["ERA5"].params["timestamp"]
         elif self.conditioning == "forecast":
-            c = meta_info["ERA5"].params["conditioning_tokens"]          # X_{t-1} as conditioning (model.py extracts last step as target, passes second-to-last here)
+            c = meta_info["LATENT_CONDITIONING_TOKENS"]         # X_{t-1} as conditioning (model.py extracts last step as target, passes second-to-last here)
 
         if self.training:
             noise_level_rn = torch.tensor(
-                [meta_info["ERA5"].params["noise_level_rn"]], device=tokens.device
+                [meta_info["ERA5_in"].params["noise_level_rn"]], device=tokens.device
             )
         else:
             # During validation, use fixed noise level (default: 0.0)

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -732,7 +732,7 @@ class Model(torch.nn.Module):
                 if np.random.rand() < self.cf.get("fe_diffusion_classifier_free_guidance_prob", 0.0):  # occasionally dropout conditioning for classifier free guidance
                     conditioning_tokens = torch.zeros_like(conditioning_tokens)
             # X_t (tokens[:, 0], most recent) is the diffusion denoising target; older steps are conditioning.
-            batch.samples[0].meta_info["ERA5"].params["conditioning_tokens"] = conditioning_tokens
+            batch.samples[0].meta_info["LATENT_CONDITIONING_TOKENS"] = conditioning_tokens
             # self.forecast_engine._pending_target_tokens = diffusion_target_tokens
             tokens = tokens[:, 0]
         else:

--- a/src/weathergen/train/target_and_aux_diffusion.py
+++ b/src/weathergen/train/target_and_aux_diffusion.py
@@ -60,7 +60,7 @@ class DiffusionLatentTargetEncoder(TargetAndAuxModuleBase):
         # so that sigma = exp(eta * p_std + p_mean) is deterministic
         if model.training:
             noise_level_rn = (
-                batch.samples[0].meta_info["ERA5"].params["noise_level_rn"]
+                batch.samples[0].meta_info["ERA5_in"].params["noise_level_rn"]
             )  # TODO: adjust for multiple streams
         else:
             noise_level_rn = self._fixed_noise_level if self._fixed_noise_level is not None else 0.0


### PR DESCRIPTION
During diffusion training with ERA5+obs, our latent target corresponded to our physical target (ERA5). This is because all other input streams were set strictly to `forcing: True` and hence not encoded by the TargetAuxCalculator. 
To fix this we remove `forcing: True` from each input stream. 
While we have 2 timestamps in the input (for conditioning and for noising), `target_input.forecasting.num_steps_input: 1` makes sure only a single timestep is encoded in the TargetAuxCalculator. 
Latent conditioning is now generally encoded on same level as streams in `batch.samples[0].meta_info["LATENT_CONDITIONING_TOKENS"] = conditioning_tokens` in model.py.
`noise_level_rn` is extracted from `ERA5_in` - we might want to remove the stream dependency in future, I opened an issue for that: #2605 

Our physical target `era5_out` is currently commented out. I will look into bringing it back with the reconstruction flag as implemented here: [Support per-stream reconstruct:false by sophie-xhonneux · Pull Request #2592 · ecmwf/WeatherGenerato…](https://github.com/ecmwf/WeatherGenerator/pull/2592/changes)

## Description

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
