### PR TITLE
Stream reconstruct flag for physical decoder handling

### DIFF
--- a/config/config_diffusion_d2048_forecast.yml
+++ b/config/config_diffusion_d2048_forecast.yml
@@ -254,14 +254,14 @@ training_config:
       eps : 2e-08
 
   losses : {
-    # "physical": {
-    #     type: LossPhysical,
-    #     weight: 0.0,
-    #     loss_fcts: {
-    #       "mse": {},
-    #     },
-    #     target_and_aux_calc: "Physical",
-    # },
+    "physical": {
+        type: LossPhysical,
+        weight: 0.0,
+        loss_fcts: {
+          "mse": {},
+        },
+        target_and_aux_calc: "Physical",
+    },
     "latent_diff": {
         type: LossLatentDiffusion,
         weight: 1.0,

--- a/config/streams/era5_georing_avhrr_synop_lowres/avhrr.yml
+++ b/config/streams/era5_georing_avhrr_synop_lowres/avhrr.yml
@@ -19,6 +19,7 @@ METOP_ABC_AVHRR_IASI :
   #       rate: 1.0
   token_size : 512 # 256
   # forcing: True
+  reconstruct: False
   embed : 
     net : transformer
     num_tokens : 1

--- a/config/streams/era5_georing_avhrr_synop_lowres/era5.yml
+++ b/config/streams/era5_georing_avhrr_synop_lowres/era5.yml
@@ -25,6 +25,7 @@ ERA5_in :
   tokenize_spacetime : True
   max_num_targets: -1
   # forcing: True
+  reconstruct: False
   frequency : 06:00:00
   nominal_time_mapping :
     "0" : 5

--- a/config/streams/era5_georing_avhrr_synop_lowres/era5_out.yml
+++ b/config/streams/era5_georing_avhrr_synop_lowres/era5_out.yml
@@ -1,117 +1,117 @@
-# # (C) Copyright 2024 WeatherGenerator contributors.
-# #
-# # This software is licensed under the terms of the Apache Licence Version 2.0
-# # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-# #
-# # In applying this licence, ECMWF does not waive the privileges and immunities
-# # granted to it by virtue of its status as an intergovernmental organisation
-# # nor does it submit to any jurisdiction.
+# (C) Copyright 2024 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
 
-# ERA5 :
-#   type : anemoi
-#   filenames : ['aifs-ea-an-oper-0001-mars-o96-1979-2024-1h-v3-with-era51.zarr']
-#   # filenames : ['aifs-ea-an-oper-0001-mars-n320-1979-2023-1h-v1-with-ERA51.zarr']
-#   stream_id : 1
-#   source : [ ]
-#   target_exclude : ['z', 'w_10', 'w_50', 'w_100', 'w_150', 'w_200', 'w_250', 'w_300', 'w_400', 'w_500', 'w_600', 'w_700', 'w_850', 'w_925', 'w_1000', 'slor', 'sdor', 'tcw', 'cp', 'tp', 'q_50', 'q_100']
-#   geoinfo_channels : ['z', 'lsm', 'slor', 'sdor', 'insolation', 'cos_local_time', 'sin_local_time', 'cos_julian_day', 'sin_julian_day']
-#   loss_weight : 1.
-#   location_weight : cosine_latitude
-#   # masking_override :
-#   #   target_input :
-#   #     masking_strategy_config :
-#   #       rate: 1.0
-#   token_size : 8
-#   tokenize_spacetime : True
-#   max_num_targets: -1 # 131072
-#   diagnostic: True
-#   frequency : 06:00:00
-#   embed : 
-#     net : transformer
-#     num_tokens : 1
-#     num_heads : 4
-#     dim_embed : 256
-#     num_blocks : 2
-#   embed_target_coords :
-#     net : linear
-#     dim_embed : 512
-#   target_readout :
-#     num_layers : 2
-#     num_heads : 4
-#   pred_head :
-#     ens_size : 1
-#     num_layers : 1
-#   # channel_weights :
-#   #   # q_10: 0.2
-#   #   # q_50: 0.2
-#   #   # q_100: 0.23
-#   #   # q_150: 0.26
-#   #   # q_200: 0.29
-#   #   # q_250: 0.33
-#   #   # q_300: 0.36
-#   #   # q_400: 0.42
-#   #   # q_500: 0.48
-#   #   # q_600: 0.55
-#   #   # q_700: 0.61
-#   #   # q_850: 0.71
-#   #   # q_925: 0.75
-#   #   # q_1000: 0.8
-#   #   t_10: 0.2
-#   #   t_50: 0.2
-#   #   t_100: 0.23
-#   #   t_150: 0.26
-#   #   t_200: 0.29
-#   #   t_250: 0.33
-#   #   t_300: 0.36
-#   #   t_400: 0.42
-#   #   t_500: 0.48
-#   #   t_600: 0.55
-#   #   t_700: 0.61
-#   #   t_850: 1.0
-#   #   t_925: 0.75
-#   #   t_1000: 0.8
-#   #   u_10: 0.2
-#   #   u_50: 0.2
-#   #   u_100: 0.23
-#   #   u_150: 0.26
-#   #   u_200: 0.29
-#   #   u_250: 0.33
-#   #   u_300: 0.36
-#   #   u_400: 0.42
-#   #   u_500: 0.48
-#   #   u_600: 0.55
-#   #   u_700: 0.61
-#   #   u_850: 1.0
-#   #   u_925: 0.75
-#   #   u_1000: 0.8
-#   #   v_10: 0.2
-#   #   v_50: 0.2
-#   #   v_100: 0.23
-#   #   v_150: 0.26
-#   #   v_200: 0.29
-#   #   v_250: 0.33
-#   #   v_300: 0.36
-#   #   v_400: 0.42
-#   #   v_500: 0.48
-#   #   v_600: 0.55
-#   #   v_700: 0.61
-#   #   v_850: 1.0
-#   #   v_925: 0.75
-#   #   v_1000: 0.8
-#   #   z_10: 0.2
-#   #   z_50: 0.2
-#   #   z_100: 0.23
-#   #   z_150: 0.26
-#   #   z_200: 0.29
-#   #   z_250: 0.33
-#   #   z_300: 0.36
-#   #   z_400: 0.42
-#   #   z_500: 1.0
-#   #   z_600: 0.55
-#   #   z_700: 0.61
-#   #   z_850: 0.71
-#   #   z_925: 0.75
-#   #   z_1000: 0.8
-#   #   2t : 2.0
-#   #   10u : 2.0
-#   #   10v : 2.0
+ERA5 :
+  type : anemoi
+  filenames : ['aifs-ea-an-oper-0001-mars-o96-1979-2024-1h-v3-with-era51.zarr']
+  # filenames : ['aifs-ea-an-oper-0001-mars-n320-1979-2023-1h-v1-with-ERA51.zarr']
+  stream_id : 1
+  source : [ ]
+  target_exclude : ['z', 'w_10', 'w_50', 'w_100', 'w_150', 'w_200', 'w_250', 'w_300', 'w_400', 'w_500', 'w_600', 'w_700', 'w_850', 'w_925', 'w_1000', 'slor', 'sdor', 'tcw', 'cp', 'tp', 'q_50', 'q_100']
+  geoinfo_channels : ['z', 'lsm', 'slor', 'sdor', 'insolation', 'cos_local_time', 'sin_local_time', 'cos_julian_day', 'sin_julian_day']
+  loss_weight : 1.
+  location_weight : cosine_latitude
+  # masking_override :
+  #   target_input :
+  #     masking_strategy_config :
+  #       rate: 1.0
+  token_size : 8
+  tokenize_spacetime : True
+  max_num_targets: -1 # 131072
+  diagnostic: True
+  frequency : 06:00:00
+  embed : 
+    net : transformer
+    num_tokens : 1
+    num_heads : 4
+    dim_embed : 256
+    num_blocks : 2
+  embed_target_coords :
+    net : linear
+    dim_embed : 512
+  target_readout :
+    num_layers : 2
+    num_heads : 4
+  pred_head :
+    ens_size : 1
+    num_layers : 1
+  # channel_weights :
+  #   # q_10: 0.2
+  #   # q_50: 0.2
+  #   # q_100: 0.23
+  #   # q_150: 0.26
+  #   # q_200: 0.29
+  #   # q_250: 0.33
+  #   # q_300: 0.36
+  #   # q_400: 0.42
+  #   # q_500: 0.48
+  #   # q_600: 0.55
+  #   # q_700: 0.61
+  #   # q_850: 0.71
+  #   # q_925: 0.75
+  #   # q_1000: 0.8
+  #   t_10: 0.2
+  #   t_50: 0.2
+  #   t_100: 0.23
+  #   t_150: 0.26
+  #   t_200: 0.29
+  #   t_250: 0.33
+  #   t_300: 0.36
+  #   t_400: 0.42
+  #   t_500: 0.48
+  #   t_600: 0.55
+  #   t_700: 0.61
+  #   t_850: 1.0
+  #   t_925: 0.75
+  #   t_1000: 0.8
+  #   u_10: 0.2
+  #   u_50: 0.2
+  #   u_100: 0.23
+  #   u_150: 0.26
+  #   u_200: 0.29
+  #   u_250: 0.33
+  #   u_300: 0.36
+  #   u_400: 0.42
+  #   u_500: 0.48
+  #   u_600: 0.55
+  #   u_700: 0.61
+  #   u_850: 1.0
+  #   u_925: 0.75
+  #   u_1000: 0.8
+  #   v_10: 0.2
+  #   v_50: 0.2
+  #   v_100: 0.23
+  #   v_150: 0.26
+  #   v_200: 0.29
+  #   v_250: 0.33
+  #   v_300: 0.36
+  #   v_400: 0.42
+  #   v_500: 0.48
+  #   v_600: 0.55
+  #   v_700: 0.61
+  #   v_850: 1.0
+  #   v_925: 0.75
+  #   v_1000: 0.8
+  #   z_10: 0.2
+  #   z_50: 0.2
+  #   z_100: 0.23
+  #   z_150: 0.26
+  #   z_200: 0.29
+  #   z_250: 0.33
+  #   z_300: 0.36
+  #   z_400: 0.42
+  #   z_500: 1.0
+  #   z_600: 0.55
+  #   z_700: 0.61
+  #   z_850: 0.71
+  #   z_925: 0.75
+  #   z_1000: 0.8
+  #   2t : 2.0
+  #   10u : 2.0
+  #   10v : 2.0

--- a/config/streams/era5_georing_avhrr_synop_lowres/geos.yml
+++ b/config/streams/era5_georing_avhrr_synop_lowres/geos.yml
@@ -23,6 +23,7 @@ METEOSAT_SEVIRI_IR :
   tokenize_spacetime : False
   max_num_targets: 131072
   # forcing: True
+  reconstruct: False
   embed : 
     net : transformer
     num_tokens : 1
@@ -56,6 +57,7 @@ GOES_ABI_IR :
   tokenize_spacetime : False
   max_num_targets: 131072
   # forcing: True
+  reconstruct: False
   embed : 
     net : transformer
     num_tokens : 1
@@ -89,6 +91,7 @@ HIMAWARI_AHI_IR :
   tokenize_spacetime : False
   max_num_targets: 131072
   # forcing: True
+  reconstruct: False
   embed : 
     net : transformer
     num_tokens : 1
@@ -123,6 +126,7 @@ GOES_ABI_VIS :
   tokenize_spacetime : False
   max_num_targets: 131072
   # forcing: True
+  reconstruct: False
   embed : 
     net : transformer
     num_tokens : 1
@@ -157,6 +161,7 @@ HIMAWARI_AHI_VIS :
   tokenize_spacetime : False
   max_num_targets: 131072
   # forcing: True
+  reconstruct: False
   embed :
     net : transformer
     num_tokens : 1

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -42,7 +42,7 @@ from weathergen.model.engines import (
 from weathergen.model.layers import MLP, NamedLinear
 from weathergen.model.utils import get_num_parameters
 from weathergen.utils.distributed import is_root
-from weathergen.utils.utils import get_dtype, is_stream_forcing
+from weathergen.utils.utils import get_dtype, is_stream_forcing, is_stream_reconstructed
 
 logger = logging.getLogger(__name__)
 
@@ -423,6 +423,11 @@ class Model(torch.nn.Module):
                 if is_stream_forcing(si):
                     continue
 
+                # skip decoder for streams that are not physically reconstructed
+                # (forcing/input-only, or explicit reconstruct: false -> JEPA-only target)
+                if not is_stream_reconstructed(si):
+                    continue
+
                 # skip for the moment to ensure target embedding and tte exist (ordering of
                 # cf.streams is random)
                 if si.get("pred_spatial_shared") is None:
@@ -515,6 +520,11 @@ class Model(torch.nn.Module):
             for i_stream, (stream_name, si) in enumerate(self.streams.items()):
                 # skip decoder if channels are empty
                 if is_stream_forcing(si):
+                    continue
+
+                # skip decoder for streams that are not physically reconstructed
+                # (forcing/input-only, or explicit reconstruct: false -> JEPA-only target)
+                if not is_stream_reconstructed(si):
                     continue
 
                 pred_spatial_shared = si.get("pred_spatial_shared")
@@ -934,6 +944,12 @@ class Model(torch.nn.Module):
 
         # pair with tokens from assimilation engine to obtain target tokens
         for stream_name in self.streams.keys():
+            # streams without a physical decoder (forcing, or reconstruct: false JEPA-only
+            # targets) have no embed_target_coords/target_token_engine. Skip them here even
+            # though they may still carry (unused) target coords on the student view.
+            if stream_name not in self.embed_target_coords:
+                continue
+            
             # extract target coords for current stream and fstep and convert to one tensor
             # Use modular indexing so that ensemble calls (batch_size > len(batch)) replicate
             # the single real sample's coordinates across all N members.

--- a/src/weathergen/utils/utils.py
+++ b/src/weathergen/utils/utils.py
@@ -49,6 +49,23 @@ def is_stream_forcing(stream_cfg: dict, stage: Stage | None = None) -> bool:
     return is_forcing
 
 
+def is_stream_reconstructed(stream_cfg: dict, stage: Stage | None = None) -> bool:
+    """
+    Determine if a stream is physically reconstructed, i.e. has a decoder and contributes
+    to the physical (decoder) reconstruction loss.
+
+    A stream is NOT reconstructed if it is forcing (input-only) or if it explicitly opts
+    out via ``reconstruct: false``. The latter lets a stream still serve as a
+    student-teacher (JEPA) target while having no physical decoder, so JEPA can be trained
+    on all streams while only a subset is reconstructed in physical space. Note that, unlike
+    forcing streams, ``reconstruct: false`` streams keep a normal (non-empty) target mask,
+    so the teacher still encodes them.
+    """
+    if is_stream_forcing(stream_cfg, stage):
+        return False
+    return stream_cfg.get("reconstruct", True)
+
+
 def is_stream_diagnostic(stream_cfg: dict, stage: Stage | None = None) -> bool:
     """
     Determine if stream is diagnostic, i.e. does not contribute to model input


### PR DESCRIPTION
By setting `reconstruct: False`, we don't create a physical decoder. By this we avoid latent targets to be decoded (`forcing: True` doesn't work here, otherwise we cannot use these input streams as a latent target). 
Note: With `diagnostic: True`, streams are being decoded as physical targets, but are not used as latent targets.

## Description

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
