### PR TITLE
[1575][data] Raise clear error for existing Zarr outputs

### DIFF
--- a/packages/common/src/weathergen/common/io.py
+++ b/packages/common/src/weathergen/common/io.py
@@ -436,7 +436,12 @@ class ZarrIO:
     def _get_group(self, item: ItemKey, create: bool) -> zarr.Array | zarr.Group:
         assert self.data_root is not None, "ZarrIO must be opened before accessing data."
         if create:
-            assert self.data_root.get(item.path) is None, "Group already exists, stop overwriting"
+            if self.data_root.get(item.path) is not None:
+                msg = (
+                    f"Output item already exists at {self._store_path}:{item.path}; "
+                    "refusing to overwrite."
+                )
+                raise ValueError(msg)
             group = self.data_root.create_group(item.path)
         else:
             try:

--- a/packages/common/tests/test_io.py
+++ b/packages/common/tests/test_io.py
@@ -1,0 +1,23 @@
+# (C) Copyright 2026 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import pytest
+
+from weathergen.common.io import ItemKey, OutputItem, ZarrIO
+
+
+def test_write_zarr_rejects_existing_output_item(tmp_path):
+    key = ItemKey(sample=0, forecast_step=0, stream="ERA5")
+    item = OutputItem(key=key, forecast_offset=0)  # type: ignore[arg-type]
+
+    with ZarrIO(tmp_path / "output.zarr", read_only=False) as writer:
+        writer.write_zarr(item)
+
+        with pytest.raises(ValueError, match=r"0/ERA5/0.*refusing to overwrite"):
+            writer.write_zarr(item)


### PR DESCRIPTION
## Description

- replace the optimization-sensitive assertion for duplicate Zarr output items with an explicit `ValueError`
- include the store and item path in the error so users can identify the conflicting output
- add a regression test that writes the same output item twice and verifies overwrite prevention

## Issue Number

Fixes #1575

## Validation

- `PYTHONPATH=packages/common/src /tmp/wg-common-test/bin/pytest packages/common/tests/test_io.py -q` — 1 passed on Python 3.12
- `ruff format --target-version py312 --check packages/common/src/weathergen/common/io.py packages/common/tests/test_io.py`
- `ruff check --target-version py312 packages/common/src/weathergen/common/io.py packages/common/tests/test_io.py`
- `git diff --check`

The full workspace unit and integration suites were not run locally. Resolving the workspace environment attempted to download the GPU/flash-attn artifacts and failed because the runner did not have enough disk space; the focused common-package test above exercises the changed behavior directly.

## Checklist before asking for review

- [x] I have performed a self-review of my code
- [x] Formatting and lint checks pass for the changed files
- [x] I have added a regression test
- [ ] Full workspace unit and integration tests run locally (see validation note above)
