### PR TITLE
[2444] reset decoder weights

### DIFF
--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -422,6 +422,9 @@ def load_merge_configs(
     else:
         base_config = load_run_config(from_run_id, mini_epoch, None)
         from_run_id = get_run_id_from_config(base_config)
+        with open_dict(base_config):
+            # one-shot action key: must be set per stage, not inherited from the previous run
+            base_config.pop("reset_modules", None)
     with open_dict(base_config):
         base_config.from_run_id = from_run_id
     # use OmegaConf.unsafe_merge if too slow

--- a/src/weathergen/model/model_interface.py
+++ b/src/weathergen/model/model_interface.py
@@ -29,7 +29,13 @@ from weathergen.model.attention import (
 )
 from weathergen.model.layers import MLP
 from weathergen.model.model import Model, ModelParams
-from weathergen.model.utils import apply_fct_to_blocks, freeze_weights, reset_weights
+from weathergen.model.utils import (
+    apply_fct_to_blocks,
+    check_reset_not_frozen,
+    freeze_weights,
+    log_trainable_summary,
+    reset_weights,
+)
 from weathergen.utils.distributed import is_root
 from weathergen.utils.utils import get_dtype
 
@@ -183,9 +189,14 @@ def init_model_and_shard(
     if loaded_from_run_id is not None and loaded_from_run_id != current_run_id:
         reset_modules = cf.get("reset_modules", "")
         if reset_modules:
+            # a parameter that is both reset and frozen would stay random forever
+            check_reset_not_frozen(model, reset_modules)
             if is_root():
                 logger.info(f"Resetting weights for modules matching: {reset_modules}")
             apply_fct_to_blocks(model, reset_modules, reset_weights)
+
+    if is_root():
+        log_trainable_summary(model)
 
     # model params
     model_params = ModelParams(cf).create(cf)

--- a/src/weathergen/model/model_interface.py
+++ b/src/weathergen/model/model_interface.py
@@ -29,7 +29,7 @@ from weathergen.model.attention import (
 )
 from weathergen.model.layers import MLP
 from weathergen.model.model import Model, ModelParams
-from weathergen.model.utils import apply_fct_to_blocks, freeze_weights
+from weathergen.model.utils import apply_fct_to_blocks, freeze_weights, reset_weights
 from weathergen.utils.distributed import is_root
 from weathergen.utils.utils import get_dtype
 
@@ -158,21 +158,34 @@ def init_model_and_shard(
             torch.distributed.fsdp.register_fsdp_forward_method(embed, "forward_columns")
 
     # complete initalization and load model if inference/continuing a run
+    loaded_from_run_id = None
     if run_id_contd is not None:
         if is_root():
             logger.info(f"Continuing run with id={run_id_contd} at mini_epoch {mini_epoch_contd}.")
         model = load_model(cf, model, device, run_id_contd, mini_epoch_contd)
+        loaded_from_run_id = run_id_contd
     elif cf.get("load_chkpt", {}).get("run_id", None):
         run_id = cf.load_chkpt.run_id
         mini_epoch = cf.load_chkpt.get("mini_epoch", -1)
         if is_root():
             logger.info(f"Loading checkpoint from id={run_id} at mini_epoch {mini_epoch}.")
         model = load_model(cf, model, device, run_id, mini_epoch)
+        loaded_from_run_id = run_id
     else:
         if with_ddp and with_fsdp:
             model.to_empty(device="cuda")
             if with_fsdp:
                 model.reset_parameters()
+
+    # Reset specified modules when starting a new stage (e.g. pretrain -> finetune); 
+    # skip when resuming the same run.
+    current_run_id = cf.general.run_id
+    if loaded_from_run_id is not None and loaded_from_run_id != current_run_id:
+        reset_modules = cf.get("reset_modules", "")
+        if reset_modules:
+            if is_root():
+                logger.info(f"Resetting weights for modules matching: {reset_modules}")
+            apply_fct_to_blocks(model, reset_modules, reset_weights)
 
     # model params
     model_params = ModelParams(cf).create(cf)

--- a/src/weathergen/model/model_interface.py
+++ b/src/weathergen/model/model_interface.py
@@ -198,7 +198,7 @@ def init_model_and_shard(
             if with_fsdp:
                 model.reset_parameters()
 
-    # Reset specified modules when starting a new stage (e.g. pretrain -> finetune); 
+    # Reset specified modules when starting a new stage (e.g. pretrain -> finetune);
     # skip when resuming the same run.
     current_run_id = cf.general.run_id
     if loaded_from_run_id is not None and loaded_from_run_id != current_run_id:

--- a/src/weathergen/model/model_interface.py
+++ b/src/weathergen/model/model_interface.py
@@ -31,6 +31,7 @@ from weathergen.model.layers import MLP
 from weathergen.model.model import Model, ModelParams
 from weathergen.model.utils import (
     apply_fct_to_blocks,
+    broadcast_matching_params,
     check_reset_not_frozen,
     freeze_weights,
     log_trainable_summary,
@@ -189,11 +190,14 @@ def init_model_and_shard(
     if loaded_from_run_id is not None and loaded_from_run_id != current_run_id:
         reset_modules = cf.get("reset_modules", "")
         if reset_modules:
+            assert not with_fsdp, "reset_modules with FSDP-sharded parameters is not supported"
             # a parameter that is both reset and frozen would stay random forever
             check_reset_not_frozen(model, reset_modules)
             if is_root():
                 logger.info(f"Resetting weights for modules matching: {reset_modules}")
             apply_fct_to_blocks(model, reset_modules, reset_weights)
+            # each rank resets with its own RNG; sync to rank 0 like DDP does at wrap time
+            broadcast_matching_params(model, reset_modules, src=0)
 
     if is_root():
         log_trainable_summary(model)

--- a/src/weathergen/model/utils.py
+++ b/src/weathergen/model/utils.py
@@ -104,9 +104,7 @@ def check_reset_not_frozen(model, reset_blocks):
     for name, module in model.named_modules():
         name = module.name if hasattr(module, "name") else name
         if (re.fullmatch(reset_blocks, name) is not None) and (name != ""):
-            frozen += [
-                f"{name}.{pn}" for pn, p in module.named_parameters() if not p.requires_grad
-            ]
+            frozen += [f"{name}.{pn}" for pn, p in module.named_parameters() if not p.requires_grad]
     if frozen:
         frozen = sorted(set(frozen))
         raise ValueError(

--- a/src/weathergen/model/utils.py
+++ b/src/weathergen/model/utils.py
@@ -60,6 +60,34 @@ def apply_fct_to_blocks(model, blocks, fct):
             fct(module)
 
 
+def broadcast_matching_params(model, blocks, src=0):
+    """
+    Broadcast parameters and buffers of blocks matching the regex from rank src to
+    all ranks. Needed after reset_parameters() under DDP: the reset draws from each
+    rank's own RNG, and DDP only syncs parameters at wrap time, so without a
+    broadcast the ranks train permanently diverged weights.
+    Args:
+        model : model instance with attribute named_modules
+        blocks : regex pattern to match block names
+        src : rank whose values are broadcast
+    """
+
+    if not (torch.distributed.is_available() and torch.distributed.is_initialized()):
+        return
+    seen = set()
+    tensors = []
+    for name, module in model.named_modules():
+        name = module.name if hasattr(module, "name") else name
+        if (re.fullmatch(blocks, name) is not None) and (name != ""):
+            for t in list(module.parameters()) + list(module.buffers()):
+                if id(t) not in seen:
+                    seen.add(id(t))
+                    tensors.append(t)
+    for t in tensors:
+        torch.distributed.broadcast(t.data, src=src)
+    logger.info(f"Broadcast {len(tensors)} reset tensors from rank {src}")
+
+
 def check_reset_not_frozen(model, reset_blocks):
     """
     Verify that no parameter about to be reset is frozen. A parameter that is reset

--- a/src/weathergen/model/utils.py
+++ b/src/weathergen/model/utils.py
@@ -60,6 +60,59 @@ def apply_fct_to_blocks(model, blocks, fct):
             fct(module)
 
 
+def check_reset_not_frozen(model, reset_blocks):
+    """
+    Verify that no parameter about to be reset is frozen. A parameter that is reset
+    to random values but has requires_grad=False can never train, leaving random
+    dead weights in the model (almost never intended).
+    Args:
+        model : model instance with attribute named_modules
+        reset_blocks : regex pattern of block names that will be reset
+    Raises:
+        ValueError listing the frozen parameters that match the reset pattern.
+    """
+
+    frozen = []
+    for name, module in model.named_modules():
+        name = module.name if hasattr(module, "name") else name
+        if (re.fullmatch(reset_blocks, name) is not None) and (name != ""):
+            frozen += [
+                f"{name}.{pn}" for pn, p in module.named_parameters() if not p.requires_grad
+            ]
+    if frozen:
+        frozen = sorted(set(frozen))
+        raise ValueError(
+            "reset_modules overlaps with frozen parameters; these would be reset to random "
+            "values but never trained. Remove them from freeze_modules or reset_modules: "
+            + ", ".join(frozen[:16])
+            + (" ..." if len(frozen) > 16 else "")
+        )
+
+
+def log_trainable_summary(model):
+    """
+    Log per-top-level-block parameter counts and trainable fractions.
+    """
+
+    # unwrap DDP for readable block names
+    block = model.module if isinstance(model, nn.parallel.DistributedDataParallel) else model
+    logger.info("Trainable parameter summary:")
+    for name, child in block.named_children():
+        n_total = sum(p.numel() for p in child.parameters())
+        if n_total == 0:
+            continue
+        n_train = sum(p.numel() for p in child.parameters() if p.requires_grad)
+        logger.info(
+            f"  {name}: {n_train:,} / {n_total:,} trainable ({100 * n_train / n_total:.1f}%)"
+        )
+    n_total = sum(p.numel() for p in block.parameters())
+    n_train = sum(p.numel() for p in block.parameters() if p.requires_grad)
+    if n_total > 0:
+        logger.info(
+            f"  total: {n_train:,} / {n_total:,} trainable ({100 * n_train / n_total:.1f}%)"
+        )
+
+
 class ActivationFactory:
     _registry = {
         "identity": nn.Identity,

--- a/src/weathergen/model/utils.py
+++ b/src/weathergen/model/utils.py
@@ -29,6 +29,15 @@ def freeze_weights(block):
         p.requires_grad = False
 
 
+def reset_weights(block):
+    block_name = getattr(block, "name", type(block).__name__)
+    if hasattr(block, "reset_parameters"):
+        logger.info(f"Reset weights of block {block_name}")
+        block.reset_parameters()
+    else:
+        logger.info(f"Skip reset for block {block_name} (no reset_parameters)")
+
+
 def set_to_eval(block):
     if hasattr(block, "name"):
         logger.info(f"Set block {block.name} to eval mode")


### PR DESCRIPTION
## Description

Adding a `reset_modules `config flag (regex, similar to `freeze_modules`) to re-initialize parts of the model when fine-tuning from a pre-trained checkpoint. In `model_interface.py`, matching modules are reset via `reset_parameters()` after the checkpoint is loaded; skipped when resuming the same run, so chain continuations don't re-reset.

In `model/utils.py`, three supporting functions are added:
1. `broadcast_matching_params`: broadcasts the reset parameters from rank 0 after the reset. Without this, each DDP rank re-initializes with its own RNG and the ranks then train diverged weights (DDP only syncs parameters at wrap time). Verified on 4 GPUs with NCCL: rank checksums differ after reset and are identical after the broadcast.
2. `check_reset_not_frozen`: raises if reset parameters are frozen (they would stay random and untrained).
3. `log_trainable_summary`: logs per-block trainable fractions at training start.

## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Closes #2444

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
