### PR TITLE
Update obs stream configs of integration tests

### DIFF
--- a/integration_tests/streams_multi/npp_atms.yml
+++ b/integration_tests/streams_multi/npp_atms.yml
@@ -2,6 +2,7 @@ NPPATMS :
   type : obs
   stream_id: 1
   filenames : ['observations-ea-ofb-0001-2012-2023-npp-atms-radiances-v2.zarr']
+  geoinfo_channels : ['cos_local_time', 'sin_local_time', 'cos_julian_day', 'sin_julian_day']
   loss_weight : 1.0
   # masking_rate : 0.6
   # masking_rate_none : 0.05

--- a/integration_tests/streams_multi/synop.yml
+++ b/integration_tests/streams_multi/synop.yml
@@ -2,6 +2,7 @@ SurfaceCombined :
   type : obs
   stream_id: 2
   filenames : ['observations-ea-ofb-0001-1979-2023-combined-surface-v2.zarr']
+  geoinfo_channels : ['cos_local_time', 'sin_local_time', 'cos_julian_day', 'sin_julian_day']
   loss_weight : 1.0
   masking_rate : 0.6
   masking_rate_none : 0.05


### PR DESCRIPTION
## Description

Updated obs stream configs of integration tests to be consistent with #2534 and explicitly include geoinfos.

## Issue Number

Closes #2640 

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
