### PR TITLE
Update surface dataset paths to v5

### DIFF
--- a/config/streams/era5_decoding_synop/synop.yml
+++ b/config/streams/era5_decoding_synop/synop.yml
@@ -13,7 +13,7 @@ SurfaceCombined :
   masking_rate : 0.6
   masking_rate_none : 0.05
   token_size : 64
-  tokenize_spacetime : True
+  tokenize_spacetime : False
   max_num_targets: -1
   embed : 
     net : transformer

--- a/config/streams/era5_decoding_synop/synop.yml
+++ b/config/streams/era5_decoding_synop/synop.yml
@@ -8,7 +8,7 @@ SurfaceCombined :
   stream_id : 2
   # source: []
   is_diagnostic: True
-  filenames : ['observations-ea-ofb-0001-1979-2023-combined-surface-v2.zarr']
+  filenames : ['observations-ea-ofb-0001-1979-2025-combined-surface-v5.zarr']
   loss_weight : 1.0
   masking_rate : 0.6
   masking_rate_none : 0.05

--- a/config/streams/era5_nppatms_synop/synop.yml
+++ b/config/streams/era5_nppatms_synop/synop.yml
@@ -6,12 +6,12 @@
 SurfaceCombined :
   type : obs
   stream_id : 2
-  filenames : ['observations-ea-ofb-0001-1979-2023-combined-surface-v2.zarr']
+  filenames : ['observations-ea-ofb-0001-1979-2025-combined-surface-v5.zarr']
   loss_weight : 1.0
   masking_rate : 0.6
   masking_rate_none : 0.05
   token_size : 64
-  tokenize_spacetime : True
+  tokenize_spacetime : False
   max_num_targets: -1
   embed : 
     net : transformer

--- a/config/streams/era5_synop_finetuning/synop.yml
+++ b/config/streams/era5_synop_finetuning/synop.yml
@@ -6,13 +6,13 @@
 SurfaceCombined :
   type : obs
   stream_id : 2
-  filenames : ['observations-ea-ofb-0001-1979-2023-combined-surface-v2.zarr']
+  filenames : ['observations-ea-ofb-0001-1979-2025-combined-surface-v5.zarr']
   loss_weight : 1.0
   diagnostic: True
   masking_rate : 0.6
   masking_rate_none : 0.05
   token_size : 64
-  tokenize_spacetime : True
+  tokenize_spacetime : False
   max_num_targets: -1
   embed : 
     net : transformer


### PR DESCRIPTION
## Description

Update SurfaceCombined datasets from v2 to v5 in streams configs.


## Issue Number

Closes #2652 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
