### PR TITLE
Synop int. test, token_size 512 tok_spctm = False

### DIFF
--- a/integration_tests/streams_multi/synop.yml
+++ b/integration_tests/streams_multi/synop.yml
@@ -6,7 +6,7 @@ SurfaceCombined :
   loss_weight : 1.0
   masking_rate : 0.6
   masking_rate_none : 0.05
-  token_size : 64
+  token_size : 512
   tokenize_spacetime : True
   max_num_targets: -1
   embed : 

--- a/integration_tests/streams_multi/synop.yml
+++ b/integration_tests/streams_multi/synop.yml
@@ -7,7 +7,7 @@ SurfaceCombined :
   masking_rate : 0.6
   masking_rate_none : 0.05
   token_size : 512
-  tokenize_spacetime : True
+  tokenize_spacetime : False
   max_num_targets: -1
   embed : 
     net : transformer


### PR DESCRIPTION
Change tokenize_spacetime to False for integration test for multi streams. v2 -> v5 SurfaceCombined changes the sampling/averaging of observations. v2 had observations averaged to hourly, while v5 keeps them continuous. This makes tokenize_spacetime True unworkable as we now have many, many unique timestamps in a 6 hour window.

Also increase token_size to avoid exceeding max num tokens.

## Description

See above


## Issue Number

Closes #2660

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
