### PR TITLE
Fix export bug, add IMERG N320

### DIFF
--- a/config/evaluate/config_zarr2cf.yaml
+++ b/config/evaluate/config_zarr2cf.yaml
@@ -96,7 +96,7 @@ variables:
     wg_unit: m
     std_unit: m
     level_type: sfc
-   hcc:
+  hcc:
     var: hcc
     long: high_cloud_cover
     std: cloud_area_fraction_high
@@ -137,6 +137,13 @@ variables:
     std: surface_downwelling_shortwave_flux_in_air
     wg_unit: J m**-2
     std_unit: J m-2
+    level_type: sfc
+  tp:
+    var: tp
+    long: imerg_total_precipitation
+    std: precipitation_amount
+    wg_unit: m
+    std_unit: m
     level_type: sfc
   
 

--- a/packages/evaluate/src/weathergen/evaluate/export/export_core.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/export_core.py
@@ -62,15 +62,13 @@ def get_data_worker(args: tuple) -> tuple[int, int, xr.DataArray]:
     npoints = data_arr.shape[0]
 
     # Handle optional ensemble dimension: squeeze it out if present.
+    data_dims = ["ipoint", "channel"]
     if data_arr.ndim == 3:
         if data_arr.shape[2] == 1:
             data_arr = data_arr[:, :, 0]
-            data_dims = ["ipoint", "channel"]
         else:
-            data_dims = ["ipoint", "channel", "mem"]
-    else:
-        data_dims = ["ipoint", "channel"]
-
+            data_dims.append("mem")
+            
     data_coords = {
         "ipoint": np.arange(npoints),
         "channel": channels,

--- a/packages/evaluate/src/weathergen/evaluate/export/export_core.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/export_core.py
@@ -68,6 +68,8 @@ def get_data_worker(args: tuple) -> tuple[int, int, xr.DataArray]:
             data_dims = ["ipoint", "channel"]
         else:
             data_dims = ["ipoint", "channel", "mem"]
+    else:
+        data_dims = ["ipoint", "channel"]
 
     data_coords = {
         "ipoint": np.arange(npoints),


### PR DESCRIPTION
## Description

Just a small PR to add to enable exporting high-res IMERG (where precip is called `tp` and not `tp_imerg_0` for some reason) and fix two small bugs. 

## Issue Number

Closes #2669 

