### PR TITLE
Mh/diffusion full pipeline latent rmse curve

### DIFF
--- a/src/weathergen/datasets/batch.py
+++ b/src/weathergen/datasets/batch.py
@@ -309,6 +309,23 @@ class ModelBatch:
         self.source2target_matching_idxs = np.full(num_source_samples, -1, dtype=np.int32)
         self.target2source_matching_idxs = [[] for _ in range(num_target_samples)]
 
+        # Optional isolated samples carrying source-channel network input at the forecast
+        # times, used only by the latent rollout RMSE diagnostic to encode truth latents.
+        # None on every standard batch; the source/target samples above are never affected.
+        self.latent_rmse_source: BatchSamples | None = None
+
+    def init_latent_rmse_source(self, streams, num_samples: int) -> None:
+        """Create the isolated latent-RMSE truth samples (see ``latent_rmse_source``)."""
+        self.latent_rmse_source = BatchSamples(
+            streams, num_samples, self.output_steps, self.output_idxs
+        )
+
+    def add_latent_rmse_source_stream(
+        self, sample_idx: int, stream_name: str, stream_data: StreamData
+    ) -> None:
+        """Add one stream's forecast-time source data to the latent-RMSE truth samples."""
+        self.latent_rmse_source.samples[sample_idx].add_stream_data(stream_name, stream_data)
+
     def pin_memory(self):
         """Pin all tensors in this batch to CPU pinned memory"""
 
@@ -317,6 +334,9 @@ class ModelBatch:
 
         # pin target samples
         self.target_samples.pin_memory()
+
+        if self.latent_rmse_source is not None:
+            self.latent_rmse_source.pin_memory()
 
         return self
 
@@ -327,6 +347,9 @@ class ModelBatch:
 
         self.source_samples.to_device(device)
         self.target_samples.to_device(device)
+
+        if self.latent_rmse_source is not None:
+            self.latent_rmse_source.to_device(device)
 
         self.device = device
 

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -113,38 +113,16 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         steps = np.array(forecast_cfg["num_steps"], dtype=np.int32).reshape(-1)
         self.list_num_forecast_steps = np.array(steps, dtype=np.int32)
 
-        # Latent rollout RMSE diagnostic (inference only). Instead of a bespoke data path,
-        # reuse the source-side num_steps_input machinery to load the truth latents at the
-        # forecast times: encode K+1 source steps and shift the base index forward by K-1
-        # (K = forecast.num_steps), so the backward source window covers [t-1, t, ..., t+(K-1)].
-        # Model.forward then re-indexes conditioning (t-1) and pairs each rollout step with its
-        # truth latent. No target-encoder or forecast-time reads needed.
+        # Latent rollout RMSE diagnostic (inference only). Attaches an ISOLATED set of
+        # source-channel samples at the forecast times [t, t+1, ..., t+(K-1)] to each batch
+        # (batch.latent_rmse_source), used only to encode truth latents for the diagnostic.
+        # The base index, the standard source/target samples, losses and zarr output are left
+        # exactly as a normal run — this is a read-only side channel.
         self.latent_rollout_rmse = mode_cfg.get("latent_rollout_rmse", False)
-        self.latent_rollout_base_shift = 0
         if self.latent_rollout_rmse:
-            k_steps = int(self.list_num_forecast_steps.max())
-            assert k_steps >= 1, "latent_rollout_rmse requires forecast.num_steps >= 1"
             assert self.output_offset == 0, (
                 f"latent_rollout_rmse requires forecast.offset == 0, got {self.output_offset}"
             )
-            # The base index is shifted forward by k_steps-1 so the backward source window
-            # covers the forecast times. Only the latent conditioning is re-indexed in
-            # Model.forward, not the physical target/write path, so write_output would emit a
-            # time-misaligned zarr. Forbid it rather than write silently corrupt output.
-            assert mode_cfg.get("output", {}).get("num_samples", 0) == 0, (
-                "latent_rollout_rmse shifts the sample base index, so output.num_samples>0 "
-                "would write a time-misaligned physical zarr. Set output.num_samples=0."
-            )
-            self.latent_rollout_base_shift = k_steps - 1
-            if OmegaConf.is_config(mode_cfg):
-                OmegaConf.set_struct(mode_cfg, False)
-            for _, sc in mode_cfg.get("model_input", {}).items():
-                sc["num_steps_input"] = k_steps + 1
-            if is_root():
-                logger.info(
-                    f"latent_rollout_rmse: model_input num_steps_input -> {k_steps + 1}, "
-                    f"base index shift -> +{k_steps - 1} (K={k_steps})"
-                )
 
         # initialise fsm, but can change for future mini_epochs
         self.batch_size = get_batch_size_from_config(mode_cfg)
@@ -451,6 +429,43 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
 
         return stream_data
 
+    def _build_latent_rmse_stream_data(
+        self,
+        stream_info: dict,
+        base_idx: TIndex,
+        num_forecast_steps: int,
+        forecast_input_data: list,
+        forecast_input_tokens: list,
+        mask: torch.Tensor | None,
+    ) -> StreamData:
+        """
+        Build an ISOLATED source-channel StreamData at the forecast times
+        [t, t+1, ..., t+(K-1)] for the latent rollout RMSE diagnostic.
+
+        Like ``_build_stream_data_input`` but walks *forward* over forecast steps: input step k
+        holds the source encoding of the true state at t+k. Used only to encode truth latents;
+        never fed to the model's conditioning, losses or zarr output.
+        """
+        num_output_steps = self._get_output_length(num_forecast_steps)
+        stream_data = StreamData(
+            base_idx, num_output_steps, num_output_steps, self.num_healpix_cells
+        )
+        for step, timestep_idx in enumerate(range(self.output_offset, num_output_steps)):
+            step_forecast_dt = base_idx + (self.time_step * timestep_idx) // self.step_timedelta
+            time_win = self.time_window_handler.window(step_forecast_dt)
+
+            rdata = forecast_input_data[step]
+            token_data = forecast_input_tokens[step]
+            if token_data[0] is None and token_data[1] is None:
+                continue
+
+            (source_cells, source_cells_lens) = self.tokenizer.get_source(
+                stream_info, rdata, token_data, (time_win.start, time_win.end), mask
+            )
+            stream_data.add_source(step, rdata, source_cells_lens, source_cells)
+
+        return stream_data
+
     def _build_stream_data_output(
         self,
         mode: str,
@@ -619,7 +634,27 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
 
             output_data += [rdata]
 
-        return (input_data, output_data)
+        # source-channel data at the forecast times, for the latent RMSE diagnostic only.
+        # Isolated from input_data/output_data; consumed only via batch.latent_rmse_source.
+        forecast_input_data = []
+        if self.latent_rollout_rmse:
+            for timestep_idx in range(self.output_offset, num_output_steps):
+                step_forecast_dt = (
+                    base_idx + (self.time_step * timestep_idx) // self.step_timedelta
+                )
+                rdata = collect_datasources(stream_ds, step_forecast_dt, "source", self.rng)
+                if rdata.is_empty():
+                    time_win = self.time_window_handler.window(step_forecast_dt)
+                    rdata = spoof(
+                        self.healpix_level,
+                        time_win.start,
+                        stream_ds[0].get_geoinfo_size(),
+                        len(stream_ds[0].mean[stream_ds[0].source_idx]),
+                    )
+                    rdata.is_spoof = True
+                forecast_input_data += [rdata]
+
+        return (input_data, output_data, forecast_input_data)
 
     def _get_source_target_masks(self, training_mode):
         """
@@ -691,6 +726,9 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
             self.output_offset,
             num_output_steps,
         )
+        if self.latent_rollout_rmse:
+            # isolated truth samples: one per target sample, mirroring the target masks
+            batch.init_latent_rmse_source(self.streams, num_target_samples)
 
         # for all streams
         for stream_info, (stream_name, stream_ds) in zip(
@@ -708,7 +746,7 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
             # input_data and output_data is conceptually consecutive but differs
             # in source and target channels; overlap in one window when self.output_offset=0
             i_max = input_steps.max().item()
-            (input_data, output_data) = self._get_data_windows(
+            (input_data, output_data, forecast_input_data) = self._get_data_windows(
                 idx, num_forecast_steps, i_max, stream_ds
             )
 
@@ -716,6 +754,11 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
             # *_tokens = [ (cells_idx, cells_idx_lens), ... ] with length = #time_steps
             input_tokens = self.tokenizer.get_tokens_windows(stream_info, input_data, True)
             output_tokens = self.tokenizer.get_tokens_windows(stream_info, output_data, False)
+            forecast_input_tokens = (
+                self.tokenizer.get_tokens_windows(stream_info, forecast_input_data, True)
+                if self.latent_rollout_rmse
+                else None
+            )
 
             for sidx, source_mask in enumerate(source_masks.masks):
                 # Map each source to its target
@@ -770,10 +813,27 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                 ]
                 batch.add_target_stream(tidx, student_indices, stream_name, sdata, target_metadata)
 
+                # Isolated latent-RMSE truth: forecast-time source under the same target mask
+                # (the mask the model is trained to predict), added to a separate sample set.
+                if self.latent_rollout_rmse:
+                    truth_sdata = self._build_latent_rmse_stream_data(
+                        stream_info,
+                        idx,
+                        num_forecast_steps,
+                        forecast_input_data,
+                        forecast_input_tokens,
+                        mask=target_mask,
+                    )
+                    batch.add_latent_rmse_source_stream(tidx, stream_name, truth_sdata)
+
         source_in_steps = input_steps.max().item()
         target_in_steps = np.array([tc.get("num_steps_input", 1) for _, tc in target_cfgs.items()])
         target_in_steps = 1 if len(target_in_steps) == 0 else target_in_steps.max().item()
         batch = self._preprocess_model_batch(batch, source_in_steps, target_in_steps)
+        if self.latent_rollout_rmse:
+            batch.latent_rmse_source.tokens_lens = get_tokens_lens(
+                self.streams, batch.latent_rmse_source, num_output_steps
+            )
 
         #add target times in source for diffusion model date/time conditioning
         if self.diffusion_model_conditioning in ["date_time", "date", "time"]:
@@ -821,10 +881,6 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
             while True:
                 idx: TIndex = perms[idx_raw % perms.shape[0]]
                 idx_raw += 1
-
-                # Latent rollout diagnostic: anchor the sample at t+(K-1) so the backward
-                # source window loads the forecast-time truth latents (see __init__).
-                idx = idx + self.latent_rollout_base_shift
 
                 batch = self._get_batch(idx, num_forecast_steps)
 

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -113,6 +113,39 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         steps = np.array(forecast_cfg["num_steps"], dtype=np.int32).reshape(-1)
         self.list_num_forecast_steps = np.array(steps, dtype=np.int32)
 
+        # Latent rollout RMSE diagnostic (inference only). Instead of a bespoke data path,
+        # reuse the source-side num_steps_input machinery to load the truth latents at the
+        # forecast times: encode K+1 source steps and shift the base index forward by K-1
+        # (K = forecast.num_steps), so the backward source window covers [t-1, t, ..., t+(K-1)].
+        # Model.forward then re-indexes conditioning (t-1) and pairs each rollout step with its
+        # truth latent. No target-encoder or forecast-time reads needed.
+        self.latent_rollout_rmse = mode_cfg.get("latent_rollout_rmse", False)
+        self.latent_rollout_base_shift = 0
+        if self.latent_rollout_rmse:
+            k_steps = int(self.list_num_forecast_steps.max())
+            assert k_steps >= 1, "latent_rollout_rmse requires forecast.num_steps >= 1"
+            assert self.output_offset == 0, (
+                f"latent_rollout_rmse requires forecast.offset == 0, got {self.output_offset}"
+            )
+            # The base index is shifted forward by k_steps-1 so the backward source window
+            # covers the forecast times. Only the latent conditioning is re-indexed in
+            # Model.forward, not the physical target/write path, so write_output would emit a
+            # time-misaligned zarr. Forbid it rather than write silently corrupt output.
+            assert mode_cfg.get("output", {}).get("num_samples", 0) == 0, (
+                "latent_rollout_rmse shifts the sample base index, so output.num_samples>0 "
+                "would write a time-misaligned physical zarr. Set output.num_samples=0."
+            )
+            self.latent_rollout_base_shift = k_steps - 1
+            if OmegaConf.is_config(mode_cfg):
+                OmegaConf.set_struct(mode_cfg, False)
+            for _, sc in mode_cfg.get("model_input", {}).items():
+                sc["num_steps_input"] = k_steps + 1
+            if is_root():
+                logger.info(
+                    f"latent_rollout_rmse: model_input num_steps_input -> {k_steps + 1}, "
+                    f"base index shift -> +{k_steps - 1} (K={k_steps})"
+                )
+
         # initialise fsm, but can change for future mini_epochs
         self.batch_size = get_batch_size_from_config(mode_cfg)
         self.shuffle = mode_cfg.shuffle
@@ -788,6 +821,10 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
             while True:
                 idx: TIndex = perms[idx_raw % perms.shape[0]]
                 idx_raw += 1
+
+                # Latent rollout diagnostic: anchor the sample at t+(K-1) so the backward
+                # source window loads the forecast-time truth latents (see __init__).
+                idx = idx + self.latent_rollout_base_shift
 
                 batch = self._get_batch(idx, num_forecast_steps)
 

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -49,6 +49,35 @@ logger = logging.getLogger(__name__)
 type StreamName = str
 
 
+def _single_step_source_view(batch, step: int):
+    """
+    Shallow view of a source ``BatchSamples`` exposing only input ``step``.
+
+    The embedding engine concatenates the source tokens of *all* input steps into one tensor
+    before embedding, so encoding a sample that carries many input steps (as the latent
+    rollout RMSE diagnostic does, num_steps_input = K+1) costs K+1x the memory and OOMs.
+    Encoding step by step through this view keeps the peak at a single step. Only
+    ``source_tokens_cells`` / ``source_tokens_lens`` and ``tokens_lens`` are read per step;
+    nothing is deep-copied, so the views alias the original tensors.
+    """
+
+    view = copy.copy(batch)
+    view.tokens_lens = batch.tokens_lens[step : step + 1]
+    view.samples = []
+    for sample in batch.samples:
+        sample_view = copy.copy(sample)
+        sample_view.streams_data = {}
+        for stream_name, stream_data in sample.streams_data.items():
+            stream_view = copy.copy(stream_data)
+            stream_view.input_steps = 1
+            stream_view.source_tokens_cells = [stream_data.source_tokens_cells[step]]
+            stream_view.source_tokens_lens = [stream_data.source_tokens_lens[step]]
+            sample_view.streams_data[stream_name] = stream_view
+        view.samples += [sample_view]
+
+    return view
+
+
 class ModelOutput:
     """
     Representation of model output
@@ -350,6 +379,10 @@ class Model(torch.nn.Module):
         # One-shot flag to avoid log spam when warning about an unsupported
         # diffusion-inference + multi-step-rollout combination.
         self._warned_diffusion_multi_step = False
+        # Set by the trainer (a LatentRolloutRMSE) when the latent rollout RMSE diagnostic is
+        # enabled; None disables it. When set, forward() re-indexes the diffusion conditioning
+        # and accumulates per-lead-time latent RMSE. See forward().
+        self.latent_rmse = None
 
     def _create_latent_pred_head(
         self, global_cfg, name, loss_cfg, use_class_token, use_patch_token
@@ -724,31 +757,55 @@ class Model(torch.nn.Module):
 
         output = ModelOutput(batch.get_output_len())
 
-        tokens, posteriors = self.encoder(model_params, batch)
+        if self.latent_rmse is not None:
+            # Latent rollout RMSE diagnostic: the source sample carries K+1 input steps, which
+            # the embed engine would otherwise concatenate into a single OOM-inducing forward.
+            # Encode each step separately and stack to bound peak memory (see
+            # _single_step_source_view). Result is already [B, T, ...].
+            step_tokens = []
+            posteriors = None
+            for s in range(batch.get_num_steps()):
+                tok_s, posteriors = self.encoder(model_params, _single_step_source_view(batch, s))
+                step_tokens.append(tok_s)
+            tokens = torch.stack(step_tokens, dim=1)
+        else:
+            tokens, posteriors = self.encoder(model_params, batch)
+            # recover batch dimension and separate input_steps -> [B, T, ...]
+            tokens = tokens.reshape((len(batch), batch.get_num_steps(), *tokens.shape[1:]))
         output.add_latent_prediction(0, "posteriors", posteriors)
 
-        # recover batch dimension and separate input_steps
-        shape = (len(batch), batch.get_num_steps(), *tokens.shape[1:])
-        # Reshape tokens to [B, T, ...]
-        tokens = tokens.reshape(shape)
+        shape = tokens.shape
+
+        # Truth latents per rollout step, populated only for the latent-rollout RMSE diagnostic.
+        truth_latents = None
 
         if self.cf.get("fe_diffusion_model_conditioning", None) == "forecast":
             tokens = tokens.reshape(shape)
             # tokens[:, 0] = t (most recent), tokens[:, 1] = t-1, ..., tokens[:, -1] = t-(T-1) (oldest)
-            if self.cf.stage == "inference":
+            if self.latent_rmse is not None:
+                # Latent rollout RMSE diagnostic (inference). The source window carries K+1
+                # encoded steps [t-1, t, ..., t+(K-1)]; most-recent first this is
+                # tokens[:, 0] = t+(K-1), ..., tokens[:, K-1] = t, tokens[:, K] = t-1.
+                # Condition on t-1 and pair rollout step j (valid time t+j) with tokens[:, K-1-j].
+                k_steps = tokens.shape[1] - 1
+                conditioning_tokens = tokens[:, k_steps]  # t-1
+                truth_latents = [tokens[:, k_steps - 1 - j] for j in range(k_steps)]  # j -> t+j
+                tokens = tokens[:, k_steps - 1]  # t (reference; the ODE sampler starts from noise)
+            elif self.cf.stage == "inference":
                 print("Using most recent steps as conditioning tokens for inference.")
                 # conditioning_tokens = tokens[:, :-1].sum(axis=1)
                 conditioning_tokens = tokens[:, 1:].sum(axis=1)
+                tokens = tokens[:, 0]
             else:
                 # Conditioning: all older context steps [t-1, ..., t-(T-1)]; denoising target: t (newest)
                 conditioning_tokens = tokens[:, 1:].sum(axis=1)
                 conditioning_tokens = conditioning_tokens + torch.randn_like(conditioning_tokens) * self.cf.get("fe_impute_latent_diffusion_noise_std", 0.0)
                 if np.random.rand() < self.cf.get("fe_diffusion_classifier_free_guidance_prob", 0.0):  # occasionally dropout conditioning for classifier free guidance
                     conditioning_tokens = torch.zeros_like(conditioning_tokens)
+                tokens = tokens[:, 0]
             # X_t (tokens[:, 0], most recent) is the diffusion denoising target; older steps are conditioning.
             batch.samples[0].meta_info["ERA5"].params["conditioning_tokens"] = conditioning_tokens
             # self.forecast_engine._pending_target_tokens = diffusion_target_tokens
-            tokens = tokens[:, 0]
         else:
             tokens = tokens.sum(axis=1)
 
@@ -756,7 +813,7 @@ class Model(torch.nn.Module):
         p_fwd = self.cf.training_config.get("forecast", {}).get("pushforward", False)
 
         # roll-out in latent space, iterate and generate output over requested output steps
-        for step in batch.get_output_idxs():
+        for j, step in enumerate(batch.get_output_idxs()):
             without_grad = p_fwd and self.training and step != max(batch.get_output_idxs())
             if without_grad:
                 # Pushforward mode: advance tokens without grad; no decoding with torch.no_grad():
@@ -830,6 +887,11 @@ class Model(torch.nn.Module):
                     output.add_physical_prediction(
                         step, sname, (torch.cat(list(pred_tuple), dim=0),)
                     )
+                # Latent rollout RMSE diagnostic: accumulate RMSE of the rolled-out latent
+                # against the encoded truth latent at this lead time. member_final_tokens is
+                # (N_members, H, D); the truth is (1, H, D) and broadcasts over members.
+                if truth_latents is not None and j < len(truth_latents):
+                    self.latent_rmse.add(j, member_final_tokens, truth_latents[j])
                 # Store per-member conditioning for the next rollout step.
                 # conditioning_tokens holds (N, H, D) during ensemble rollout; inference_forward
                 # calls expand(N, ...) which is a no-op when the dim already matches.

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -55,10 +55,10 @@ def _single_step_source_view(batch, step: int):
 
     The embedding engine concatenates the source tokens of *all* input steps into one tensor
     before embedding, so encoding a sample that carries many input steps (as the latent
-    rollout RMSE diagnostic does, num_steps_input = K+1) costs K+1x the memory and OOMs.
-    Encoding step by step through this view keeps the peak at a single step. Only
-    ``source_tokens_cells`` / ``source_tokens_lens`` and ``tokens_lens`` are read per step;
-    nothing is deep-copied, so the views alias the original tensors.
+    rollout RMSE truth samples do, K steps) costs Kx the memory and OOMs. Encoding step by
+    step through this view keeps peak memory at a single step. Only ``source_tokens_cells`` /
+    ``source_tokens_lens`` and ``tokens_lens`` are read per step; nothing is deep-copied, so
+    the views alias the original tensors.
     """
 
     view = copy.copy(batch)
@@ -379,10 +379,10 @@ class Model(torch.nn.Module):
         # One-shot flag to avoid log spam when warning about an unsupported
         # diffusion-inference + multi-step-rollout combination.
         self._warned_diffusion_multi_step = False
-        # Set by the trainer (a LatentRolloutRMSE) when the latent rollout RMSE diagnostic is
-        # enabled; None disables it. When set, forward() re-indexes the diffusion conditioning
-        # and accumulates per-lead-time latent RMSE. See forward().
-        self.latent_rmse = None
+        # Set by the trainer for the latent rollout RMSE diagnostic: when True, forward()
+        # records the rolled-out latent per step under the "latent_rollout_pred" key. Purely
+        # additive — the standard path is unaffected.
+        self.record_latent_rollout = False
 
     def _create_latent_pred_head(
         self, global_cfg, name, loss_cfg, use_class_token, use_patch_token
@@ -757,55 +757,31 @@ class Model(torch.nn.Module):
 
         output = ModelOutput(batch.get_output_len())
 
-        if self.latent_rmse is not None:
-            # Latent rollout RMSE diagnostic: the source sample carries K+1 input steps, which
-            # the embed engine would otherwise concatenate into a single OOM-inducing forward.
-            # Encode each step separately and stack to bound peak memory (see
-            # _single_step_source_view). Result is already [B, T, ...].
-            step_tokens = []
-            posteriors = None
-            for s in range(batch.get_num_steps()):
-                tok_s, posteriors = self.encoder(model_params, _single_step_source_view(batch, s))
-                step_tokens.append(tok_s)
-            tokens = torch.stack(step_tokens, dim=1)
-        else:
-            tokens, posteriors = self.encoder(model_params, batch)
-            # recover batch dimension and separate input_steps -> [B, T, ...]
-            tokens = tokens.reshape((len(batch), batch.get_num_steps(), *tokens.shape[1:]))
+        tokens, posteriors = self.encoder(model_params, batch)
         output.add_latent_prediction(0, "posteriors", posteriors)
 
-        shape = tokens.shape
-
-        # Truth latents per rollout step, populated only for the latent-rollout RMSE diagnostic.
-        truth_latents = None
+        # recover batch dimension and separate input_steps
+        shape = (len(batch), batch.get_num_steps(), *tokens.shape[1:])
+        # Reshape tokens to [B, T, ...]
+        tokens = tokens.reshape(shape)
 
         if self.cf.get("fe_diffusion_model_conditioning", None) == "forecast":
             tokens = tokens.reshape(shape)
             # tokens[:, 0] = t (most recent), tokens[:, 1] = t-1, ..., tokens[:, -1] = t-(T-1) (oldest)
-            if self.latent_rmse is not None:
-                # Latent rollout RMSE diagnostic (inference). The source window carries K+1
-                # encoded steps [t-1, t, ..., t+(K-1)]; most-recent first this is
-                # tokens[:, 0] = t+(K-1), ..., tokens[:, K-1] = t, tokens[:, K] = t-1.
-                # Condition on t-1 and pair rollout step j (valid time t+j) with tokens[:, K-1-j].
-                k_steps = tokens.shape[1] - 1
-                conditioning_tokens = tokens[:, k_steps]  # t-1
-                truth_latents = [tokens[:, k_steps - 1 - j] for j in range(k_steps)]  # j -> t+j
-                tokens = tokens[:, k_steps - 1]  # t (reference; the ODE sampler starts from noise)
-            elif self.cf.stage == "inference":
+            if self.cf.stage == "inference":
                 print("Using most recent steps as conditioning tokens for inference.")
                 # conditioning_tokens = tokens[:, :-1].sum(axis=1)
                 conditioning_tokens = tokens[:, 1:].sum(axis=1)
-                tokens = tokens[:, 0]
             else:
                 # Conditioning: all older context steps [t-1, ..., t-(T-1)]; denoising target: t (newest)
                 conditioning_tokens = tokens[:, 1:].sum(axis=1)
                 conditioning_tokens = conditioning_tokens + torch.randn_like(conditioning_tokens) * self.cf.get("fe_impute_latent_diffusion_noise_std", 0.0)
                 if np.random.rand() < self.cf.get("fe_diffusion_classifier_free_guidance_prob", 0.0):  # occasionally dropout conditioning for classifier free guidance
                     conditioning_tokens = torch.zeros_like(conditioning_tokens)
-                tokens = tokens[:, 0]
             # X_t (tokens[:, 0], most recent) is the diffusion denoising target; older steps are conditioning.
             batch.samples[0].meta_info["ERA5"].params["conditioning_tokens"] = conditioning_tokens
             # self.forecast_engine._pending_target_tokens = diffusion_target_tokens
+            tokens = tokens[:, 0]
         else:
             tokens = tokens.sum(axis=1)
 
@@ -813,7 +789,7 @@ class Model(torch.nn.Module):
         p_fwd = self.cf.training_config.get("forecast", {}).get("pushforward", False)
 
         # roll-out in latent space, iterate and generate output over requested output steps
-        for j, step in enumerate(batch.get_output_idxs()):
+        for step in batch.get_output_idxs():
             without_grad = p_fwd and self.training and step != max(batch.get_output_idxs())
             if without_grad:
                 # Pushforward mode: advance tokens without grad; no decoding with torch.no_grad():
@@ -887,11 +863,15 @@ class Model(torch.nn.Module):
                     output.add_physical_prediction(
                         step, sname, (torch.cat(list(pred_tuple), dim=0),)
                     )
-                # Latent rollout RMSE diagnostic: accumulate RMSE of the rolled-out latent
-                # against the encoded truth latent at this lead time. member_final_tokens is
-                # (N_members, H, D); the truth is (1, H, D) and broadcasts over members.
-                if truth_latents is not None and j < len(truth_latents):
-                    self.latent_rmse.add(j, member_final_tokens, truth_latents[j])
+                # Latent rollout RMSE diagnostic: record the rolled-out latent under a
+                # dedicated key (never "latent_state") so the latent loss is unaffected. The
+                # trainer pairs this with the encoded truth latent. Off by default.
+                if self.record_latent_rollout:
+                    output.add_latent_prediction(
+                        step,
+                        "latent_rollout_pred",
+                        self.tokens_to_latent_state(None, member_final_tokens),
+                    )
                 # Store per-member conditioning for the next rollout step.
                 # conditioning_tokens holds (N, H, D) during ensemble rollout; inference_forward
                 # calls expand(N, ...) which is a no-op when the dim already matches.
@@ -908,6 +888,20 @@ class Model(torch.nn.Module):
             output = self.predict_latent(model_params, step, tokens, batch, output)
 
         return output
+
+    @torch.no_grad()
+    def encode_source_chunked(self, model_params: ModelParams, source_samples) -> torch.Tensor:
+        """
+        Encode a multi-input-step source ``BatchSamples`` one step at a time and stack the
+        latents to ``[B, T, H, D]``. Used by the latent rollout RMSE diagnostic to encode the
+        truth latents at the forecast times without the K-step concatenation OOM (see
+        _single_step_source_view). Read-only; does not touch model state.
+        """
+        step_tokens = []
+        for s in range(source_samples.get_num_steps()):
+            tok_s, _ = self.encoder(model_params, _single_step_source_view(source_samples, s))
+            step_tokens.append(tok_s)
+        return torch.stack(step_tokens, dim=1)
 
     @staticmethod
     def _reindex_output_for_trajectory(output: ModelOutput, n_steps: int) -> ModelOutput:

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -47,6 +47,7 @@ from weathergen.train.utils import (
     get_target_idxs_from_cfg,
 )
 from weathergen.utils.distributed import is_root
+from weathergen.utils.latent_rmse import LatentRolloutRMSE
 from weathergen.utils.performance import NullThroughputTracker, ThroughputTracker
 from weathergen.utils.train_logger import TrainLogger, prepare_losses_for_logging
 from weathergen.utils.utils import get_dtype
@@ -625,9 +626,20 @@ class Trainer(TrainerBase):
         all_losses: dict[str, list] = {}
         all_stddev: dict[str, list] = {}
 
+        # Latent rollout RMSE diagnostic: the model accumulates per-lead-time latent RMSE in
+        # forward() while self.latent_rmse is set. Accumulate only over the first (random
+        # noise-level) pass so the curve corresponds to a single sampling setting.
+        base_model = getattr(self.model, "module", self.model)
+        latent_rmse = (
+            LatentRolloutRMSE(self.cf, mode_cfg, self.device)
+            if mode_cfg.get("latent_rollout_rmse", False)
+            else None
+        )
+
         for noise_idx, noise_level in enumerate(noise_levels):
             if is_diffusion:
                 self._set_validation_noise_level(noise_level)
+            base_model.latent_rmse = latent_rmse if noise_idx == 0 else None
 
             if noise_level is None:
                 loss_suffix = ""
@@ -752,6 +764,11 @@ class Trainer(TrainerBase):
         # reset fixed noise level
         if is_diffusion:
             self._set_validation_noise_level(None)
+
+        # latent rollout RMSE: reduce across ranks and plot like the evaluate package's curves
+        base_model.latent_rmse = None
+        if latent_rmse is not None:
+            latent_rmse.plot(config.get_path_run(self.cf))
 
         # avoid that there is a systematic bias in the validation subset
         self.dataset_val.advance()

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -626,9 +626,10 @@ class Trainer(TrainerBase):
         all_losses: dict[str, list] = {}
         all_stddev: dict[str, list] = {}
 
-        # Latent rollout RMSE diagnostic: the model accumulates per-lead-time latent RMSE in
-        # forward() while self.latent_rmse is set. Accumulate only over the first (random
-        # noise-level) pass so the curve corresponds to a single sampling setting.
+        # Latent rollout RMSE diagnostic (isolated side channel): the model records rolled-out
+        # latents under "latent_rollout_pred" while record_latent_rollout is set; the truth
+        # latents are encoded here from the isolated batch.latent_rmse_source. Accumulate only
+        # over the first (random noise-level) pass. Standard preds/losses/zarr are untouched.
         base_model = getattr(self.model, "module", self.model)
         latent_rmse = (
             LatentRolloutRMSE(self.cf, mode_cfg, self.device)
@@ -639,7 +640,7 @@ class Trainer(TrainerBase):
         for noise_idx, noise_level in enumerate(noise_levels):
             if is_diffusion:
                 self._set_validation_noise_level(noise_level)
-            base_model.latent_rmse = latent_rmse if noise_idx == 0 else None
+            base_model.record_latent_rollout = latent_rmse is not None and noise_idx == 0
 
             if noise_level is None:
                 loss_suffix = ""
@@ -711,6 +712,31 @@ class Trainer(TrainerBase):
                             metadata=extract_batch_metadata(batch),
                         )
 
+                        # Latent rollout RMSE: encode the isolated truth latents and pair them
+                        # with the recorded predictions by lead step (both valid at t+j). Encode
+                        # under the same autocast as the forward so truth and pred share dtype.
+                        if (
+                            latent_rmse is not None
+                            and noise_idx == 0
+                            and batch.latent_rmse_source is not None
+                        ):
+                            with torch.autocast(
+                                device_type=f"cuda:{cf.local_rank}",
+                                dtype=self.mixed_precision_dtype,
+                                enabled=cf.with_mixed_precision,
+                            ):
+                                truth = base_model.encode_source_chunked(
+                                    self.model_params, batch.latent_rmse_source
+                                )  # [B, K, H, D]
+                            for j in range(truth.shape[1]):
+                                pl = (
+                                    preds.latent[j].get("latent_rollout_pred")
+                                    if j < len(preds.latent)
+                                    else None
+                                )
+                                if pl is not None:
+                                    latent_rmse.add(j, pl.z_pre_norm, truth[:, j])
+
                         # log output
                         if noise_idx == 0:
                             if bidx < num_samples_write:
@@ -766,7 +792,7 @@ class Trainer(TrainerBase):
             self._set_validation_noise_level(None)
 
         # latent rollout RMSE: reduce across ranks and plot like the evaluate package's curves
-        base_model.latent_rmse = None
+        base_model.record_latent_rollout = False
         if latent_rmse is not None:
             latent_rmse.plot(config.get_path_run(self.cf))
 

--- a/src/weathergen/utils/latent_rmse.py
+++ b/src/weathergen/utils/latent_rmse.py
@@ -16,6 +16,7 @@ equivalent latent-space curve is accumulated online here and plotted with the ve
 plotting classes from ``weathergen.evaluate`` so that both look alike.
 """
 
+import json
 import logging
 
 import numpy as np
@@ -119,13 +120,33 @@ class LatentRolloutRMSE:
             data = data.swap_dims({"forecast_step": "lead_time"})
             x_dim = "lead_time"
 
+        tag = create_filename(prefix=["rmse", "global"], middle=[self.run_id], suffix=["latent"])
+
         plotter = LinePlots(_PLOT_CFG, output_dir)
         plotter.plot(
             [data],
             [self.run_id],
-            tag=create_filename(prefix=["rmse", "global"], middle=[self.run_id], suffix=["latent"]),
+            tag=tag,
             x_dim=x_dim,
             y_dim="rmse",
             print_summary=True,
             title="RMSE | latent | z_pre_norm",
         )
+
+        # drop the plotted values next to the figure so the curve can be re-used numerically;
+        # "compare_" mirrors the prefix LinePlots.plot() puts on the figure file name
+        self._write_json(plotter.out_plot_dir / f"compare_{tag}.json", data)
+
+    def _write_json(self, path, data: xr.DataArray) -> None:
+        """Write the plotted curve as JSON, in the same layout the evaluate package uses."""
+
+        data = data.assign_attrs(
+            run_id=self.run_id,
+            metric="rmse",
+            space="latent",
+            variable="z_pre_norm",
+            step_hours=float(self.step_hours),
+        )
+        with open(path, "w") as f:
+            json.dump(data.to_dict(), f, indent=2)
+        logger.info(f"Wrote latent RMSE values to {path}")

--- a/src/weathergen/utils/latent_rmse.py
+++ b/src/weathergen/utils/latent_rmse.py
@@ -1,0 +1,131 @@
+# (C) Copyright 2025 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Latent-space RMSE per forecast step, accumulated during (rollout) inference.
+
+The evaluate package computes RMSE-vs-lead-time curves for physical variables from the
+zarr output of an inference run. Latents are far too large to write out for that, so the
+equivalent latent-space curve is accumulated online here and plotted with the very same
+plotting classes from ``weathergen.evaluate`` so that both look alike.
+"""
+
+import logging
+
+import numpy as np
+import torch
+import xarray as xr
+
+from weathergen.common.config import parse_timedelta
+from weathergen.evaluate.plotting.line_plots import LinePlots
+from weathergen.evaluate.plotting.plot_utils import create_filename
+from weathergen.utils.distributed import ddp_average, is_root
+
+logger = logging.getLogger(__name__)
+
+# defaults mirroring the ones the evaluate package uses in plot_summary()
+_PLOT_CFG = {
+    "image_format": "png",
+    "dpi_val": 300,
+    "fig_size": (8, 10),
+    "log_scale": False,
+    "add_grid": True,
+    "plot_ensemble": False,
+    "baseline": None,
+}
+
+
+class LatentRolloutRMSE:
+    """
+    Accumulate the RMSE between predicted and encoded ground-truth latents per forecast
+    step and plot it against lead time.
+    """
+
+    def __init__(self, cf, mode_cfg, device):
+        self.run_id = cf.general.run_id
+        self.device = device
+
+        time_step = parse_timedelta(mode_cfg.get("forecast", {}).get("time_step", 0))
+        self.step_hours = time_step / np.timedelta64(1, "h")
+
+        # squared error sum and element count per forecast step; grown on demand
+        self._sum_sq: dict[int, torch.Tensor] = {}
+        self._counts: dict[int, torch.Tensor] = {}
+
+    def add(self, step_idx: int, pred: torch.Tensor, truth: torch.Tensor) -> None:
+        """
+        Accumulate the squared error between a predicted and an encoded truth latent for one
+        rollout step of one batch.
+
+        Parameters
+        ----------
+        step_idx:
+            Zero-based rollout step (lead index); step 0 is the forecast of ``t``.
+        pred:
+            Rolled-out latent, shape ``(N_members, H, D)`` (or ``(1, H, D)``).
+        truth:
+            Encoded truth latent, shape ``(1, H, D)``; broadcasts over ensemble members so the
+            accumulated value is the member-averaged squared error.
+        """
+
+        pred = pred.float()
+        truth = truth.float()
+        if pred.shape[-2:] != truth.shape[-2:]:
+            raise ValueError(
+                f"Latent prediction shape {tuple(pred.shape)} is incompatible with truth latent "
+                f"shape {tuple(truth.shape)} at rollout step {step_idx}."
+            )
+        diff = pred - truth
+        sum_sq = diff.pow(2).sum(dtype=torch.float64)
+        count = torch.tensor(float(diff.numel()), device=self.device, dtype=torch.float64)
+
+        if step_idx not in self._sum_sq:
+            self._sum_sq[step_idx] = torch.zeros((), device=self.device, dtype=torch.float64)
+            self._counts[step_idx] = torch.zeros((), device=self.device, dtype=torch.float64)
+        self._sum_sq[step_idx] += sum_sq.to(self.device)
+        self._counts[step_idx] += count.to(self.device)
+
+    def plot(self, output_dir) -> None:
+        """Reduce across ranks, then write the RMSE-vs-lead-time plot (root rank only)."""
+
+        if not self._sum_sq:
+            logger.warning("No latent predictions collected; skipping latent RMSE plot.")
+            return
+
+        steps = np.array(sorted(self._sum_sq.keys()))
+        sum_sq = ddp_average(torch.stack([self._sum_sq[s] for s in steps]))
+        counts = ddp_average(torch.stack([self._counts[s] for s in steps]))
+        rmse = torch.sqrt(sum_sq / counts).numpy()
+
+        if not is_root():
+            return
+
+        data = xr.DataArray(
+            rmse,
+            dims=["forecast_step"],
+            coords={"forecast_step": steps},
+            name="rmse",
+        )
+        # forecast step k is valid (k+1) * time_step after the last conditioning state
+        data = data.assign_coords(lead_time=("forecast_step", (steps + 1) * self.step_hours))
+        x_dim = "forecast_step"
+        if self.step_hours > 0:
+            data = data.swap_dims({"forecast_step": "lead_time"})
+            x_dim = "lead_time"
+
+        plotter = LinePlots(_PLOT_CFG, output_dir)
+        plotter.plot(
+            [data],
+            [self.run_id],
+            tag=create_filename(prefix=["rmse", "global"], middle=[self.run_id], suffix=["latent"]),
+            x_dim=x_dim,
+            y_dim="rmse",
+            print_summary=True,
+            title="RMSE | latent | z_pre_norm",
+        )


### PR DESCRIPTION
## Description

This PR enables plotting of latent RMSE during inference of the diffusion model. Simply enable via `test_config.latent_rollout_rmse=True`.

**NB**: This involved adding a new batch to the sampler (see changes). I dropped the idea of reusing the `num_steps_input` as this would mess with the indexing of the entire pipeline, and there are many ways that it could fail silently. This implementation is a bit more intrusive, but all changes are gated with a flag, so that the standard path is minimally disrupted. If this is to become a permanent feature on develop, I think a broader discussion should be had about what is the best way.


## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
