### PR TITLE
getting seeps scores instead of seeps error + doc string for the func…

### DIFF
--- a/docs/evaluate_config_reference.md
+++ b/docs/evaluate_config_reference.md
@@ -610,7 +610,7 @@ evaluation:
 | `rpss` | Ranked Probability Skill Score |
 | `fact` | Forecast Activity (standard deviation of forecast anomaly) |
 | `tact` | Target Activity (standard deviation of target anomaly) |
-| `seeps` | Stable Equitable Error in Probability Space ([Rodwell et al., 2011](https://journals.ametsoc.org/view/journals/mwre/140/8/mwr-d-11-00301.1.pdf)). |
+| `seeps` | Stable Equitable Error in Probability Space ([Rodwell et al., 2011](https://journals.ametsoc.org/view/journals/mwre/140/8/mwr-d-11-00301.1.pdf)). Reported as the positively-oriented skill `1 − SEEPS_error` (**higher is better**; 1 = perfect). |
 
 ### Probabilistic metrics (require ensemble dimension)
 
@@ -701,6 +701,13 @@ evaluation:
 ```
 
 #### `seeps` score
+The underlying [`scores`](https://scores.readthedocs.io/) implementation computes the Rodwell et al.
+SEEPS **error** (negatively oriented, 0 = perfect). WeatherGenerator reports the
+**positively-oriented** form `1 − SEEPS_error` (**higher is better**), matching the convention used
+for reporting SEEPS at ECMWF (e.g. the [AIFS "it's raining data" blog](https://www.ecmwf.int/en/about/media-centre/aifs-blog/2024/its-raining-data)).
+A perfect forecast scores 1, a climatology/no-skill forecast scores ~0, and values can be negative
+where the forecast is worse than the penalty-matrix reference.
+
 The `seeps` metric accepts two parameters:
 ```yaml
 evaluation:

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -33,17 +33,14 @@ except Exception:
         "Thus, rank histogram calculations are not supported."
     )
 
-try:        
+try:
     from scores.probability import (
         crps_for_ensemble,
         interval_tw_crps_for_ensemble,
         tail_tw_crps_for_ensemble,
     )
 except Exception:
-    _logger.warning(
-        "Could not import scores. "
-        "Thus, CRPS calculations are not supported."
-    )
+    _logger.warning("Could not import scores. Thus, CRPS calculations are not supported.")
 
 
 # helper function to calculate skill score
@@ -1347,14 +1344,38 @@ class Scores:
         return ratio_spat_variability
 
     def calc_seeps(
-        self, 
-        p: xr.DataArray, 
-        gt: xr.DataArray, 
+        self,
+        p: xr.DataArray,
+        gt: xr.DataArray,
         c: xr.Dataset,
         minimum_dry_prob: float = 0.1,
         maximum_dry_prob: float = 0.85,
     ) -> xr.DataArray:
-        return scores.categorical.seeps(
+        """
+        Calculate SEEPS skill (Rodwell et al. 2010) of precipitation forecast vs. reference.
+
+        ``scores.categorical.seeps`` returns the negatively-oriented SEEPS *error*
+        (0 = perfect). This method returns ``1 - SEEPS_error`` instead, the
+        positively-oriented convention used for ECMWF/AIFS reporting and consistent
+        with ``lower_is_better`` treating ``seeps`` as higher-is-better.
+
+        Parameters
+        ----------
+        p, gt: xr.DataArray
+            Forecast / ground truth precipitation (metres; converted to mm internally).
+        c: xr.Dataset
+            Climatology with a ``statistic`` dim providing ``prob_dry`` and
+            ``light_heavy_threshold``.
+        minimum_dry_prob, maximum_dry_prob: float
+            Bounds on climatological dry probability outside which points are masked.
+
+        Returns
+        -------
+        xr.DataArray
+            ``1 - SEEPS_error`` (higher is better): 1 = perfect, ~0 = no-skill,
+            negative = worse than reference. Masked climatological extremes are NaN.
+        """
+        seeps_error = scores.categorical.seeps(
             fcst=p * 1000,  # converted to mm
             obs=gt * 1000,
             prob_dry=c.sel(statistic="prob_dry"),
@@ -1365,6 +1386,8 @@ class Scores:
             upper_masked_value=maximum_dry_prob,
             reduce_dims=self._agg_dims,
         )
+        # Positively-oriented SEEPS (1 - error); NaNs propagate unchanged.
+        return 1.0 - seeps_error
 
     def calc_nse(self, p: xr.DataArray, gt: xr.DataArray) -> xr.DataArray:
         """


### PR DESCRIPTION
## Description
Converting seeps calculation from error to score as per Rodwell et al. 2010

## Issue Number

Closes #2687


Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ X ] I have performed a self-review of my code
-   [ X ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
