### PR TITLE
[2685] Plot training for LSF

### DIFF
--- a/src/weathergen/utils/plot_training.py
+++ b/src/weathergen/utils/plot_training.py
@@ -10,6 +10,7 @@
 import argparse
 import logging
 import pdb
+import shutil
 import subprocess
 import sys
 import traceback
@@ -18,7 +19,6 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 import yaml
-import shutil
 
 import weathergen.common.config as config
 from weathergen.train.utils import TRAIN
@@ -31,6 +31,37 @@ MAX_FILENAME_LEN = 255
 PLOT_DPI_VALUE = 150
 
 
+def check_active_runs(runs_ids):
+    """
+    Check if the specified runs are active.
+
+    Parameters
+    ----------
+    runs_ids : dict
+        Dictionary of run IDs to check.
+
+    Returns
+    -------
+    list
+        List of booleans indicating if each run is active.
+    """
+    if shutil.which("squeue"):
+        sq_arg = "--format='%.18i %.9P %.30j %.8u %.8T %.10M %.9l %.6D %R' --me"
+        ret = subprocess.run(["squeue", sq_arg], capture_output=True)
+        running_state = "RUNNING"
+    else:
+        ret = subprocess.run(["bjobs", "-o", "jobid stat job_name"], capture_output=True)
+        running_state = "RUN"
+
+    lines = str(ret.stdout).split("\\n")
+    runs_active = [
+        any([run_id in line and running_state in line for line in lines[1:]])
+        for run_id in runs_ids.keys()
+    ]
+    return runs_active
+
+
+####################################################################################################
 def _add_legend(
     labels,
     outside: bool,
@@ -909,18 +940,7 @@ def plot_train(args=None):
     ]
 
     # determine which runs are still alive (as a process, though they might hang internally)
-    if shutil.which("squeue"):
-        sq_arg = "--format='%.18i %.9P %.30j %.8u %.8T %.10M %.9l %.6D %R' --me"
-        ret = subprocess.run(["squeue", sq_arg], capture_output=True)
-        running_state = "RUNNING"
-    else:
-        ret = subprocess.run(["bjobs", "-o", "jobid stat job_name"], capture_output=True)
-        running_state = "RUN"
-        lines = str(ret.stdout).split("\\n")
-        runs_active = [
-            any([run_id in line and running_state in line for line in lines[1:]])
-            for run_id in runs_ids.keys()
-        ]
+    runs_active = check_active_runs(runs_ids)
 
     x_scale_log = args.log_x
 

--- a/src/weathergen/utils/plot_training.py
+++ b/src/weathergen/utils/plot_training.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 import yaml
+import shutil
 
 import weathergen.common.config as config
 from weathergen.train.utils import TRAIN
@@ -908,13 +909,18 @@ def plot_train(args=None):
     ]
 
     # determine which runs are still alive (as a process, though they might hang internally)
-    sq_arg = "--format='%.18i %.9P %.30j %.8u %.8T %.10M %.9l %.6D %R' --me"
-    ret = subprocess.run(["squeue", sq_arg], capture_output=True)
-    lines = str(ret.stdout).split("\\n")
-    runs_active = [
-        any([run_id in line and "RUNNING" in line for line in lines[1:]])
-        for run_id in runs_ids.keys()
-    ]
+    if shutil.which("squeue"):
+        sq_arg = "--format='%.18i %.9P %.30j %.8u %.8T %.10M %.9l %.6D %R' --me"
+        ret = subprocess.run(["squeue", sq_arg], capture_output=True)
+        running_state = "RUNNING"
+    else:
+        ret = subprocess.run(["bjobs", "-o", "jobid stat job_name"], capture_output=True)
+        running_state = "RUN"
+        lines = str(ret.stdout).split("\\n")
+        runs_active = [
+            any([run_id in line and running_state in line for line in lines[1:]])
+            for run_id in runs_ids.keys()
+        ]
 
     x_scale_log = args.log_x
 


### PR DESCRIPTION
## Description
Adds support for LSF alongside Slurm when checking active job runs.

- Added the LSF command to check active runs

- Added a check to detect whether the scheduler is Slurm or LSF, so the correct command is used automatically


## Issue Number
closes #2685 
<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [X] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
