### PR TITLE
Region-mask the climatology in all scoring pipelines

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
@@ -49,6 +49,7 @@ from weathergen.evaluate.plotting.timeseries import Timeseries
 from weathergen.evaluate.scores.score import VerifiedData, get_score
 from weathergen.evaluate.utils.array_utils import bias_ranges, common_ranges
 from weathergen.evaluate.utils.clim_utils import get_climatology, needs_climatology
+from weathergen.evaluate.utils.regions import RegionBoundingBox
 
 _logger = logging.getLogger(__name__)
 
@@ -112,6 +113,9 @@ def run_score_timeseries_pipeline(
         max_workers=reader.eval_cfg.get("max_workers", None),
     )
 
+    needs_clim = needs_climatology(metrics_dict)
+    aligned_clim_data = get_climatology(reader, da_tars, stream) if needs_clim else None
+
     # --- Parallel score computation across (region, fstep) pairs ---
     score_tasks: list[dict] = []
     for fstep in fsteps:
@@ -130,6 +134,12 @@ def run_score_timeseries_pipeline(
         )
         preds_with_hour = preds_fs.assign_coords(source_end_hour=source_end_hour)
         tars_with_hour = tars_fs.assign_coords(source_end_hour=source_end_hour)
+        # get_score groups every DataArray argument, so the climatology is grouped too.
+        clim_with_hour = (
+            aligned_clim_data[fstep].assign_coords(source_end_hour=source_end_hour)
+            if aligned_clim_data
+            else None
+        )
 
         for region in regions:
             # PSD is a spatial metric incompatible with sample+ipoint aggregation
@@ -140,14 +150,23 @@ def run_score_timeseries_pipeline(
 
             metric_names = list(region_metrics.keys())
             metric_params = list(region_metrics.values())
+            # Masked here: the worker only labels its results with `region`.
+            bbox = RegionBoundingBox.from_region_name(region)
+            preds_r = bbox.apply_mask(preds_with_hour)
+            tars_r = bbox.apply_mask(tars_with_hour)
+            if preds_r.sizes.get("ipoint") == 0:
+                continue
             score_tasks.append(
                 dict(
                     fstep=fstep,
                     region=region,
                     metric_names=metric_names,
                     metric_params=metric_params,
-                    preds_with_hour=preds_with_hour,
-                    tars_with_hour=tars_with_hour,
+                    preds_with_hour=preds_r,
+                    tars_with_hour=tars_r,
+                    clim_with_hour=(
+                        bbox.apply_mask(clim_with_hour) if clim_with_hour is not None else None
+                    ),
                     unique_hours=unique_hours,
                 )
             )
@@ -183,6 +202,7 @@ def _compute_timeseries_scores_for_fstep(
     metric_params: list,
     preds_with_hour: xr.DataArray,
     tars_with_hour: xr.DataArray,
+    clim_with_hour: xr.DataArray | None,
     unique_hours: list[int],
 ) -> tuple[int, str, dict[str, xr.DataArray]]:
     """Compute grouped scores for one (region, fstep) pair (parallelisable worker).
@@ -195,7 +215,7 @@ def _compute_timeseries_scores_for_fstep(
     metric_scores: dict[str, xr.DataArray] = {}
     for metric_name, parameters in zip(metric_names, metric_params, strict=False):
         score = get_score(
-            VerifiedData(preds_with_hour, tars_with_hour, None, None, None),
+            VerifiedData(preds_with_hour, tars_with_hour, None, None, clim_with_hour),
             metric_name,
             agg_dims=agg_dims,
             group_by_coord=group_by_coord,

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration_utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration_utils.py
@@ -106,9 +106,10 @@ def _compute_scores(
             preds_fs = da_preds[fstep]
             preds_next, tars_next = get_next_fstep_data(fstep, da_preds, da_tars, fsteps)
             climatology = aligned_clim_data[fstep] if aligned_clim_data else None
-            tars_r, preds_r, tars_next_r, preds_next_r = [
+            # The climatology is aligned to the full target, so it is masked with the data.
+            tars_r, preds_r, tars_next_r, preds_next_r, climatology_r = [
                 bbox.apply_mask(x) if x is not None else None
-                for x in (tars_fs, preds_fs, tars_next, preds_next)
+                for x in (tars_fs, preds_fs, tars_next, preds_next, climatology)
             ]
             tasks.append(
                 dict(
@@ -117,7 +118,7 @@ def _compute_scores(
                     metric_names=metric_names,
                     metric_params=metric_params,
                     score_data=VerifiedData(
-                        preds_r, tars_r, preds_next_r, tars_next_r, climatology
+                        preds_r, tars_r, preds_next_r, tars_next_r, climatology_r
                     ),
                     preds_r=preds_r,
                 )

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -1375,6 +1375,9 @@ class Scores:
             ``1 - SEEPS_error`` (higher is better): 1 = perfect, ~0 = no-skill,
             negative = worse than reference. Masked climatological extremes are NaN.
         """
+        if c is None:
+            return xr.full_like(p.mean(self._agg_dims), np.nan)
+
         seeps_error = scores.categorical.seeps(
             fcst=p * 1000,  # converted to mm
             obs=gt * 1000,

--- a/packages/evaluate/src/weathergen/evaluate/scores/score_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score_orchestration.py
@@ -74,12 +74,15 @@ def _score_single_fstep(
     -------
     (fstep, combined_metrics, metric_attrs) or None if no valid scores.
     """
+    # The climatology is aligned to the full target, so it is masked with the data.
+    tars, preds, tars_next, preds_next, climatology = [
+        bbox.apply_mask(x) if x is not None else None
+        for x in (tars, preds, tars_next, preds_next, climatology)
+    ]
+
+    # Checked after masking: the region itself may contain no points.
     if preds.sizes.get("ipoint") == 0:
         return None
-
-    tars, preds, tars_next, preds_next = [
-        bbox.apply_mask(x) if x is not None else None for x in (tars, preds, tars_next, preds_next)
-    ]
 
     score_data = VerifiedData(preds, tars, preds_next, tars_next, climatology)
 

--- a/packages/evaluate/src/weathergen/evaluate/utils/clim_utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/utils/clim_utils.py
@@ -132,6 +132,13 @@ def align_clim_data(
                 ),
                 dims=["statistic"] + list(target_da.dims),
                 coords=all_stat_coords,
+            ).assign_coords(
+                # Keep the target's non-dimension coords (lat/lon) for region masking
+                {
+                    name: coord
+                    for name, coord in target_da.coords.items()
+                    if name not in all_stat_coords
+                }
             )
         else:
             aligned_clim[fstep] = xr.DataArray(


### PR DESCRIPTION
## Description

Basically what I changed here is applying region sepcific box on climatology so the plots and scores can be calculated with no issues when specifying a region for your evaluation.

I tested it on few runs (imerg and seeps) for 5 regions ['nhem', 'shem', 'tropics', 'europe', 'globa'] and it worked without producing 
the alignment error: AlignmentError: cannot align … join='exact' for seeps.

I am not sure if I touched all the needed file and if this fix could lead to an error somewhere else and I would strongly recommend a rigorous review

## Issue Number

Closes #2696 


Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [X] I have performed a self-review of my code
-   [X] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
