### PR TITLE
switch for consistently enabling gradient tracking

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -92,6 +92,8 @@ load_chkpt: {}
 norm_type: "LayerNorm"
 qk_norm_type: null  # if null, defaults to norm_type
 
+lrp_enabled: False
+
 #####################################
 
 streams_directory: "./config/streams/era5_1deg/"

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -123,8 +123,12 @@ class EmbeddingEngine(torch.nn.Module):
             scatter_idxs = self.get_scatter_idxs_vectorized(batch)
             scatter_idxs = scatter_idxs.unsqueeze(1).repeat((1, self.cf.ae_local_dim_embed))
 
-            # actual scatter operation and apply per cell positional encoding
-            tokens_all.scatter_(0, scatter_idxs, torch.cat(x_embeds))
+            # for xai lrp technique 
+            if self.cf.lrp_enabled:
+                tokens_all = tokens_all.scatter(0, scatter_idxs, torch.cat(x_embeds))
+            else:
+                # actual scatter operation and apply per cell positional encoding
+                tokens_all = tokens_all.scatter_(0, scatter_idxs, torch.cat(x_embeds))
 
         pe_idxs = self.get_pe_idxs_vectorized(batch)
         tokens_all = tokens_all + pe_embed[pe_idxs]


### PR DESCRIPTION
## Description

In the current WeatherGenerator setup when the model does a forward pass, it runs through `_scatter` in some instances this does not preserve the autograd graph back to the ERA5 input tokens. I've implemented a switch in the config. Will add some sample runs to show that performance of model doesn't change here.


## Issue Number

Closes #2661 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
