### PR TITLE
Add data_loading.num_workers_validation

### DIFF
--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -705,7 +705,7 @@ class Model(torch.nn.Module):
 
         num_params_fe = get_num_parameters(
             self.forecast_engine.net.fe_blocks
-            if self.cf.get("fe_diffusion_model")
+            if self.cf.get("fe_diffusion_model", False)
             else self.forecast_engine.fe_blocks
         )
 
@@ -885,7 +885,7 @@ class Model(torch.nn.Module):
                     # NOTE: This is precautionary, might need to be handled differently.
                     # It should not be the same as conditioning tokens.
                     tokens = None
-                    continue
+src/weathergen/model/model.py                    continue
 
                 # Unified diffusion decoding path — handles both:
                 #  • rollout (diffusion_rollout=True): tokens is a list; take the final ODE state

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -401,7 +401,8 @@ class Model(torch.nn.Module):
         if cf.fe_num_blocks > 0:
             if cf.get("fe_diffusion_model_conditioning_type", None) == "ada_ln":
                 assert cf.get("fe_diffusion_model_conditioning_type", None) is not None, (
-                    "Diffusion conditioning embedding dimension must be specified when using diffusion model conditioning"
+                    "Diffusion conditioning embedding dimension must be specified when "
+                    + "using diffusion model conditioning"
                 )
                 self.forecast_engine = ForecastingEngine(
                     cf,
@@ -704,7 +705,7 @@ class Model(torch.nn.Module):
 
         num_params_fe = get_num_parameters(
             self.forecast_engine.net.fe_blocks
-            if self.cf.fe_diffusion_model
+            if self.cf.get("fe_diffusion_model")
             else self.forecast_engine.fe_blocks
         )
 
@@ -796,13 +797,14 @@ class Model(torch.nn.Module):
             and self.cf.get("fe_diffusion_model_conditioning", None) == "forecast"
         ):
             tokens = tokens.reshape(shape)
-            # tokens[:, 0] = t (most recent), tokens[:, 1] = t-1, ..., tokens[:, -1] = t-(T-1) (oldest)
+            # tokens[:,0] = t (most recent), tokens[:,1] = t-1, ..., tokens[:,-1] = t-(T-1) (oldest)
             if self.cf.stage == "inference":
                 print("Using most recent steps as conditioning tokens for inference.")
                 # conditioning_tokens = tokens[:, :-1].sum(axis=1)
                 conditioning_tokens = tokens[:, 1:].sum(axis=1)
             else:
-                # Conditioning: all older context steps [t-1, ..., t-(T-1)]; denoising target: t (newest)
+                # Conditioning: all older context steps [t-1, ..., t-(T-1)];
+                # denoising target: t (newest)
                 conditioning_tokens = tokens[:, 1:].sum(axis=1)
                 conditioning_tokens = conditioning_tokens + torch.randn_like(
                     conditioning_tokens
@@ -811,7 +813,8 @@ class Model(torch.nn.Module):
                     "fe_diffusion_classifier_free_guidance_prob", 0.0
                 ):  # occasionally dropout conditioning for classifier free guidance
                     conditioning_tokens = torch.zeros_like(conditioning_tokens)
-            # X_t (tokens[:, 0], most recent) is the diffusion denoising target; older steps are conditioning.
+            # X_t (tokens[:, 0], most recent) is the diffusion denoising target;
+            # older steps are conditioning.
             batch.samples[0].meta_info["LATENT_CONDITIONING_TOKENS"] = conditioning_tokens
             # self.forecast_engine._pending_target_tokens = diffusion_target_tokens
             tokens = tokens[:, 0]
@@ -879,7 +882,9 @@ class Model(torch.nn.Module):
                     # inference_forward always starts from pure noise regardless.
                     final_abs = cond + tokens[-1] if predict_residual else tokens[-1]
                     batch.samples[0].meta_info["LATENT_CONDITIONING_TOKENS"] = final_abs
-                    tokens = None  # NOTE: This is precautionary, might need to be handled differently. It should not be the same as conditioning tokens.
+                    # NOTE: This is precautionary, might need to be handled differently.
+                    # It should not be the same as conditioning tokens.
+                    tokens = None
                     continue
 
                 # Unified diffusion decoding path — handles both:
@@ -889,7 +894,7 @@ class Model(torch.nn.Module):
                     "diffusion_rollout", False
                 ):
                     if isinstance(tokens, list):
-                        # diffusion_rollout=True: discard intermediate ODE steps, keep the final state.
+                        # diffusion_rollout=True: discard intermediate steps, keep the final state.
                         tokens = tokens[-1]  # (1, healpix_cells, embed_dim)
                     cond = batch.samples[0].meta_info["LATENT_CONDITIONING_TOKENS"]
                     predict_residual = self.cf.get("fe_diffusion_predict_residual", False)
@@ -901,7 +906,8 @@ class Model(torch.nn.Module):
                         model_params, step, member_final_tokens, batch, tmp_output, out_step=0
                     )
                     # pred_tuple has N entries (one per member / "batch" item).
-                    # Concatenate along dim 0: (N, n_points, channels), wrap in 1-tuple (batch_size=1).
+                    # Concatenate along dim 0: (N, n_points, channels),
+                    # wrap in 1-tuple (batch_size=1).
                     for sname, pred_tuple in tmp_output.physical[0].items():
                         output.add_physical_prediction(
                             step, sname, (torch.cat(list(pred_tuple), dim=0),)

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -343,7 +343,9 @@ class Trainer(TrainerBase):
             "num_workers": cf.data_loading.num_workers,
         }
         self.data_loader = torch.utils.data.DataLoader(self.dataset, **loader_params, sampler=None)
-        # loader_params["num_workers"]=  0
+        loader_params["num_workers"] = cf.data_loading.get(
+            "num_workers_validation", cf.data_loading.num_workers
+        )
         self.data_loader_validation = torch.utils.data.DataLoader(
             self.dataset_val, **loader_params, sampler=None
         )
@@ -1291,8 +1293,8 @@ class Trainer(TrainerBase):
             if is_root():
                 if stage == VAL:
                     logger.info(
-                        f"""validation{stage_suffix} ({self.cf.general.run_id}) : {mini_epoch:03d} : 
-                        {np.nanmean(avg_loss)}"""
+                        f"""validation{stage_suffix} ({self.cf.general.run_id}) : 
+                        {mini_epoch:03d} : {np.nanmean(avg_loss)}"""
                     )
 
                 elif stage == TRAIN:


### PR DESCRIPTION
## Description

Add data_loading.num_workers_validation

Example usage:

```
data_loading :

  num_workers: 12
  num_workers_validation: 6
  rng_seed: ???
  repeat_data_in_mini_epoch : False
```

## Issue Number

-

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
