### PR TITLE
Make loss-spike batch skip a global all-reduce decision across ranks

### DIFF
--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -1230,7 +1230,7 @@ class Trainer(TrainerBase):
             skip_flag = torch.tensor(
                 [int(should_skip)], dtype=torch.int32, device=self.device or torch.device("cpu")
             )
-            torch.distributed.broadcast(skip_flag, src=0)
+            torch.distributed.all_reduce(skip_flag, op=torch.distributed.ReduceOp.MAX)
             should_skip = bool(skip_flag.item())
 
         return should_skip
@@ -1245,10 +1245,11 @@ class Trainer(TrainerBase):
         if not self.loss_spike_cfg.enabled:
             return False
 
+        # each rank checks its local loss; the skip decision is then all-reduced (OR) so
+        # that a spike / non-finite loss on any rank skips the batch on all ranks
         should_skip = False
-        if not is_root():
-            return self._sync_loss_spike_skip(should_skip)
-
+        local_anomaly = False
+        baseline, ratio = float("nan"), float("nan")
         is_finite = np.isfinite(loss_value)
         min_history = int(self.loss_spike_cfg.min_history)
         if len(self.loss_spike_history) >= min_history:
@@ -1256,14 +1257,19 @@ class Trainer(TrainerBase):
             ratio = loss_value / baseline if baseline > 0 else np.inf
             is_large_enough = loss_value >= float(self.loss_spike_cfg.loss_threshold)
             is_spike = ratio >= float(self.loss_spike_cfg.ratio_threshold)
-            if (is_finite and is_large_enough and is_spike) or not is_finite:
-                self._write_loss_spike_record(loss_value, baseline, ratio, batch, mini_epoch, bidx)
-                should_skip = bool(self.loss_spike_cfg.skip_batch)
+            local_anomaly = (is_finite and is_large_enough and is_spike) or not is_finite
+            should_skip = local_anomaly and bool(self.loss_spike_cfg.skip_batch)
+
+        should_skip = self._sync_loss_spike_skip(should_skip)
+
+        # logging stays rank-0-only; record fields are rank 0's local values
+        if is_root() and (local_anomaly or should_skip):
+            self._write_loss_spike_record(loss_value, baseline, ratio, batch, mini_epoch, bidx)
 
         if is_finite and not should_skip:
             self.loss_spike_history.append(float(loss_value))
 
-        return self._sync_loss_spike_skip(should_skip)
+        return should_skip
 
     def _log_instant_grad_norms(self, stage: Stage):
         """


### PR DESCRIPTION
Under DDP the loss-spike/NaN skip decision was computed only on rank 0 and broadcast, but losses are rank-local, so a NaN or spike on ranks 1..N-1 with a finite rank-0 loss was never skipped and its gradients poisoned the all-reduce (only the GradScaler silently rejected the step). Every rank now evaluates the spike/NaN check on its local loss (each maintaining its own history) and the flags are combined with an all-reduce MAX (logical OR), so an anomaly on any rank skips the batch on all ranks. Collective-call symmetry is preserved in all code paths and the non-distributed path is unchanged; jsonl logging stays rank-0-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)