### PR TITLE
Fix NaN poisoning from mask-excluded tokens in SSL L1 loss

### DIFF
--- a/src/weathergen/train/loss_modules/loss_module_ssl.py
+++ b/src/weathergen/train/loss_modules/loss_module_ssl.py
@@ -321,7 +321,10 @@ def _masked_l1_loss_per_sample(
     mask_f = mask.to(per_token_loss.dtype)
     token_counts = mask_f.sum(dim=-1)
     valid_samples = token_counts > 0
-    per_sample_loss = (per_token_loss * mask_f).sum(dim=-1) / token_counts.clamp(min=1.0)
+    # torch.where (not multiply): NaN at mask-excluded positions must not poison the sum.
+    per_sample_loss = torch.where(mask.bool(), per_token_loss, 0.0).sum(dim=-1) / (
+        token_counts.clamp(min=1.0)
+    )
 
     return per_sample_loss[valid_samples].mean()
 


### PR DESCRIPTION
## Description

In `_masked_l1_loss_per_sample`, masked-out tokens were zeroed by multiplying with the mask,
but `NaN * 0 = NaN`, so a non-finite value at an excluded position poisoned the whole loss
(and its gradients). Fixed by selecting with `torch.where(mask.bool(), per_token_loss, 0.0)`
so excluded positions contribute exactly zero.

Sanity-tested: NaN outside the mask now yields the expected finite L1 mean, a NaN inside the
mask still propagates, and gradients are unchanged for finite inputs.

This is the same single commit as #2717 (which targets `sophiex/dev-ssl/ssl-and-diff-july`),
cherry-picked onto `develop-ssl-diffusion-v1` so it can be reviewed and merged independently.

## Issue Number

Closes #2723

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)
