### PR TITLE
use the target random number for also source random number

### DIFF
--- a/config/diffusion/config_diffusion_forecast.yml
+++ b/config/diffusion/config_diffusion_forecast.yml
@@ -270,7 +270,16 @@ training_config:
   target_input: {
     "forecasting" : {
       masking_strategy: "forecast",
-      masking_strategy_config: {diffusion_rn: True},
+      # The target draw is the authoritative diffusion noise level (see Masker.
+      # build_samples_for_stream), so it has to carry the same distribution spec as
+      # model_input -- without it the draw silently falls back to log_normal N(0,1)
+      # while diffusion.py and the latent-diffusion loss both read it as log_sigma.
+      masking_strategy_config: {
+        diffusion_rn: True,
+        noise_distribution: *noise_distribution,
+        sigma_min: *sigma_min,
+        sigma_max: *sigma_max
+        },
       num_steps_input: 1,
       num_samples: 1,
       }

--- a/src/weathergen/datasets/masking.py
+++ b/src/weathergen/datasets/masking.py
@@ -460,13 +460,6 @@ class Masker:
                 # determine if diagnostic dataset or randomly dropped => mask is empty
                 if is_stream_diagnostic(stream_info, self.stage) or is_stream_dropped:
                     source_mask, mask_params = torch.zeros(num_cells, dtype=torch.bool), {}
-                    # Propagate noise_level_rn from the corresponding target metadata so that
-                    # diffusion.py can access it via the source sample's meta_info during forward.
-                    target_noise_level = target_masks.metadata[target_idx].params.get(
-                        "noise_level_rn"
-                    )
-                    if target_noise_level is not None:
-                        mask_params = {"noise_level_rn": target_noise_level}
                 else:
                     source_mask, mask_params = self._get_mask(
                         num_cells=num_cells,
@@ -475,6 +468,16 @@ class Masker:
                         target_relationship_mask=(relationship, target_masks.get_mask(target_idx)),
                         channel_names=source_channel_names,
                     )
+
+                # One noise level per source/target pair. diffusion.py reads it off the source
+                # metadata to noise the latents, the latent-diffusion loss reads it off the target
+                # metadata to weight the residual; they have to be the same draw. The target is
+                # authoritative, so any value drawn for the source above is discarded here. This
+                # also covers sources whose mask is forced empty (diagnostic streams, randomly
+                # dropped sources), which never draw a noise level of their own.
+                target_noise_level = target_masks.metadata[target_idx].params.get("noise_level_rn")
+                if target_noise_level is not None:
+                    mask_params["noise_level_rn"] = target_noise_level
 
                 corr = target_idx
                 source_masks.add_mask(


### PR DESCRIPTION
## Description

Problem: the random number used to make the noise signal for the diffusion forward process is coming from the source random draw. the random number for calculating the loss weight for diffusion is coming from the target random draw. 

Fix: take the arget random number also for the source.

Remark: for this to work, the `target_input` in the config has to be set:
```
  target_input: {
    "forecasting" : {
      ...
      masking_strategy_config: {
        diffusion_rn: True,
        noise_distribution: *noise_distribution,
        sigma_min: *sigma_min,
        sigma_max: *sigma_max
        },
      ...
```


## Issue Number

No issue

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
