### PR TITLE
Fix x-axis label in average loss training plot

### DIFF
--- a/src/weathergen/utils/plot_training.py
+++ b/src/weathergen/utils/plot_training.py
@@ -347,7 +347,7 @@ def plot_loss_avg(
         plt.xscale("log")
     plt.title("average loss")
     plt.ylabel("loss")
-    plt.xlabel("step")
+    plt.xlabel("samples")
     plt.tight_layout()
     _add_legend(
         legend_str,


### PR DESCRIPTION
## Description

This PR fixes a minor labelling bug in the `plot_loss_avg` function within `src/weathergen/utils/plot_training.py`. 

* The function extracts the `num_samples` column from the metrics log to plot on the x-axis, but previously incorrectly hardcoded the axis label to `plt.xlabel("step")`.
* Updated the label to `plt.xlabel("samples")` so the generated `*train_avg.png` plots accurately reflect the underlying data.

* Purely cosmetic fix for the training diagnostics plots.
* No impact on the actual training pipeline or metrics gathering.

## Issue Number

Closes #2734 
<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
