### PR TITLE
Re-enable param re-naming to allow for more robust chkpt loading

### DIFF
--- a/src/weathergen/model/model_interface.py
+++ b/src/weathergen/model/model_interface.py
@@ -269,20 +269,20 @@ def load_model(cf, model, device, run_id: str, with_ddp: bool, with_fsdp: bool, 
 
     is_model_sharded = with_ddp and with_fsdp
     if is_model_sharded:
-        # model_has_prefix_module = list(model.state_dict().keys())[0].split(".")[0] == "module"
-        # params_has_prefix_module = list(params.keys())[0].split(".")[0] == "module"
-        # if model_has_prefix_module and not params_has_prefix_module:
-        #     # add "module." prefix
-        #     params_temp = {}
-        #     for k in params.keys():
-        #         params_temp["module." + k] = params[k]
-        #     params = params_temp
-        # elif not model_has_prefix_module and params_has_prefix_module:
-        #     # remove "module." prefix
-        #     params_temp = {}
-        #     for k in params.keys():
-        #         params_temp[k.replace("module.", "")] = params[k]
-        #     params = params_temp
+        model_has_prefix_module = list(model.state_dict().keys())[0].split(".")[0] == "module"
+        params_has_prefix_module = list(params.keys())[0].split(".")[0] == "module"
+        if model_has_prefix_module and not params_has_prefix_module:
+            # add "module." prefix
+            params_temp = {}
+            for k in params.keys():
+                params_temp["module." + k] = params[k]
+            params = params_temp
+        elif not model_has_prefix_module and params_has_prefix_module:
+            # remove "module." prefix
+            params_temp = {}
+            for k in params.keys():
+                params_temp[k.replace("module.", "")] = params[k]
+            params = params_temp
 
         meta_sharded_sd = model.state_dict()
         maybe_sharded_sd = {}


### PR DESCRIPTION
## Description

Re-enable param re-naming to allow for more robust chkpt loading

## Issue Number

-

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
