### PR TITLE
add reset_parameters to RSMNorm

### DIFF
--- a/src/weathergen/model/norms.py
+++ b/src/weathergen/model/norms.py
@@ -33,6 +33,11 @@ class RMSNorm(torch.nn.Module):
         self.eps = eps
         self.weight = torch.nn.Parameter(torch.ones(dim))
 
+    def reset_parameters(self):
+        """Re-initialize the learnable scale to ones (matches ``__init__``).
+        """
+        torch.nn.init.ones_(self.weight)
+
     def _norm(self, x):
         """
         Apply the RMSNorm normalization to the input tensor.


### PR DESCRIPTION
Needed so the checkpoint loader can re-init a freshly built RMSNorm after ``to_empty()`` (e.g. modules absent from the checkpoint, like a fresh diffusion forecast engine).

## Description

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
