### PR TITLE
Add condition for timestep index generation so inference for non-diff…

### DIFF
--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -57,7 +57,7 @@ def write_output(
     # forecast indices, so synthesize a contiguous run of indices starting at the
     # original first index to cover every entry in model_output / target_aux_out.
     n_pred_steps = len(model_output.physical)
-    if n_pred_steps > len(timestep_idxs):
+    if cf.get("fe_diffusion_model", False) and n_pred_steps > len(timestep_idxs):
         timestep_idxs = list(range(forecast_offset, forecast_offset + n_pred_steps))
 
     targets_lens = []


### PR DESCRIPTION
…usion models works

## Description

Previously getting this error when trying to inference a JEPA then forecast fine-tuned model:

```
jupiter

uv run --offline inference --from-run-id rrvj7vjv 


Sufficient available samples in the time range specified
  0%|                                                                                                                      | 0/120 [01:46<?, ?it/s]
Traceback (most recent call last):
  File "/e/project1/e-ext-2025e01-128/hickman3/wg_base/develop-ssl-diffusion-v1/WeatherGenerator/src/weathergen/run_train.py", line 113, in run_inference
    trainer.inference(cf, devices, args.from_run_id, args.mini_epoch)
  File "/e/project1/e-ext-2025e01-128/hickman3/wg_base/develop-ssl-diffusion-v1/WeatherGenerator/src/weathergen/train/trainer.py", line 321, in inference
    self.validate(0, self.test_cfg, self.batch_size_test_per_gpu)
  File "/e/project1/e-ext-2025e01-128/hickman3/wg_base/develop-ssl-diffusion-v1/WeatherGenerator/src/weathergen/train/trainer.py", line 776, in validate
    write_output(
  File "/e/project1/e-ext-2025e01-128/hickman3/wg_base/develop-ssl-diffusion-v1/WeatherGenerator/src/weathergen/utils/validation_io.py", line 83, in write_output
    targets = target_aux_out.physical[t_idx][sname]["target"]
              ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
IndexError: list index out of range
[3] > /e/project1/e-ext-2025e01-128/hickman3/wg_base/develop-ssl-diffusion-v1/WeatherGenerator/src/weathergen/utils/validation_io.py(83)write_output()
-> targets = target_aux_out.physical[t_idx][sname]["target"]
```


## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel
