### PR TITLE
Further reduces mem footprint during inference

### DIFF
--- a/src/weathergen/datasets/data_reader_anemoi.py
+++ b/src/weathergen/datasets/data_reader_anemoi.py
@@ -165,7 +165,7 @@ class DataReaderAnemoi(DataReaderTimestep):
         return self.len
 
     @override
-    def _get(self, idx: TIndex, channels_idx: list[int]) -> ReaderData:
+    def _get(self, idx: TIndex, channels_idx: list[int], time_only: bool = False) -> ReaderData:
         """
         Get data for window (for either source or target, through public interface)
 
@@ -193,36 +193,42 @@ class DataReaderAnemoi(DataReaderTimestep):
         # End is inclusive
         didx_end = t_idxs[-1] + 1
 
-        # extract number of time steps and collapse ensemble dimension
-        # ds is a wrapper around zarr with get_coordinate_selection not being exposed since
-        # subsetting is pushed to the ctor via frequency argument; this also ensures that no sub-
-        # sampling is required here
-        try:
-            data = self.ds[didx_start:didx_end][:, :, 0].astype(np.float32)
-        except MissingDateError as e:
-            _logger.debug(f"Date not present in anemoi dataset: {str(e)}. Skipping.")
-            return ReaderData.empty(
-                num_data_fields=len(channels_idx), num_geo_fields=len(self.geoinfo_idx)
-            )
+        if not time_only:
+            # extract number of time steps and collapse ensemble dimension
+            # ds is a wrapper around zarr with get_coordinate_selection not being exposed since
+            # subsetting is pushed to the ctor via frequency argument; this also ensures that no sub-
+            # sampling is required here
+            try:
+                data = self.ds[didx_start:didx_end][:, :, 0].astype(np.float32)
+            except MissingDateError as e:
+                _logger.debug(f"Date not present in anemoi dataset: {str(e)}. Skipping.")
+                return ReaderData.empty(
+                    num_data_fields=len(channels_idx), num_geo_fields=len(self.geoinfo_idx)
+                )
 
-        # coords-first representation and collapse multiple steps
-        data = data.transpose([0, 2, 1]).reshape((data.shape[0] * data.shape[2], -1))
+            # coords-first representation and collapse multiple steps
+            data = data.transpose([0, 2, 1]).reshape((data.shape[0] * data.shape[2], -1))
 
-        # extract geoinfo channels (can be time-varying, so read from dataset)
-        geoinfos = data[:, list(self.geoinfo_idx)]
-        # extract channels
-        data = data[:, list(channels_idx)]
+            # extract geoinfo channels (can be time-varying, so read from dataset)
+            geoinfos = data[:, list(self.geoinfo_idx)]
+            # extract channels
+            data = data[:, list(channels_idx)]
 
-        # construct lat/lon coords
-        latlon = np.concatenate(
-            [
-                np.expand_dims(self.latitudes, 0),
-                np.expand_dims(self.longitudes, 0),
-            ],
-            axis=0,
-        ).transpose()
-        # repeat latlon len(t_idxs) times
-        coords = np.vstack((latlon,) * len(t_idxs))
+            # construct lat/lon coords
+            latlon = np.concatenate(
+                [
+                    np.expand_dims(self.latitudes, 0),
+                    np.expand_dims(self.longitudes, 0),
+                ],
+                axis=0,
+            ).transpose()
+            # repeat latlon len(t_idxs) times
+            coords = np.vstack((latlon,) * len(t_idxs))
+
+        else:
+            data = np.empty((0, len(channels_idx)), dtype=np.float32)
+            geoinfos = np.empty((0, len(self.geoinfo_idx)), dtype=np.float32)
+            coords = np.empty((0, 2), dtype=np.float32)
 
         # date time matching #data points of data
         # Assuming a fixed frequency for the dataset
@@ -234,7 +240,8 @@ class DataReaderAnemoi(DataReaderTimestep):
             data=data,
             datetimes=datetimes,
         )
-        check_reader_data(rd, dtr)
+        if not time_only:
+            check_reader_data(rd, dtr)
 
         return rd
 

--- a/src/weathergen/datasets/data_reader_base.py
+++ b/src/weathergen/datasets/data_reader_base.py
@@ -407,8 +407,28 @@ class DataReaderBase(metaclass=ABCMeta):
 
         return rdata
 
+    def get_time(self, idx: TIndex) -> ReaderData:
+        """
+        Get target data for idx
+
+        Parameters
+        ----------
+        idx : int
+            Index of temporal window
+
+        Returns
+        -------
+        target data (coords, geoinfos, data, datetimes)
+        """
+
+        rdata = self._get(idx, self.target_idx)
+
+        # keep only time
+
+        return rdata
+
     @abstractmethod
-    def _get(self, idx: TIndex, channels_idx: list[int]) -> ReaderData:
+    def _get(self, idx: TIndex, channels_idx: list[int], time_only: bool = False) -> ReaderData:
         """
         Get data for window
 

--- a/src/weathergen/datasets/data_reader_obs.py
+++ b/src/weathergen/datasets/data_reader_obs.py
@@ -243,7 +243,7 @@ class DataReaderObs(DataReaderBase):
         self.properties["vars"] = self.data.attrs["vars"]
 
     @override
-    def _get(self, idx: int, channels_idx: list[int]) -> ReaderData:
+    def _get(self, idx: int, channels_idx: list[int], time_only: bool = False) -> ReaderData:
         """
         Get data for window
 
@@ -272,14 +272,21 @@ class DataReaderObs(DataReaderBase):
         start_row = self.indices_start[idx]
         end_row = self.indices_end[idx]
 
-        coords = self.data.oindex[start_row:end_row, self.coords_idx]
-        geoinfos = (
-            self.data.oindex[start_row:end_row, self.geoinfo_idx]
-            if len(self.geoinfo_idx) > 0
-            else np.zeros((coords.shape[0], 0), np.float32)
-        )
+        if not time_only:
+            coords = self.data.oindex[start_row:end_row, self.coords_idx]
+            geoinfos = (
+                self.data.oindex[start_row:end_row, self.geoinfo_idx]
+                if len(self.geoinfo_idx) > 0
+                else np.zeros((coords.shape[0], 0), np.float32)
+            )
 
-        data = self.data.oindex[start_row:end_row, channels_idx]
+            data = self.data.oindex[start_row:end_row, channels_idx]
+
+        else:
+            data = np.empty((0, len(channels_idx)), dtype=np.float32)
+            geoinfos = np.empty((0, len(self.geoinfo_idx)), dtype=np.float32)
+            coords = np.empty((0, 2), dtype=np.float32)
+
         datetimes = self.dt[start_row:end_row][:, 0]
 
         # indices_start, indices_end above work with [t_start, t_end] and violate
@@ -296,6 +303,8 @@ class DataReaderObs(DataReaderBase):
         )
 
         dtr = self.time_window_handler.window(idx)
-        check_reader_data(rdata, dtr)
+
+        if not time_only:
+            check_reader_data(rdata, dtr)
 
         return rdata

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -67,6 +67,10 @@ def collect_datasources(stream_datasets: list, idx: int, type: str, rng) -> IORe
             get_reader_data = ds.get_source
             normalize_channels = ds.normalize_source_channels
             shuffle = ds.stream_info.get("shuffle_source", False)
+        elif ds.stream_info.get("repeat_steps", False) and type == "target":
+            get_reader_data = ds.get_time
+            normalize_channels = ds.normalize_source_channels
+            shuffle = False
         elif type == "target":
             get_reader_data = ds.get_target
             normalize_channels = ds.normalize_target_channels
@@ -479,13 +483,12 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
         """
 
         if not is_stream_forcing(stream_info, self._stage):
-
             # collect for all forecast steps
             num_output_steps = self._get_output_length(num_forecast_steps)
             # only read one step if target coords can be repeated
-            if stream_info.get("repeat_steps", False) :
+            if stream_info.get("repeat_steps", False):
                 num_output_steps = self.output_offset + 1
-            
+
             for step, timestep_idx in enumerate(range(self.output_offset, num_output_steps)):
                 step_forecast_dt = idx + (self.time_step * timestep_idx) // self.step_timedelta
                 time_win_target = self.time_window_handler.window(step_forecast_dt)
@@ -497,6 +500,9 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                 if token_data[0] is None and token_data[1] is None:
                     continue
 
+                if step > self.output_offset and stream_info.get("repeat_steps", False):
+                    stream_data.add_times(self._stage, timestep_idx, rdata.datetimes)
+
                 if "target_coords" in mode:
                     (tc, tc_l) = self.tokenizer.get_target_coords(
                         stream_info,
@@ -505,7 +511,9 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                         (time_win_target.start, time_win_target.end),
                         target_mask,
                     )
-                    stream_data.add_target_coords(self._stage, timestep_idx, tc, tc_l, rdata.is_spoof)
+                    stream_data.add_target_coords(
+                        self._stage, timestep_idx, tc, tc_l, rdata.is_spoof
+                    )
 
                 if "target_values" in mode:
                     (tt_cells, tt_t, tt_c, idxs_inv) = self.tokenizer.get_target_values(
@@ -554,8 +562,8 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
         Returns:
             StreamData with source and targets masked according to view_meta
         """
-        
-        print( "Starting _build_stream_data for stream: ", stream_info["name"])
+
+        print("Starting _build_stream_data for stream: ", stream_info["name"])
 
         num_output_steps = self._get_output_length(num_forecast_steps)
         stream_data = StreamData(
@@ -576,7 +584,7 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                 input_tokens,
                 input_mask,
             )
-        print( "Finished _build_stream_data_input for stream: ", stream_info["name"])
+        print("Finished _build_stream_data_input for stream: ", stream_info["name"])
 
         if not is_stream_forcing(stream_info, self._stage):
             stream_data = self._build_stream_data_output(
@@ -589,7 +597,7 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                 output_tokens,
                 output_mask,
             )
-            print( "Finished _build_stream_data_output for stream: ", stream_info["name"])
+            print("Finished _build_stream_data_output for stream: ", stream_info["name"])
 
         return stream_data
 
@@ -603,7 +611,6 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
         # source data: iterate overall input steps
         input_data = []
         if not is_stream_diagnostic(stream_ds[0].stream_info, self._stage):
-
             for idx in range(base_idx - num_steps_input_max + 1, base_idx + 1):
                 # TODO: check that we are not out of bounds when we go back in time
 
@@ -625,13 +632,12 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
 
         output_data = []
         if not is_stream_forcing(stream_ds[0].stream_info, self._stage):
-        
             # target data: collect for all forecast steps
             num_output_steps = self._get_output_length(num_forecast_steps)
-            # only read one step if target coords can be repeated
-            if stream_ds[0].stream_info.get("repeat_steps", False) :
-                num_output_steps = self.output_offset + 1
-                
+            # # only read one step if target coords can be repeated
+            # if stream_ds[0].stream_info.get("repeat_steps", False):
+            #     num_output_steps = self.output_offset + 1
+
             for timestep_idx in range(self.output_offset, num_output_steps):
                 step_forecast_dt = base_idx + (self.time_step * timestep_idx) // self.step_timedelta
 
@@ -730,7 +736,7 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
             stream_info = self.streams[stream_name]
             (target_masks, source_masks, source_to_target) = masks_streams[stream_name]
 
-            print( "Starting processing stream: ", stream_name)
+            print("Starting processing stream: ", stream_name)
 
             # max number of input steps
             input_steps = np.array([sc.get("num_steps_input", 1) for _, sc in source_cfgs.items()])
@@ -745,8 +751,8 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
             (input_data, output_data) = self._get_data_windows(
                 idx, num_forecast_steps, i_max, stream_ds.readers
             )
-            
-            print( "Finished _get_data_windows")
+
+            print("Finished _get_data_windows")
 
             # When teacher_time_offset > 0, load a separate set of data windows
             # shifted forward in time for the teacher (target) samples.
@@ -773,8 +779,8 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                 input_tokens_target = input_tokens
                 output_tokens_target = output_tokens
 
-            print( "Finished building tokens")
-            
+            print("Finished building tokens")
+
             for sidx, source_mask in enumerate(source_masks.masks):
                 # Map each source to its target
                 tidx = source_to_target[sidx].item()
@@ -803,8 +809,8 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
 
                 batch.add_source_stream(sidx, tidx, stream_name, sdata, source_masks.metadata[sidx])
 
-            print( "Finished source_masks")
-            
+            print("Finished source_masks")
+
             # for t_idx, mask in enumerate(source_masks):
             input_data_target_orig = input_data_target
             for tidx, target_mask in enumerate(target_masks.masks):
@@ -885,7 +891,9 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                     target_timestamp = target_sample.meta_info[stream_name].params.get("timestamp")
                     source_sample.meta_info[stream_name].add_params({"timestamp": target_timestamp})
 
-        print( "Finished _get_batch for idx: ", idx, " with num_forecast_steps: ", num_forecast_steps)
+        print(
+            "Finished _get_batch for idx: ", idx, " with num_forecast_steps: ", num_forecast_steps
+        )
 
         return batch
 

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -515,6 +515,8 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                         self._stage, timestep_idx, tc, tc_l, rdata.is_spoof
                     )
 
+                # import code; code.interact(local=locals())
+
                 if "target_values" in mode:
                     (tt_cells, tt_t, tt_c, idxs_inv) = self.tokenizer.get_target_values(
                         stream_info,
@@ -563,8 +565,6 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
             StreamData with source and targets masked according to view_meta
         """
 
-        print("Starting _build_stream_data for stream: ", stream_info["name"])
-
         num_output_steps = self._get_output_length(num_forecast_steps)
         stream_data = StreamData(
             base_idx,
@@ -584,7 +584,6 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                 input_tokens,
                 input_mask,
             )
-        print("Finished _build_stream_data_input for stream: ", stream_info["name"])
 
         if not is_stream_forcing(stream_info, self._stage):
             stream_data = self._build_stream_data_output(
@@ -597,7 +596,6 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                 output_tokens,
                 output_mask,
             )
-            print("Finished _build_stream_data_output for stream: ", stream_info["name"])
 
         return stream_data
 
@@ -736,8 +734,6 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
             stream_info = self.streams[stream_name]
             (target_masks, source_masks, source_to_target) = masks_streams[stream_name]
 
-            print("Starting processing stream: ", stream_name)
-
             # max number of input steps
             input_steps = np.array([sc.get("num_steps_input", 1) for _, sc in source_cfgs.items()])
             assert input_steps.min() == input_steps.max(), (
@@ -751,8 +747,6 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
             (input_data, output_data) = self._get_data_windows(
                 idx, num_forecast_steps, i_max, stream_ds.readers
             )
-
-            print("Finished _get_data_windows")
 
             # When teacher_time_offset > 0, load a separate set of data windows
             # shifted forward in time for the teacher (target) samples.
@@ -778,8 +772,6 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
             else:
                 input_tokens_target = input_tokens
                 output_tokens_target = output_tokens
-
-            print("Finished building tokens")
 
             for sidx, source_mask in enumerate(source_masks.masks):
                 # Map each source to its target
@@ -808,8 +800,6 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                 )
 
                 batch.add_source_stream(sidx, tidx, stream_name, sdata, source_masks.metadata[sidx])
-
-            print("Finished source_masks")
 
             # for t_idx, mask in enumerate(source_masks):
             input_data_target_orig = input_data_target
@@ -890,10 +880,6 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                 ):
                     target_timestamp = target_sample.meta_info[stream_name].params.get("timestamp")
                     source_sample.meta_info[stream_name].add_params({"timestamp": target_timestamp})
-
-        print(
-            "Finished _get_batch for idx: ", idx, " with num_forecast_steps: ", num_forecast_steps
-        )
 
         return batch
 

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -35,7 +35,7 @@ from weathergen.datasets.utils import (
 from weathergen.readers_extra.registry import get_extra_reader
 from weathergen.train.utils import Stage, get_batch_size_from_config
 from weathergen.utils.distributed import is_root
-from weathergen.utils.utils import is_stream_diagnostic
+from weathergen.utils.utils import is_stream_diagnostic, is_stream_forcing
 
 type AnyDataReader = DataReaderBase | DataReaderAnemoi | DataReaderObs
 type StreamName = str
@@ -478,41 +478,47 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
 
         """
 
-        # collect for all forecast steps
-        num_output_steps = self._get_output_length(num_forecast_steps)
-        for step, timestep_idx in enumerate(range(self.output_offset, num_output_steps)):
-            step_forecast_dt = idx + (self.time_step * timestep_idx) // self.step_timedelta
-            time_win_target = self.time_window_handler.window(step_forecast_dt)
+        if not is_stream_forcing(stream_info, self._stage):
 
-            # collect all targets for current stream
-            rdata = output_data[step]
-            token_data = output_tokens[step]
+            # collect for all forecast steps
+            num_output_steps = self._get_output_length(num_forecast_steps)
+            # only read one step if target coords can be repeated
+            if stream_info.get("repeat_steps", False) :
+                num_output_steps = self.output_offset + 1
+            
+            for step, timestep_idx in enumerate(range(self.output_offset, num_output_steps)):
+                step_forecast_dt = idx + (self.time_step * timestep_idx) // self.step_timedelta
+                time_win_target = self.time_window_handler.window(step_forecast_dt)
 
-            if token_data[0] is None and token_data[1] is None:
-                continue
+                # collect all targets for current stream
+                rdata = output_data[step]
+                token_data = output_tokens[step]
 
-            if "target_coords" in mode:
-                (tc, tc_l) = self.tokenizer.get_target_coords(
-                    stream_info,
-                    rdata,
-                    token_data,
-                    (time_win_target.start, time_win_target.end),
-                    target_mask,
-                )
-                stream_data.add_target_coords(self._stage, timestep_idx, tc, tc_l, rdata.is_spoof)
+                if token_data[0] is None and token_data[1] is None:
+                    continue
 
-            if "target_values" in mode:
-                (tt_cells, tt_t, tt_c, idxs_inv) = self.tokenizer.get_target_values(
-                    stream_info,
-                    rdata,
-                    token_data,
-                    (time_win_target.start, time_win_target.end),
-                    target_mask,
-                )
+                if "target_coords" in mode:
+                    (tc, tc_l) = self.tokenizer.get_target_coords(
+                        stream_info,
+                        rdata,
+                        token_data,
+                        (time_win_target.start, time_win_target.end),
+                        target_mask,
+                    )
+                    stream_data.add_target_coords(self._stage, timestep_idx, tc, tc_l, rdata.is_spoof)
 
-                stream_data.add_target_values(
-                    self._stage, timestep_idx, tt_cells, tt_c, tt_t, idxs_inv, rdata.is_spoof
-                )
+                if "target_values" in mode:
+                    (tt_cells, tt_t, tt_c, idxs_inv) = self.tokenizer.get_target_values(
+                        stream_info,
+                        rdata,
+                        token_data,
+                        (time_win_target.start, time_win_target.end),
+                        target_mask,
+                    )
+
+                    stream_data.add_target_values(
+                        self._stage, timestep_idx, tt_cells, tt_c, tt_t, idxs_inv, rdata.is_spoof
+                    )
 
         return stream_data
 
@@ -548,6 +554,8 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
         Returns:
             StreamData with source and targets masked according to view_meta
         """
+        
+        print( "Starting _build_stream_data for stream: ", stream_info["name"])
 
         num_output_steps = self._get_output_length(num_forecast_steps)
         stream_data = StreamData(
@@ -557,27 +565,31 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
             self.num_healpix_cells,
         )
 
-        stream_data = self._build_stream_data_input(
-            modes,
-            stream_data,
-            base_idx,
-            stream_info,
-            num_steps_input,
-            input_data,
-            input_tokens,
-            input_mask,
-        )
+        if not is_stream_diagnostic(stream_info, self._stage):
+            stream_data = self._build_stream_data_input(
+                modes,
+                stream_data,
+                base_idx,
+                stream_info,
+                num_steps_input,
+                input_data,
+                input_tokens,
+                input_mask,
+            )
+        print( "Finished _build_stream_data_input for stream: ", stream_info["name"])
 
-        stream_data = self._build_stream_data_output(
-            modes,
-            stream_data,
-            base_idx,
-            stream_info,
-            num_forecast_steps,
-            output_data,
-            output_tokens,
-            output_mask,
-        )
+        if not is_stream_forcing(stream_info, self._stage):
+            stream_data = self._build_stream_data_output(
+                modes,
+                stream_data,
+                base_idx,
+                stream_info,
+                num_forecast_steps,
+                output_data,
+                output_tokens,
+                output_mask,
+            )
+            print( "Finished _build_stream_data_output for stream: ", stream_info["name"])
 
         return stream_data
 
@@ -590,46 +602,54 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
 
         # source data: iterate overall input steps
         input_data = []
-        for idx in range(base_idx - num_steps_input_max + 1, base_idx + 1):
-            # TODO: check that we are not out of bounds when we go back in time
+        if not is_stream_diagnostic(stream_ds[0].stream_info, self._stage):
 
-            rdata = collect_datasources(stream_ds, idx, "source", self.rng)
+            for idx in range(base_idx - num_steps_input_max + 1, base_idx + 1):
+                # TODO: check that we are not out of bounds when we go back in time
 
-            if rdata.is_empty():
-                # work around for https://github.com/pytorch/pytorch/issues/158719
-                # create non-empty mean data instead of empty tensor
-                time_win = self.time_window_handler.window(idx)
-                rdata = spoof(
-                    self.healpix_level,
-                    time_win.start,
-                    stream_ds[0].get_geoinfo_size(),
-                    len(stream_ds[0].mean[stream_ds[0].source_idx]),
-                )
-                rdata.is_spoof = True
+                rdata = collect_datasources(stream_ds, idx, "source", self.rng)
 
-            input_data += [rdata]
+                if rdata.is_empty():
+                    # work around for https://github.com/pytorch/pytorch/issues/158719
+                    # create non-empty mean data instead of empty tensor
+                    time_win = self.time_window_handler.window(idx)
+                    rdata = spoof(
+                        self.healpix_level,
+                        time_win.start,
+                        stream_ds[0].get_geoinfo_size(),
+                        len(stream_ds[0].mean[stream_ds[0].source_idx]),
+                    )
+                    rdata.is_spoof = True
 
-        # target data: collect for all forecast steps
+                input_data += [rdata]
+
         output_data = []
-        num_output_steps = self._get_output_length(num_forecast_steps)
-        for timestep_idx in range(self.output_offset, num_output_steps):
-            step_forecast_dt = base_idx + (self.time_step * timestep_idx) // self.step_timedelta
+        if not is_stream_forcing(stream_ds[0].stream_info, self._stage):
+        
+            # target data: collect for all forecast steps
+            num_output_steps = self._get_output_length(num_forecast_steps)
+            # only read one step if target coords can be repeated
+            if stream_ds[0].stream_info.get("repeat_steps", False) :
+                num_output_steps = self.output_offset + 1
+                
+            for timestep_idx in range(self.output_offset, num_output_steps):
+                step_forecast_dt = base_idx + (self.time_step * timestep_idx) // self.step_timedelta
 
-            rdata = collect_datasources(stream_ds, step_forecast_dt, "target", self.rng)
+                rdata = collect_datasources(stream_ds, step_forecast_dt, "target", self.rng)
 
-            if rdata.is_empty():
-                # work around for https://github.com/pytorch/pytorch/issues/158719
-                # create non-empty mean data instead of empty tensor
-                time_win = self.time_window_handler.window(step_forecast_dt)
-                rdata = spoof(
-                    self.healpix_level,
-                    time_win.start,
-                    stream_ds[0].get_geoinfo_size(),
-                    len(stream_ds[0].mean[stream_ds[0].target_idx]),
-                )
-                rdata.is_spoof = True
+                if rdata.is_empty():
+                    # work around for https://github.com/pytorch/pytorch/issues/158719
+                    # create non-empty mean data instead of empty tensor
+                    time_win = self.time_window_handler.window(step_forecast_dt)
+                    rdata = spoof(
+                        self.healpix_level,
+                        time_win.start,
+                        stream_ds[0].get_geoinfo_size(),
+                        len(stream_ds[0].mean[stream_ds[0].target_idx]),
+                    )
+                    rdata.is_spoof = True
 
-            output_data += [rdata]
+                output_data += [rdata]
 
         return (input_data, output_data)
 
@@ -710,6 +730,8 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
             stream_info = self.streams[stream_name]
             (target_masks, source_masks, source_to_target) = masks_streams[stream_name]
 
+            print( "Starting processing stream: ", stream_name)
+
             # max number of input steps
             input_steps = np.array([sc.get("num_steps_input", 1) for _, sc in source_cfgs.items()])
             assert input_steps.min() == input_steps.max(), (
@@ -723,6 +745,8 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
             (input_data, output_data) = self._get_data_windows(
                 idx, num_forecast_steps, i_max, stream_ds.readers
             )
+            
+            print( "Finished _get_data_windows")
 
             # When teacher_time_offset > 0, load a separate set of data windows
             # shifted forward in time for the teacher (target) samples.
@@ -749,6 +773,8 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                 input_tokens_target = input_tokens
                 output_tokens_target = output_tokens
 
+            print( "Finished building tokens")
+            
             for sidx, source_mask in enumerate(source_masks.masks):
                 # Map each source to its target
                 tidx = source_to_target[sidx].item()
@@ -777,6 +803,8 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
 
                 batch.add_source_stream(sidx, tidx, stream_name, sdata, source_masks.metadata[sidx])
 
+            print( "Finished source_masks")
+            
             # for t_idx, mask in enumerate(source_masks):
             input_data_target_orig = input_data_target
             for tidx, target_mask in enumerate(target_masks.masks):
@@ -856,6 +884,8 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                 ):
                     target_timestamp = target_sample.meta_info[stream_name].params.get("timestamp")
                     source_sample.meta_info[stream_name].add_params({"timestamp": target_timestamp})
+
+        print( "Finished _get_batch for idx: ", idx, " with num_forecast_steps: ", num_forecast_steps)
 
         return batch
 

--- a/src/weathergen/datasets/stream_data.py
+++ b/src/weathergen/datasets/stream_data.py
@@ -350,6 +350,40 @@ class StreamData:
 
         self.target_is_spoof[fstep] = is_spoof
 
+    def add_target_times(
+        self,
+        stage: Stage,
+        fstep: int,
+        times_raw: torch.Tensor,
+    ) -> None:
+        """
+        Add data for target for one input.
+
+        Parameters
+        ----------
+        fstep : int
+            forecast step
+        targets : torch.tensor( number of healpix cells )
+            [ torch.tensor( num tokens, channels) ]
+              Target data for loss computation
+        targets_lens : torch.tensor( number of healpix cells)
+            length of targets per cell
+        target_coords : list( number of healpix cells)
+            [ torch.tensor( points per cell, 105) ]
+              target coordinates
+        target_times : list( number of healpix cells)
+            [ torch.tensor( points per cell) ]
+              absolute target times
+        idxs_inv:
+            Indices to reorder targets back to order in input
+
+        Returns
+        -------
+        None
+        """
+
+        self.target_times_raw[fstep] = times_raw
+
     def target_empty(self) -> bool:
         """
         Test if target for stream is empty

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -1102,7 +1102,7 @@ class Model(torch.nn.Module):
             Prediction output tokens in physical representation for each target_coords.
         """
         chunk_idx = output.chunk_idx(step)
-        fstep_idx = output.fstep_idx(step)
+        fstep_idx = 1  # output.fstep_idx(step)
 
         # Empty dicts evaluate to False in python
         if not self.pred_heads:
@@ -1181,7 +1181,9 @@ class Model(torch.nn.Module):
                 # lens for varlen attention (replicate coords for ensemble members)
                 tcls = torch.cat(
                     [
-                        batch.samples[i_b % n_real].streams_data[stream_name].target_coords_lens[fstep_idx]
+                        batch.samples[i_b % n_real]
+                        .streams_data[stream_name]
+                        .target_coords_lens[fstep_idx]
                         for i_b in range(batch_size)
                     ]
                 )

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -319,45 +319,37 @@ class Trainer(TrainerBase):
         target_aux_chunk = copy.deepcopy(targets_and_auxs[physical_loss_names[0]])
 
         for chunk_idx, chunk in enumerate(chunks):
-            print(f"Starting chunk {chunk_idx} : {chunk}")
-
-            if not compute_full_loss and chunk_idx == 0:
-                batch.to_device_for_output_chunk(self.device, [1])
-            else:
-                # update sine/cosine of day of the year
-                julian_day = (
-                    batch.source_samples.samples[0].streams_data["ERA5"].target_coords[1][:, 14]
-                )
-                julian_day = (torch.acos((julian_day * 0.707112) + 1.5913e-05) * 365.25) / (
-                    2.0 * np.pi
-                )
-                julian_day = (julian_day + 0.25) % 365
-                batch.source_samples.samples[0].streams_data["ERA5"].target_coords[1][:, 14] = (
-                    torch.cos(2.0 * np.pi * julian_day / 365.25) - 1.5913e-05
-                ) / 0.707112
-                batch.source_samples.samples[0].streams_data["ERA5"].target_coords[1][:, 15] = (
-                    torch.sin(2.0 * np.pi * julian_day / 365.25) - 1.5913e-05
-                ) / 0.707112
-                julian_day = (
-                    batch.source_samples.samples[0].streams_data["ERA5"].target_coords[1][:, 14]
-                )
-                # update sine/cosine local time
-                local_time = (
-                    batch.source_samples.samples[0].streams_data["ERA5"].target_coords[1][:, 12]
-                )
-                local_time = (torch.acos(torch.clamp(local_time * 0.707107, -1.0, 1.0)) * 24) / (
-                    2.0 * np.pi
-                )
-                local_time = (local_time + 6.0) % 24.0
-                batch.source_samples.samples[0].streams_data["ERA5"].target_coords[1][:, 12] = (
-                    torch.cos(2.0 * np.pi * local_time / 24.0) / 0.707107
-                )
-                batch.source_samples.samples[0].streams_data["ERA5"].target_coords[1][:, 13] = (
-                    torch.sin(2.0 * np.pi * local_time / 24.0) / 0.707107
-                )
-                local_time = (
-                    batch.source_samples.samples[0].streams_data["ERA5"].target_coords[1][:, 12]
-                )
+            if not compute_full_loss:
+                if chunk_idx == 0:
+                    batch.to_device_for_output_chunk(self.device, chunk)
+                else:
+                    if self.cf.streams["ERA5"].get("repeat_steps", False):
+                        batch.to_device_for_output_chunk(self.device, chunk)
+                    else:
+                        # update sine/cosine of day of the year
+                        pi2 = 2.0 * np.pi
+                        target_coords = (
+                            batch.source_samples.samples[0].streams_data["ERA5"].target_coords
+                        )
+                        julian_day = target_coords[1][:, 14]
+                        julian_day = (torch.acos((julian_day * 0.707112) + 1.5913e-05) * 365.25) / (
+                            2.0 * np.pi
+                        )
+                        julian_day = (julian_day + 0.25) % 365.25
+                        target_coords[1][:, 14] = (
+                            torch.cos(pi2 * julian_day / 365.25) - 1.5913e-05
+                        ) / 0.707112
+                        target_coords[1][:, 15] = (
+                            torch.sin(pi2 * julian_day / 365.25) - 1.5913e-05
+                        ) / 0.707112
+                        # update sine/cosine local time
+                        local_time = target_coords[1][:, 12]
+                        local_time = (
+                            torch.acos(torch.clamp(local_time * 0.707107, -1.0, 1.0)) * 24
+                        ) / (2.0 * np.pi)
+                        local_time = (local_time + 6.0) % 24.0
+                        target_coords[1][:, 12] = torch.cos(pi2 * local_time / 24.0) / 0.707107
+                        target_coords[1][:, 13] = torch.sin(pi2 * local_time / 24.0) / 0.707107
 
             if self.ema_model is None:
                 forecast_chunk = self.model(

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -320,8 +320,11 @@ class Trainer(TrainerBase):
         target_aux_chunk = copy.deepcopy(targets_and_auxs[physical_loss_names[0]])
         
         for chunk_idx, chunk in enumerate(chunks):
-            if not compute_full_loss:
-                batch.to_device_for_output_chunk(self.device, chunk)
+
+            print(f"Starting chunk {chunk_idx} : {chunk}")
+
+            if not compute_full_loss and chunk_idx == 0:
+                batch.to_device_for_output_chunk(self.device, [1])
 
             if self.ema_model is None:
                 forecast_chunk = self.model(
@@ -363,8 +366,8 @@ class Trainer(TrainerBase):
                 forecast_chunk.physical.clear()
                 forecast_chunk.latent = [forecast_chunk.latent[-1]]
 
-            if not compute_full_loss:
-                batch.clear_output_chunk_coordinates(chunk)
+            # if not compute_full_loss:
+            #     batch.clear_output_chunk_coordinates(chunk)
 
         if is_diffusion:
             # single chunk; its fstep dimension is the trajectory, not forecast steps
@@ -914,12 +917,13 @@ class Trainer(TrainerBase):
                                     targets_and_auxs,
                                 )
 
-                        _ = self.loss_calculator_val.compute_loss(
-                            preds=preds,
-                            targets_and_aux=targets_and_auxs,
-                            metadata=extract_batch_metadata(batch),
-                        )
-                        pbar.update(batch_size * self.cf.world_size)
+                        if self.compute_full_validation_loss or is_diffusion:
+                            _ = self.loss_calculator_val.compute_loss(
+                                preds=preds,
+                                targets_and_aux=targets_and_auxs,
+                                metadata=extract_batch_metadata(batch),
+                            )
+                            pbar.update(batch_size * self.cf.world_size)
 
                         if (bidx * batch_size) > mode_cfg.samples_per_mini_epoch:
                             break

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -326,30 +326,36 @@ class Trainer(TrainerBase):
                     if self.cf.streams["ERA5"].get("repeat_steps", False):
                         batch.to_device_for_output_chunk(self.device, chunk)
                     else:
-                        # update sine/cosine of day of the year
                         pi2 = 2.0 * np.pi
                         target_coords = (
-                            batch.source_samples.samples[0].streams_data["ERA5"].target_coords
+                            batch.source_samples.samples[0].streams_data["ERA5"].target_coords[1]
                         )
-                        julian_day = target_coords[1][:, 14]
-                        julian_day = (torch.acos((julian_day * 0.707112) + 1.5913e-05) * 365.25) / (
-                            2.0 * np.pi
-                        )
+
+                        # update sine/cosine of day of the year
+                        julian_day_sin = (target_coords[:, 14] * 0.707118) + 3.26027e-05
+                        julian_day_cos = (target_coords[:, 13] * 0.707095) + 4.48532e-06
+                        julian_day = torch.atan2(julian_day_sin, julian_day_cos) * (365.25 / pi2)
                         julian_day = (julian_day + 0.25) % 365.25
-                        target_coords[1][:, 14] = (
-                            torch.cos(pi2 * julian_day / 365.25) - 1.5913e-05
-                        ) / 0.707112
-                        target_coords[1][:, 15] = (
-                            torch.sin(pi2 * julian_day / 365.25) - 1.5913e-05
-                        ) / 0.707112
+                        target_coords[:, 13] = (
+                            torch.cos(pi2 * julian_day / 365.25) - 4.48532e-06
+                        ) / 0.707095
+                        target_coords[:, 14] = (
+                            torch.sin(pi2 * julian_day / 365.25) - 3.26027e-05
+                        ) / 0.707118
+
                         # update sine/cosine local time
-                        local_time = target_coords[1][:, 12]
-                        local_time = (
-                            torch.acos(torch.clamp(local_time * 0.707107, -1.0, 1.0)) * 24
-                        ) / (2.0 * np.pi)
+                        local_time = torch.atan2(
+                            target_coords[:, 12] * 0.707107, target_coords[:, 11] * 0.707107
+                        )
+                        local_time = ((local_time * 24) / pi2) + 12.0
                         local_time = (local_time + 6.0) % 24.0
-                        target_coords[1][:, 12] = torch.cos(pi2 * local_time / 24.0) / 0.707107
-                        target_coords[1][:, 13] = torch.sin(pi2 * local_time / 24.0) / 0.707107
+                        sign = (-1) ** ((chunk_idx) % 2) if chunk_idx > 1 else -1
+                        target_coords[:, 11] = sign * torch.cos(pi2 * local_time / 24.0) / 0.707107
+                        target_coords[:, 12] = sign * torch.sin(pi2 * local_time / 24.0) / 0.707107
+
+                        # ref = batch.source_samples.samples[0].streams_data["ERA5"].target_coords[chunk[0]].to("cuda")
+                        # errs = [(target_coords[:,i] - ref[:,i]).abs().max().item() for i in [11,12,13,14]]
+                        # print( f"chunk {chunk_idx}: errs = {errs}")
 
             if self.ema_model is None:
                 forecast_chunk = self.model(

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -307,8 +307,7 @@ class Trainer(TrainerBase):
                 )
 
         physical_loss_names = [
-            name for name, loss_cfg in mode_cfg.losses.items()
-            if loss_cfg.type == "LossPhysical"
+            name for name, loss_cfg in mode_cfg.losses.items() if loss_cfg.type == "LossPhysical"
         ]
         assert len(physical_loss_names) == 1, (
             "Chunked non-full validation requires one LossPhysical term."
@@ -316,11 +315,10 @@ class Trainer(TrainerBase):
 
         physical, latent = [], []
         forecast_chunk = batch.get_source_samples()
-        
-        target_aux_chunk = copy.deepcopy(targets_and_auxs[physical_loss_names[0]])
-        
-        for chunk_idx, chunk in enumerate(chunks):
 
+        target_aux_chunk = copy.deepcopy(targets_and_auxs[physical_loss_names[0]])
+
+        for chunk_idx, chunk in enumerate(chunks):
             print(f"Starting chunk {chunk_idx} : {chunk}")
 
             if not compute_full_loss and chunk_idx == 0:
@@ -341,7 +339,9 @@ class Trainer(TrainerBase):
 
             if should_write_output:
                 target_aux = targets_and_auxs[physical_loss_names[0]]
-                target_aux_chunk.physical = [None for _ in range(chunk[0])] + [target_aux.physical[step] for step in chunk]
+                target_aux_chunk.physical = [None for _ in range(chunk[0])] + [
+                    target_aux.physical[step] for step in chunk
+                ]
                 target_aux_chunk.output_idxs = chunk
                 # this modifies targets_and_auxs in place
                 write_output(
@@ -353,7 +353,7 @@ class Trainer(TrainerBase):
                     denormalize_data_fct,
                     batch,
                     forecast_chunk,
-                    { physical_loss_names[0]: target_aux_chunk },
+                    {physical_loss_names[0]: target_aux_chunk},
                 )
 
             if compute_full_loss:
@@ -380,7 +380,6 @@ class Trainer(TrainerBase):
         )
         preds.physical = physical
         preds.latent = latent
-
 
         if not compute_full_loss:
             # this modifies targets_and_auxs in place
@@ -917,7 +916,7 @@ class Trainer(TrainerBase):
                                     targets_and_auxs,
                                 )
 
-                        if self.compute_full_validation_loss or is_diffusion:
+                        if mode_cfg.get("compute_full_validation_loss", True):
                             _ = self.loss_calculator_val.compute_loss(
                                 preds=preds,
                                 targets_and_aux=targets_and_auxs,

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -323,6 +323,41 @@ class Trainer(TrainerBase):
 
             if not compute_full_loss and chunk_idx == 0:
                 batch.to_device_for_output_chunk(self.device, [1])
+            else:
+                # update sine/cosine of day of the year
+                julian_day = (
+                    batch.source_samples.samples[0].streams_data["ERA5"].target_coords[1][:, 14]
+                )
+                julian_day = (torch.acos((julian_day * 0.707112) + 1.5913e-05) * 365.25) / (
+                    2.0 * np.pi
+                )
+                julian_day = (julian_day + 0.25) % 365
+                batch.source_samples.samples[0].streams_data["ERA5"].target_coords[1][:, 14] = (
+                    torch.cos(2.0 * np.pi * julian_day / 365.25) - 1.5913e-05
+                ) / 0.707112
+                batch.source_samples.samples[0].streams_data["ERA5"].target_coords[1][:, 15] = (
+                    torch.sin(2.0 * np.pi * julian_day / 365.25) - 1.5913e-05
+                ) / 0.707112
+                julian_day = (
+                    batch.source_samples.samples[0].streams_data["ERA5"].target_coords[1][:, 14]
+                )
+                # update sine/cosine local time
+                local_time = (
+                    batch.source_samples.samples[0].streams_data["ERA5"].target_coords[1][:, 12]
+                )
+                local_time = (torch.acos(torch.clamp(local_time * 0.707107, -1.0, 1.0)) * 24) / (
+                    2.0 * np.pi
+                )
+                local_time = (local_time + 6.0) % 24.0
+                batch.source_samples.samples[0].streams_data["ERA5"].target_coords[1][:, 12] = (
+                    torch.cos(2.0 * np.pi * local_time / 24.0) / 0.707107
+                )
+                batch.source_samples.samples[0].streams_data["ERA5"].target_coords[1][:, 13] = (
+                    torch.sin(2.0 * np.pi * local_time / 24.0) / 0.707107
+                )
+                local_time = (
+                    batch.source_samples.samples[0].streams_data["ERA5"].target_coords[1][:, 12]
+                )
 
             if self.ema_model is None:
                 forecast_chunk = self.model(

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -138,11 +138,11 @@ def write_output(
                     idxs_inv = target_aux_out.physical[t_idx][sname]["idxs_inv"][i_batch]
                     if idxs_inv is not None and len(idxs_inv) > 0:
                         pred = pred[:, idxs_inv]
-                        target = target[idxs_inv] 
+                        target = target[idxs_inv]
                         t_coords = t_coords[idxs_inv]
                         t_times = t_times[idxs_inv]
 
-                    if len(idxs_inv) == 0 :
+                    if len(idxs_inv) == 0:
                         target = torch.zeros((0, pred.shape[-1]), dtype=target.dtype)
                         t_coords = torch.zeros((0, 2), dtype=torch.float32)
 

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -155,7 +155,7 @@ def write_output(
                     t_times_s += [t_times.astype("datetime64[ns]")]
 
             targets_lens[-1] += [[]]
-            targets_lens[-1][-1] += [t.shape[0] for t in targets_s]
+            targets_lens[-1][-1] += [p.shape[1] for p in preds_s]
 
             preds_all[-1] += [np.concatenate(preds_s, axis=1)]
             targets_all[-1] += [np.concatenate(targets_s)]

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -111,7 +111,7 @@ def write_output(
             if t_idx < forecast_offset:
                 preds_s, targets_s, t_coords_s, t_times_s = _empty_step(n_samples, 1, n_channels)
 
-            elif not_reconstructed or target_aux_out.physical[t_idx][sname]["is_spoof"][0]:
+            if not_reconstructed or target_aux_out.physical[t_idx][sname]["is_spoof"][0]:
                 preds = model_output.get_physical_prediction(chunk_idx, sname)
                 n_ens = preds[0].shape[0] if preds is not None and len(preds) > 0 else 1
                 preds_s, targets_s, t_coords_s, t_times_s = _empty_step(
@@ -136,11 +136,15 @@ def write_output(
                     t_times = target_data["target_times"][i_batch]
 
                     idxs_inv = target_aux_out.physical[t_idx][sname]["idxs_inv"][i_batch]
-                    if idxs_inv is not None:
+                    if idxs_inv is not None and len(idxs_inv) > 0:
                         pred = pred[:, idxs_inv]
-                        target = target[idxs_inv]
-                        t_coords = t_coords[idxs_inv]
+                        target = target[idxs_inv] 
+                        t_coords = t_coords[idxs_inv] 
                         t_times = t_times[idxs_inv]
+
+                    if len(idxs_inv) == 0 :
+                        target = torch.zeros((0, pred.shape[-1]), dtype=target.dtype)
+                        t_coords = torch.zeros((0, 2), dtype=t_coords.dtype)
 
                     # denormalize data if requested and map to storage format
                     preds_s += [dn_data(sname, pred.to(fp32)).detach().cpu().numpy()]

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -139,12 +139,12 @@ def write_output(
                     if idxs_inv is not None and len(idxs_inv) > 0:
                         pred = pred[:, idxs_inv]
                         target = target[idxs_inv] 
-                        t_coords = t_coords[idxs_inv] 
+                        t_coords = t_coords[idxs_inv]
                         t_times = t_times[idxs_inv]
 
                     if len(idxs_inv) == 0 :
                         target = torch.zeros((0, pred.shape[-1]), dtype=target.dtype)
-                        t_coords = torch.zeros((0, 2), dtype=t_coords.dtype)
+                        t_coords = torch.zeros((0, 2), dtype=torch.float32)
 
                     # denormalize data if requested and map to storage format
                     preds_s += [dn_data(sname, pred.to(fp32)).detach().cpu().numpy()]

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -111,7 +111,7 @@ def write_output(
             if t_idx < forecast_offset:
                 preds_s, targets_s, t_coords_s, t_times_s = _empty_step(n_samples, 1, n_channels)
 
-            if not_reconstructed or target_aux_out.physical[t_idx][sname]["is_spoof"][0]:
+            elif not_reconstructed or target_aux_out.physical[t_idx][sname]["is_spoof"][0]:
                 preds = model_output.get_physical_prediction(chunk_idx, sname)
                 n_ens = preds[0].shape[0] if preds is not None and len(preds) > 0 else 1
                 preds_s, targets_s, t_coords_s, t_times_s = _empty_step(


### PR DESCRIPTION
## Description

Further reduces mem footprint during inference. Introduce flag to repeat target coords 

Run with 

```
uv run --offline inference --from-run-id igsqdagc --mini-epoch 8 --options test_config.compute_full_validation_loss=False test_config.forecast.num_steps=40 test_config.forecast.chunk_size=1 streams.ERA5.repeat_steps=True test_config.samples_per_mini_epoch=2 data_loading.num_workers=0
```

## Issue Number

-

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel

#### FastEvaluation
 - [ ] I have updated the public documentation if necessary

