### PR TITLE
Sophiex/dev ssl diffusion/make write target optional

### DIFF
--- a/packages/common/src/weathergen/common/io.py
+++ b/packages/common/src/weathergen/common/io.py
@@ -597,6 +597,10 @@ class OutputBatchData:
     forecast_offset: int
     forecast_steps: list[int]
 
+    # if False, no target datasets are built/written (skip_target_values inference);
+    # self.targets then only provides row counts via targets_lens
+    write_targets: bool = True
+
     @functools.cached_property
     def samples(self):
         """Continous indices of all samples accross all batches."""
@@ -686,20 +690,26 @@ class OutputBatchData:
                 datapoints
             ]
 
-        assert len(data_coords.channels) == target_data.shape[1], (
-            "Number of channel names does not align with target data."
-        )
         assert len(data_coords.channels) == preds_data.shape[1], (
             "Number of channel names does not align with prediction data."
         )
 
-        target_dataset = OutputDataset(
-            "target",
-            key,
-            source_interval,
-            target_data,
-            **dataclasses.asdict(data_coords),
-        )
+        if self.write_targets:
+            assert len(data_coords.channels) == target_data.shape[1], (
+                "Number of channel names does not align with target data."
+            )
+            target_dataset = OutputDataset(
+                "target",
+                key,
+                source_interval,
+                target_data,
+                **dataclasses.asdict(data_coords),
+            )
+        else:
+            # target values were never read (skip_target_values); coords/times are
+            # still written as part of the prediction dataset
+            target_dataset = None
+
         prediction_dataset = OutputDataset(
             "prediction",
             key,

--- a/scripts/inference_cw6a4szu_40step_array.sbatch
+++ b/scripts/inference_cw6a4szu_40step_array.sbatch
@@ -23,7 +23,7 @@
 #SBATCH --gres=gpu:1
 #SBATCH --time=01:30:00
 #SBATCH --array=0-15%16
-#SBATCH --job-name=wg-cw6-f40
+#SBATCH --job-name=wg-cw8-f40
 #SBATCH --output=logs/%x-%A_%a.out
 #SBATCH --error=logs/%x-%A_%a.err
 
@@ -31,7 +31,7 @@ set -euo pipefail
 
 FROM_RUN_ID=cw6a4szu
 MINI_EPOCH=8
-RUN_PREFIX=cw6
+RUN_PREFIX=cw8
 FORECAST_STEPS=40
 FORECAST_CHUNK_SIZE=4
 RESULTS_ROOT=/iopsstor/scratch/cscs/thunter/shared_work/results

--- a/scripts/inference_cw6a4szu_40step_array.sbatch
+++ b/scripts/inference_cw6a4szu_40step_array.sbatch
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# (C) Copyright 2025 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+# One independent 40-step inference sample per array task.
+# Task i writes run cw6iiiii for source window
+# 2023-06-01T12:00 + i * 12 hours. Each task uses a local test date range that
+# contains exactly that one valid input window.
+#
+# Submit from the WeatherGenerator root with:
+#   sbatch scripts/inference_cw6a4szu_40step_array.sbatch
+#
+# Santis normal is node-exclusive: every one-GPU array task reserves one full
+# four-GPU GH200 node. The shared partition can avoid this, but is limited to 1h.
+
+#SBATCH -A ch17
+#SBATCH --partition=normal
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=18
+#SBATCH --gres=gpu:1
+#SBATCH --time=01:30:00
+#SBATCH --array=0-15%16
+#SBATCH --job-name=wg-cw6-f40
+#SBATCH --output=logs/%x-%A_%a.out
+#SBATCH --error=logs/%x-%A_%a.err
+
+set -euo pipefail
+
+FROM_RUN_ID=cw6a4szu
+MINI_EPOCH=8
+RUN_PREFIX=cw6
+FORECAST_STEPS=40
+FORECAST_CHUNK_SIZE=4
+RESULTS_ROOT=/iopsstor/scratch/cscs/thunter/shared_work/results
+FIRST_SOURCE_START=2023-06-01T12:00
+SOURCE_CADENCE_HOURS=12
+INPUT_STEP_HOURS=6
+# 1 input step + 1 selected window + (40 forecast steps + offset 1) * 6 h.
+LOCAL_TEST_RANGE_HOURS=258
+
+task_id=${SLURM_ARRAY_TASK_ID:?This script must run as a Slurm array task.}
+run_id=$(printf '%s%05d' "$RUN_PREFIX" "$task_id")
+source_start=$(date -u --date="$FIRST_SOURCE_START UTC + $((task_id * SOURCE_CADENCE_HOURS)) hours" '+%Y-%m-%dT%H:%M')
+source_end=$(date -u --date="$source_start UTC + $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
+test_start=$(date -u --date="$source_start UTC - $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
+test_end=$(date -u --date="$test_start UTC + $LOCAL_TEST_RANGE_HOURS hours" '+%Y-%m-%dT%H:%M')
+expected_result="$RESULTS_ROOT/$run_id/validation_chkpt00000_rank0000.zip"
+
+if [[ -e "$expected_result" ]]; then
+    echo "Refusing to overwrite existing inference output: $expected_result" >&2
+    exit 2
+fi
+
+# The Santis virtual environment bundles Python 3.12 and CUDA 12.6 PyTorch.
+# Do not load the former Jupiter modules or force its Mellanox UCX device names.
+export OMP_NUM_THREADS="$SLURM_CPUS_PER_TASK"
+export MKL_NUM_THREADS="$SLURM_CPUS_PER_TASK"
+export OPENBLAS_NUM_THREADS="$SLURM_CPUS_PER_TASK"
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+
+# Slurm executes a spooled copy of this script, so BASH_SOURCE[0] points into
+# /var/spool/slurmd rather than this checkout. Submit from the repository root.
+weathergen_home=${SLURM_SUBMIT_DIR:?Submit this script from the WeatherGenerator root.}
+if [[ ! -f "$weathergen_home/.venv/bin/activate" ]]; then
+    echo "WeatherGenerator virtual environment not found: $weathergen_home/.venv" >&2
+    exit 2
+fi
+private_config="$(dirname "$weathergen_home")/WeatherGenerator-private/hpc/santis/config/paths.yml"
+if [[ ! -f "$private_config" ]]; then
+    echo "Missing Santis private config: $private_config" >&2
+    exit 2
+fi
+cd "$weathergen_home"
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+echo "run_id=$run_id source_interval=[$source_start, $source_end)"
+echo "test_interval=[$test_start, $test_end)"
+srun --ntasks=1 --cpus-per-task="$SLURM_CPUS_PER_TASK" \
+    python -u src/weathergen/run_train.py inference \
+    --from-run-id "$FROM_RUN_ID" \
+    --mini-epoch "$MINI_EPOCH" \
+    --run-id "$run_id" \
+    --private-config "$private_config" \
+    --options \
+        data_loading.num_workers=1 \
+        data_loading.persistent_workers=false \
+        test_config.samples_per_mini_epoch=1 \
+        test_config.shuffle=false \
+        test_config.start_date="$test_start" \
+        test_config.end_date="$test_end" \
+        test_config.output.num_samples=1 \
+        test_config.forecast.num_steps="$FORECAST_STEPS" \
+        test_config.forecast.chunk_size="$FORECAST_CHUNK_SIZE" \
+        test_config.compute_full_validation_loss=false
+
+test -s "$expected_result"

--- a/scripts/inference_cw6a4szu_40step_array_ag.sbatch
+++ b/scripts/inference_cw6a4szu_40step_array_ag.sbatch
@@ -27,9 +27,9 @@
 #SBATCH --gpus-per-node=4
 #SBATCH --cpus-per-task=32
 #SBATCH --mem=0
-#SBATCH --time=06:00:00
+#SBATCH --time=02:00:00
 #SBATCH --array=0-15%16
-#SBATCH --job-name=wg-cw6-f40
+#SBATCH --job-name=wg-cw8-f40
 #SBATCH --output=logs/%x-%A_%a.out
 #SBATCH --error=logs/%x-%A_%a.err
 
@@ -37,7 +37,7 @@ set -euo pipefail
 
 FROM_RUN_ID=cw6a4szu
 MINI_EPOCH=8
-RUN_PREFIX=cw6
+RUN_PREFIX=cw8
 FORECAST_STEPS=40
 FORECAST_CHUNK_SIZE=1                 # value proven interactively on ag for this checkpoint
 FIRST_SOURCE_START=2023-06-01T12:00

--- a/scripts/inference_cw6a4szu_40step_array_ag.sbatch
+++ b/scripts/inference_cw6a4szu_40step_array_ag.sbatch
@@ -35,9 +35,9 @@
 
 set -euo pipefail
 
-FROM_RUN_ID=cw6a4szu
+FROM_RUN_ID=xq65fhca
 MINI_EPOCH=8
-RUN_PREFIX=cw8
+RUN_PREFIX="${FROM_RUN_ID:0:4}"
 FORECAST_STEPS=40
 FORECAST_CHUNK_SIZE=1                 # value proven interactively on ag for this checkpoint
 FIRST_SOURCE_START=2023-06-01T12:00
@@ -48,7 +48,7 @@ NUM_SAMPLES_PER_TASK=8
 LOCAL_TEST_RANGE_HOURS=258
 
 task_id=${SLURM_ARRAY_TASK_ID:?This script must run as a Slurm array task.}
-run_id=$(printf '%s%05d' "$RUN_PREFIX" "$task_id")
+run_id=$(printf '%s%04d' "$RUN_PREFIX" "$task_id")
 # Advance each task by exactly its own NUM_SAMPLES_PER_TASK windows
 # (INPUT_STEP_HOURS each) so consecutive tasks tile without overlap or grid drift.
 source_start=$(date -u --date="$FIRST_SOURCE_START UTC + $((task_id * INPUT_STEP_HOURS * NUM_SAMPLES_PER_TASK)) hours" '+%Y-%m-%dT%H:%M')

--- a/scripts/inference_cw6a4szu_40step_array_ag.sbatch
+++ b/scripts/inference_cw6a4szu_40step_array_ag.sbatch
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# (C) Copyright 2025 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+# ag (GH200) twin of inference_cw6a4szu_40step_array_jupiter.sbatch: IDENTICAL
+# sampling/date logic, only the platform layer differs --
+#   * ECMWF ag account/qos instead of the JSC account/partition;
+#   * the self-contained aarch64 uv venv + three runtime exports instead of the
+#     module / UCX / MASTER_ADDR block;
+#   * torchrun for the 4-way single-node DDP instead of srun --ntasks=4;
+#   * this checkpoint is really cw6a4szu (the Jupiter file runs xq65fhca).
+#
+# Eight 40-step inference samples per array task. Task i writes run cw6iiiii for
+# the 8 source windows starting 2023-06-01T12:00 + i * 48 hours
+# (NUM_SAMPLES_PER_TASK * INPUT_STEP_HOURS), so tasks tile consecutive dates
+# without overlap.
+#
+# Submit from the WeatherGenerator root:
+#   sbatch scripts/inference_cw6a4szu_40step_array_ag.sbatch
+
+#SBATCH --qos=ng
+#SBATCH --account=ecwegen
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --gpus-per-node=4
+#SBATCH --cpus-per-task=32
+#SBATCH --mem=0
+#SBATCH --time=06:00:00
+#SBATCH --array=0-15%16
+#SBATCH --job-name=wg-cw6-f40
+#SBATCH --output=logs/%x-%A_%a.out
+#SBATCH --error=logs/%x-%A_%a.err
+
+set -euo pipefail
+
+FROM_RUN_ID=cw6a4szu
+MINI_EPOCH=8
+RUN_PREFIX=cw6
+FORECAST_STEPS=40
+FORECAST_CHUNK_SIZE=1                 # value proven interactively on ag for this checkpoint
+FIRST_SOURCE_START=2023-06-01T12:00
+INPUT_STEP_HOURS=6
+NUM_SAMPLES_PER_TASK=8
+# 1 input step + 1 selected window + (40 forecast steps + offset 1) * 6 h,
+# widened by NUM_SAMPLES_PER_TASK windows so all 8 samples survive check_samples.
+LOCAL_TEST_RANGE_HOURS=258
+
+task_id=${SLURM_ARRAY_TASK_ID:?This script must run as a Slurm array task.}
+run_id=$(printf '%s%05d' "$RUN_PREFIX" "$task_id")
+# Advance each task by exactly its own NUM_SAMPLES_PER_TASK windows
+# (INPUT_STEP_HOURS each) so consecutive tasks tile without overlap or grid drift.
+source_start=$(date -u --date="$FIRST_SOURCE_START UTC + $((task_id * INPUT_STEP_HOURS * NUM_SAMPLES_PER_TASK)) hours" '+%Y-%m-%dT%H:%M')
+source_end=$(date -u --date="$source_start UTC + $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
+test_start=$(date -u --date="$source_start UTC - $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
+test_end=$(date -u --date="$test_start UTC + $((LOCAL_TEST_RANGE_HOURS + NUM_SAMPLES_PER_TASK * INPUT_STEP_HOURS)) hours" '+%Y-%m-%dT%H:%M')
+
+weathergen_home=${SLURM_SUBMIT_DIR:?Submit this script from the WeatherGenerator root.}
+RESULTS_ROOT="$weathergen_home/results"
+expected_result="$RESULTS_ROOT/$run_id/validation_chkpt00000_rank0000.zip"
+if [[ -e "$expected_result" ]]; then
+    echo "Refusing to overwrite existing inference output: $expected_result" >&2
+    exit 2
+fi
+if [[ ! -x "$weathergen_home/.venv/bin/torchrun" ]]; then
+    echo "WeatherGenerator venv not found: $weathergen_home/.venv" >&2
+    exit 2
+fi
+private_config="$(dirname "$weathergen_home")/WeatherGenerator-private/hpc/hpc2020/config/paths.yml"
+if [[ ! -f "$private_config" ]]; then
+    echo "Missing ag private config: $private_config" >&2
+    exit 2
+fi
+
+# ag (aarch64) runtime -- the three fixes from the N320 port: resolve the
+# checkpoint via the private config (platform-env.py has no ag rule), give
+# flash-attn its GLIBCXX (gcc/15.2.0), and de-fragment the allocator (the var
+# was renamed from PYTORCH_CUDA_ALLOC_CONF in torch 2.9).
+export WEATHERGEN_PRIVATE_CONF="$private_config"
+export LD_LIBRARY_PATH="/usr/local/apps/gcc/15.2.0/lib64:${LD_LIBRARY_PATH:-}"
+export PYTORCH_ALLOC_CONF=expandable_segments:True
+
+cd "$weathergen_home"
+echo "run_id=$run_id source_interval=[$source_start, $source_end)"
+echo "test_interval=[$test_start, $test_end)"
+.venv/bin/torchrun --nproc-per-node=4 \
+    src/weathergen/run_train.py inference \
+    --from-run-id "$FROM_RUN_ID" \
+    --mini-epoch "$MINI_EPOCH" \
+    --run-id "$run_id" \
+    --private-config "$private_config" \
+    --options \
+        data_loading.num_workers=0 \
+        data_loading.num_workers_validation=0 \
+        data_loading.persistent_workers=false \
+        test_config.samples_per_mini_epoch="$NUM_SAMPLES_PER_TASK" \
+        test_config.output.num_samples="$NUM_SAMPLES_PER_TASK" \
+        test_config.shuffle=false \
+        test_config.start_date="$test_start" \
+        test_config.end_date="$test_end" \
+        test_config.forecast.num_steps="$FORECAST_STEPS" \
+        test_config.forecast.chunk_size="$FORECAST_CHUNK_SIZE" \
+        test_config.compute_full_validation_loss=false \
+        test_config.skip_target_values=true
+
+test -s "$expected_result"

--- a/scripts/inference_cw6a4szu_40step_array_jupiter.sbatch
+++ b/scripts/inference_cw6a4szu_40step_array_jupiter.sbatch
@@ -16,14 +16,14 @@
 # four-GPU GH200 node. The shared partition can avoid this, but is limited to 1h.
 
 #SBATCH --account=e-ext-2025e01-128
-#SBATCH --time=01:00:00
+#SBATCH --time=01:30:00
 #SBATCH --nodes=1
 #SBATCH --ntasks=4
 #SBATCH --cpus-per-task=72
 #SBATCH --gres=gpu:4
 #SBATCH --chdir=.
 #SBATCH --partition=booster
-#SBATCH --array=0-15%16
+#SBATCH --array=0-92%92
 #SBATCH --output=logs/weathergen-%x.%j.out
 #SBATCH --error=logs/weathergen-%x.%j.err
 
@@ -66,13 +66,13 @@ fi
 echo "MASTER_ADDR: $MASTER_ADDR"
 set -euo pipefail
 
-FROM_RUN_ID=xq65fhca
-MINI_EPOCH=14
-RUN_PREFIX=xq65
+FROM_RUN_ID=cw6a4szu
+MINI_EPOCH=8
+RUN_PREFIX="${FROM_RUN_ID:0:4}"
 FORECAST_STEPS=40
 FORECAST_CHUNK_SIZE=1
 RESULTS_ROOT=/e/scratch/weatherai/shared_work/results
-FIRST_SOURCE_START=2023-06-01T12:00
+FIRST_SOURCE_START=2023-06-01T00:00
 INPUT_STEP_HOURS=6
 NUM_SAMPLES_PER_TASK=8
 # SOURCE_CADENCE_HOURS=12
@@ -80,8 +80,8 @@ NUM_SAMPLES_PER_TASK=8
 LOCAL_TEST_RANGE_HOURS=258
 
 task_id=${SLURM_ARRAY_TASK_ID:?This script must run as a Slurm array task.}
-run_id=$(printf '%s%05d' "$RUN_PREFIX" "$task_id")
-source_start=$(date -u --date="$FIRST_SOURCE_START UTC + $((task_id * 4 * NUM_SAMPLES_PER_TASK)) hours" '+%Y-%m-%dT%H:%M')
+run_id=$(printf '%s%04d' "$RUN_PREFIX" "$task_id")
+source_start=$(date -u --date="$FIRST_SOURCE_START UTC + $((task_id * INPUT_STEP_HOURS * NUM_SAMPLES_PER_TASK)) hours" '+%Y-%m-%dT%H:%M')
 source_end=$(date -u --date="$source_start UTC + $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
 test_start=$(date -u --date="$source_start UTC - $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
 test_end=$(date -u --date="$test_start UTC + $((LOCAL_TEST_RANGE_HOURS + NUM_SAMPLES_PER_TASK * INPUT_STEP_HOURS)) hours" '+%Y-%m-%dT%H:%M')

--- a/scripts/inference_cw6a4szu_40step_array_jupiter.sbatch
+++ b/scripts/inference_cw6a4szu_40step_array_jupiter.sbatch
@@ -1,0 +1,140 @@
+#!/bin/bash -x
+# (C) Copyright 2025 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+# One independent 40-step inference sample per array task.
+# Task i writes run cw6iiiii for source window
+# 2023-06-01T12:00 + i * 12 hours. Each task uses a local test date range that
+# contains exactly that one valid input window.
+#
+# Submit from the WeatherGenerator root with:
+#   sbatch scripts/inference_cw6a4szu_40step_array.sbatch
+#
+# Jupiter normal is node-exclusive: every one-GPU array task reserves one full
+# four-GPU GH200 node. The shared partition can avoid this, but is limited to 1h.
+
+#SBATCH --account=e-ext-2025e01-128
+#SBATCH --time=01:00:00
+#SBATCH --nodes=1
+#SBATCH --ntasks=4
+#SBATCH --cpus-per-task=72
+#SBATCH --gres=gpu:4
+#SBATCH --chdir=.
+#SBATCH --partition=booster
+#SBATCH --array=0-15%16
+#SBATCH --output=logs/weathergen-%x.%j.out
+#SBATCH --error=logs/weathergen-%x.%j.err
+
+echo "shell $SHELL"
+if [ -f "$HOME/.local/bin/env" ]; then
+    . "$HOME/.local/bin/env"
+fi
+
+. "$HOME/.bashrc"
+echo "LMOD_ROOT $LMOD_ROOT"
+# Does not get loaded automatically. Unsure why.
+. $LMOD_ROOT/lmod/init/bash
+# Load basic modules from software stack
+module --force purge
+module load Stages/2025
+
+module load GCC/13.3.0
+module load GCCcore/.13.3.0
+
+ml git/2.45.1
+ml Python/3.12.3
+
+
+# set some environment variables to ensure that GPU-devices are used properly
+export UCX_TLS="^cma"
+export UCX_NET_DEVICES=mlx5_0:1,mlx5_1:1,mlx5_4:1,mlx5_5:1
+
+export SRUN_CPUS_PER_TASK=${SLURM_CPUS_PER_TASK}
+export CUDA_VISIBLE_DEVICES=0,1,2,3
+
+# so processes know who to talk to
+export MASTER_ADDR="$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)"
+if [ "$SYSTEMNAME" = juwelsbooster ] \
+       || [ "$SYSTEMNAME" = juwels ] \
+       || [ "$SYSTEMNAME" = jurecadc ] \
+       || [ "$SYSTEMNAME" = jusuf ]; then
+    # Allow communication over InfiniBand cells on JSC machines.
+    MASTER_ADDR="$MASTER_ADDR"i
+fi
+echo "MASTER_ADDR: $MASTER_ADDR"
+set -euo pipefail
+
+FROM_RUN_ID=xq65fhca
+MINI_EPOCH=16
+RUN_PREFIX=xq65
+FORECAST_STEPS=40
+FORECAST_CHUNK_SIZE=1
+RESULTS_ROOT=/e/scratch/weatherai/shared_work/results
+FIRST_SOURCE_START=2023-06-01T12:00
+INPUT_STEP_HOURS=6
+NUM_SAMPLES_PER_TASK=8
+# SOURCE_CADENCE_HOURS=12
+# 1 input step + 1 selected window + (40 forecast steps + offset 1) * 6 h.
+LOCAL_TEST_RANGE_HOURS=258
+
+task_id=${SLURM_ARRAY_TASK_ID:?This script must run as a Slurm array task.}
+run_id=$(printf '%s%05d' "$RUN_PREFIX" "$task_id")
+source_start=$(date -u --date="$FIRST_SOURCE_START UTC + $((task_id * NUM_SAMPLES_PER_TASK)) hours" '+%Y-%m-%dT%H:%M')
+source_end=$(date -u --date="$source_start UTC + $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
+test_start=$(date -u --date="$source_start UTC - $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
+test_end=$(date -u --date="$test_start UTC + $LOCAL_TEST_RANGE_HOURS hours" '+%Y-%m-%dT%H:%M')
+expected_result="$RESULTS_ROOT/$run_id/validation_chkpt00000_rank0000.zip"
+
+if [[ -e "$expected_result" ]]; then
+    echo "Refusing to overwrite existing inference output: $expected_result" >&2
+    exit 2
+fi
+
+# The Santis virtual environment bundles Python 3.12 and CUDA 12.6 PyTorch.
+# Do not load the former Jupiter modules or force its Mellanox UCX device names.
+export OMP_NUM_THREADS="$SLURM_CPUS_PER_TASK"
+export MKL_NUM_THREADS="$SLURM_CPUS_PER_TASK"
+export OPENBLAS_NUM_THREADS="$SLURM_CPUS_PER_TASK"
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+
+# Slurm executes a spooled copy of this script, so BASH_SOURCE[0] points into
+# /var/spool/slurmd rather than this checkout. Submit from the repository root.
+weathergen_home=${SLURM_SUBMIT_DIR:?Submit this script from the WeatherGenerator root.}
+if [[ ! -f "$weathergen_home/.venv/bin/activate" ]]; then
+    echo "WeatherGenerator virtual environment not found: $weathergen_home/.venv" >&2
+    exit 2
+fi
+private_config="$(dirname "$weathergen_home")/WeatherGenerator-private/hpc/jupiter/config/paths.yml"
+if [[ ! -f "$private_config" ]]; then
+    echo "Missing Jupiter private config: $private_config" >&2
+    exit 2
+fi
+cd "$weathergen_home"
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+echo "run_id=$run_id source_interval=[$source_start, $source_end)"
+echo "test_interval=[$test_start, $test_end)"
+srun --ntasks=4 --cpus-per-task="$SLURM_CPUS_PER_TASK" \
+    python -u src/weathergen/run_train.py inference \
+    --from-run-id "$FROM_RUN_ID" \
+    --mini-epoch "$MINI_EPOCH" \
+    --run-id "$run_id" \
+    --private-config "$private_config" \
+    --options \
+        data_loading.num_workers=0 \
+        data_loading.num_workers_validation=0 \
+        data_loading.persistent_workers=false \
+        test_config.samples_per_mini_epoch="$NUM_SAMPLES_PER_TASK" \
+        test_config.shuffle=false \
+        test_config.start_date="$test_start" \
+        test_config.end_date="$test_end" \
+        test_config.output.num_samples="$NUM_SAMPLES_PER_TASK" \
+        test_config.forecast.num_steps="$FORECAST_STEPS" \
+        test_config.forecast.chunk_size="$FORECAST_CHUNK_SIZE" \
+        test_config.compute_full_validation_loss=false \
+        test_config.skip_target_values=true
+
+test -s "$expected_result"

--- a/scripts/inference_cw6a4szu_40step_array_jupiter.sbatch
+++ b/scripts/inference_cw6a4szu_40step_array_jupiter.sbatch
@@ -67,7 +67,7 @@ echo "MASTER_ADDR: $MASTER_ADDR"
 set -euo pipefail
 
 FROM_RUN_ID=xq65fhca
-MINI_EPOCH=16
+MINI_EPOCH=14
 RUN_PREFIX=xq65
 FORECAST_STEPS=40
 FORECAST_CHUNK_SIZE=1
@@ -81,10 +81,10 @@ LOCAL_TEST_RANGE_HOURS=258
 
 task_id=${SLURM_ARRAY_TASK_ID:?This script must run as a Slurm array task.}
 run_id=$(printf '%s%05d' "$RUN_PREFIX" "$task_id")
-source_start=$(date -u --date="$FIRST_SOURCE_START UTC + $((task_id * NUM_SAMPLES_PER_TASK)) hours" '+%Y-%m-%dT%H:%M')
+source_start=$(date -u --date="$FIRST_SOURCE_START UTC + $((task_id * 4 * NUM_SAMPLES_PER_TASK)) hours" '+%Y-%m-%dT%H:%M')
 source_end=$(date -u --date="$source_start UTC + $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
 test_start=$(date -u --date="$source_start UTC - $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
-test_end=$(date -u --date="$test_start UTC + $LOCAL_TEST_RANGE_HOURS hours" '+%Y-%m-%dT%H:%M')
+test_end=$(date -u --date="$test_start UTC + $((LOCAL_TEST_RANGE_HOURS + NUM_SAMPLES_PER_TASK * INPUT_STEP_HOURS)) hours" '+%Y-%m-%dT%H:%M')
 expected_result="$RESULTS_ROOT/$run_id/validation_chkpt00000_rank0000.zip"
 
 if [[ -e "$expected_result" ]]; then
@@ -128,10 +128,10 @@ srun --ntasks=4 --cpus-per-task="$SLURM_CPUS_PER_TASK" \
         data_loading.num_workers_validation=0 \
         data_loading.persistent_workers=false \
         test_config.samples_per_mini_epoch="$NUM_SAMPLES_PER_TASK" \
+        test_config.output.num_samples="$NUM_SAMPLES_PER_TASK" \
         test_config.shuffle=false \
         test_config.start_date="$test_start" \
         test_config.end_date="$test_end" \
-        test_config.output.num_samples="$NUM_SAMPLES_PER_TASK" \
         test_config.forecast.num_steps="$FORECAST_STEPS" \
         test_config.forecast.chunk_size="$FORECAST_CHUNK_SIZE" \
         test_config.compute_full_validation_loss=false \

--- a/src/weathergen/datasets/data_reader_base.py
+++ b/src/weathergen/datasets/data_reader_base.py
@@ -389,7 +389,7 @@ class DataReaderBase(metaclass=ABCMeta):
 
         return rdata
 
-    def get_target(self, idx: TIndex) -> ReaderData:
+    def get_target(self, idx: TIndex, coords_geoinfos_only: bool = False) -> ReaderData:
         """
         Get target data for idx
 
@@ -397,13 +397,33 @@ class DataReaderBase(metaclass=ABCMeta):
         ----------
         idx : int
             Index of temporal window
+        coords_geoinfos_only : bool
+            If True, only coords, geoinfos and datetimes are provided; data has zero
+            width (shape (num_datapoints, 0)) so no target values are read or stored.
 
         Returns
         -------
         target data (coords, geoinfos, data, datetimes)
         """
 
+        if coords_geoinfos_only:
+            return self._get_coords_geoinfos_only(idx, self.target_idx)
+
         rdata = self._get(idx, self.target_idx)
+
+        return rdata
+
+    def _get_coords_geoinfos_only(self, idx: TIndex, channels_idx: list[int]) -> ReaderData:
+        """
+        Get data for window with zero-width data values (coords, geoinfos, datetimes only)
+
+        Default implementation performs a full read and drops the values; subclasses can
+        override to avoid reading the values altogether. The width-0 slice keeps the row
+        count so all row-alignment invariants (is_empty, shuffle, tokenization) hold.
+        """
+
+        rdata = self._get(idx, channels_idx)
+        rdata.data = rdata.data[:, :0]
 
         return rdata
 

--- a/src/weathergen/datasets/data_reader_obs.py
+++ b/src/weathergen/datasets/data_reader_obs.py
@@ -243,7 +243,7 @@ class DataReaderObs(DataReaderBase):
         self.properties["vars"] = self.data.attrs["vars"]
 
     @override
-    def _get(self, idx: int, channels_idx: list[int]) -> ReaderData:
+    def _get(self, idx: int, channels_idx: list[int], read_values: bool = True) -> ReaderData:
         """
         Get data for window
 
@@ -253,6 +253,8 @@ class DataReaderObs(DataReaderBase):
             Index of temporal window
         channels_idx : np.array
             Selection of channels
+        read_values : bool
+            If False, skip reading the data values; data has zero width.
 
         Returns
         -------
@@ -279,7 +281,11 @@ class DataReaderObs(DataReaderBase):
             else np.zeros((coords.shape[0], 0), np.float32)
         )
 
-        data = self.data.oindex[start_row:end_row, channels_idx]
+        data = (
+            self.data.oindex[start_row:end_row, channels_idx]
+            if read_values
+            else np.zeros((coords.shape[0], 0), np.float32)
+        )
         datetimes = self.dt[start_row:end_row][:, 0]
 
         # indices_start, indices_end above work with [t_start, t_end] and violate
@@ -297,5 +303,14 @@ class DataReaderObs(DataReaderBase):
 
         dtr = self.time_window_handler.window(idx)
         check_reader_data(rdata, dtr)
+
+        return rdata
+
+    @override
+    def _get_coords_geoinfos_only(self, idx: int, channels_idx: list[int]) -> ReaderData:
+        # skip the data-columns read entirely; coords/geoinfos/datetimes read as usual
+        rdata = self._get(idx, channels_idx, read_values=False)
+        # the empty-window early returns in _get yield (0, len(channels_idx)) data
+        rdata.data = rdata.data[:, :0]
 
         return rdata

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -8,6 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 import dataclasses
+import functools
 import logging
 import pathlib
 from collections.abc import Sequence
@@ -35,7 +36,11 @@ from weathergen.datasets.utils import (
 from weathergen.readers_extra.registry import get_extra_reader
 from weathergen.train.utils import Stage, get_batch_size_from_config
 from weathergen.utils.distributed import is_root
-from weathergen.utils.utils import is_stream_diagnostic, is_stream_forcing
+from weathergen.utils.utils import (
+    is_stream_diagnostic,
+    is_stream_forcing,
+    is_stream_reconstructed,
+)
 
 type AnyDataReader = DataReaderBase | DataReaderAnemoi | DataReaderObs
 type StreamName = str
@@ -50,11 +55,15 @@ FORECAST_DEFAULTS = {
 }
 
 
-def collect_datasources(stream_datasets: list, idx: int, type: str, rng) -> IOReaderData:
+def collect_datasources(
+    stream_datasets: list, idx: int, type: str, rng, coords_geoinfos_only: bool = False
+) -> IOReaderData:
     """
     Utility function to collect all sources / targets from streams list
 
     rng and num_subset are used to drop data
+
+    coords_geoinfos_only (targets only): skip reading the data values; data has zero width
     """
 
     rdatas = []
@@ -68,7 +77,9 @@ def collect_datasources(stream_datasets: list, idx: int, type: str, rng) -> IORe
             normalize_channels = ds.normalize_source_channels
             shuffle = ds.stream_info.get("shuffle_source", False)
         elif type == "target":
-            get_reader_data = ds.get_target
+            get_reader_data = functools.partial(
+                ds.get_target, coords_geoinfos_only=coords_geoinfos_only
+            )
             normalize_channels = ds.normalize_target_channels
             num_subset = ds.stream_info.get("max_num_targets", -1)
             shuffle = ds.stream_info.get("shuffle_target", False)
@@ -79,7 +90,9 @@ def collect_datasources(stream_datasets: list, idx: int, type: str, rng) -> IORe
         rdata = (
             get_reader_data(idx).shuffle(rng, shuffle, num_subset).remove_nan_coords_and_geoinfos()
         )
-        rdata.data = normalize_channels(rdata.data)
+        if not coords_geoinfos_only:
+            # zero-width data has nothing to normalize (and would fail the channel-count check)
+            rdata.data = normalize_channels(rdata.data)
         rdata.geoinfos = ds.normalize_geoinfos(rdata.geoinfos)
         rdatas += [rdata]
 
@@ -136,6 +149,17 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                     "Ignoring teacher_time_offset (setting to 0)."
                 )
             self.teacher_time_offset = 0
+
+        # skip_target_values: inference-only; do not read/store target values for physically
+        # reconstructed streams, only coords/geoinfos/datetimes (data gets zero width)
+        self.skip_target_values = bool(mode_cfg.get("skip_target_values", False))
+        if self.skip_target_values and (
+            "student_teacher" in training_mode or "latent_loss" in training_mode
+        ):
+            raise ValueError(
+                "skip_target_values is incompatible with student_teacher/latent_loss modes: "
+                "target values are needed to build the teacher's network input."
+            )
 
         self.batch_size = get_batch_size_from_config(mode_cfg)
         self.num_workers = cf.data_loading.num_workers
@@ -618,11 +642,23 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
         # target data: collect for all forecast steps
         output_data = []
         if not is_stream_forcing(stream_ds[0].stream_info, self._stage):
+            # skip target values only for physically reconstructed streams; forcing streams
+            # are skipped entirely above and reconstruct:false (teacher-only) streams keep
+            # their values
+            coords_geoinfos_only = self.skip_target_values and is_stream_reconstructed(
+                stream_ds[0].stream_info, self._stage
+            )
             num_output_steps = self._get_output_length(num_forecast_steps)
             for timestep_idx in range(self.output_offset, num_output_steps):
                 step_forecast_dt = base_idx + (self.time_step * timestep_idx) // self.step_timedelta
 
-                rdata = collect_datasources(stream_ds, step_forecast_dt, "target", self.rng)
+                rdata = collect_datasources(
+                    stream_ds,
+                    step_forecast_dt,
+                    "target",
+                    self.rng,
+                    coords_geoinfos_only=coords_geoinfos_only,
+                )
 
                 if rdata.is_empty():
                     # work around for https://github.com/pytorch/pytorch/issues/158719
@@ -632,7 +668,10 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                         self.healpix_level,
                         time_win.start,
                         stream_ds[0].get_geoinfo_size(),
-                        len(stream_ds[0].mean[stream_ds[0].target_idx]),
+                        # zero width to match the coords_geoinfos_only data downstream
+                        0
+                        if coords_geoinfos_only
+                        else len(stream_ds[0].mean[stream_ds[0].target_idx]),
                     )
                     rdata.is_spoof = True
 

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -959,9 +959,9 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
         worker_info = torch.utils.data.get_worker_info()
 
         if worker_info is None:
-            # assert self.world_size == 1, self.world_size
-            iter_start = 0
-            iter_end = len(self)
+            # no loader workers: each DDP rank still takes its own disjoint slice
+            iter_start = local_start
+            iter_end = local_end
 
         else:
             # ensure the rng seed is fully unique across workers and mini_epochs

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -295,8 +295,9 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                         raise FileNotFoundError(msg)
 
                     # The same dataset can exist on different locations in the filesystem,
-                    # so we need to choose here.
-                    filename = filenames[0]
+                    # so pick the first data_paths root that actually has it (the check
+                    # above guarantees at least one exists).
+                    filename = next(f for f in filenames if f.exists())
 
                 ds_type = stream_info["type"]
                 if is_root():

--- a/src/weathergen/datasets/stream_data.py
+++ b/src/weathergen/datasets/stream_data.py
@@ -412,7 +412,9 @@ class StreamData:
         """
 
         is_nan = torch.isnan(torch.cat(self.target_tokens))
-        return is_nan.all() if len(is_nan) > 0 else False
+        # numel, not len: zero-width values (skip_target_values) have rows but no
+        # elements, and .all() on an empty tensor is vacuously True
+        return is_nan.all() if is_nan.numel() > 0 else False
 
     def source_nan(self) -> bool:
         """

--- a/src/weathergen/datasets/stream_data.py
+++ b/src/weathergen/datasets/stream_data.py
@@ -366,8 +366,18 @@ class StreamData:
 
         # cat over forecast steps
         target_coords_empty = torch.cat(self.target_coords_lens).sum() == 0
-        target_tokens_empty = torch.cat(self.target_tokens).sum() == 0
-        return target_coords_empty and target_tokens_empty
+        # count coord rows rather than summing values: values may have zero width
+        # (skip_target_values), which a value-based check misreports as empty;
+        # spoofed windows carry no real points and still count as empty
+        target_points_empty = (
+            sum(
+                len(c)
+                for c, is_spoof in zip(self.target_coords_raw, self.target_is_spoof, strict=True)
+                if not is_spoof
+            )
+            == 0
+        )
+        return target_coords_empty and target_points_empty
 
     def source_empty(self) -> bool:
         """

--- a/src/weathergen/datasets/tokenizer_masking.py
+++ b/src/weathergen/datasets/tokenizer_masking.py
@@ -227,7 +227,9 @@ class TokenizerMasking(Tokenizer):
         )
 
         idxs_ord_inv = None
-        if data.numel() > 0:
+        # row count, not numel(): zero-width data (skip_target_values) still needs the
+        # inverse ordering so written coords/times/preds keep the original point order
+        if data.shape[0] > 0:
             # flatten per-token indices into one flat list
             idxs_flat = torch.cat([idxs for idxs_cell in idxs_cells for idxs in idxs_cell])
             # compute indices for inversion

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -318,8 +318,11 @@ class Trainer(TrainerBase):
         forecast_chunk = batch.get_source_samples()
        
         if not compute_full_loss:
-            target_aux_chunk = copy.deepcopy(targets_and_auxs[physical_loss_names[0]])
-        
+            # shallow copy is sufficient: .physical and .output_idxs are reassigned before
+            # any use, and the shared per-step target dicts are only read downstream
+            target_aux = targets_and_auxs[physical_loss_names[0]]
+            target_aux_chunk = copy.copy(target_aux)
+
         for chunk_idx, chunk in enumerate(chunks):
             if not compute_full_loss:
                 batch.to_device_for_output_chunk(self.device, chunk)
@@ -339,7 +342,6 @@ class Trainer(TrainerBase):
 
             if should_write_output:
                 if not compute_full_loss:
-                    target_aux = targets_and_auxs[physical_loss_names[0]]
                     target_aux_chunk.physical = [None for _ in range(chunk[0])] + [target_aux.physical[step] for step in chunk]
                     target_aux_chunk.output_idxs = chunk
                     target_output = { physical_loss_names[0]: target_aux_chunk }
@@ -427,6 +429,10 @@ class Trainer(TrainerBase):
             self.dataset, **loader_params, sampler=None
         )
 
+        # Inference runs under torch.no_grad with no gradient synchronization, so the
+        # DDP/FSDP wrappers are not needed; skipping them avoids allocating DDP gradient
+        # buckets (~one model-size buffer per rank). The process group set up by torchrun
+        # is still used for per-rank data sharding.
         self.model, self.model_params = init_model_and_shard(
             cf,
             self.dataset,
@@ -434,8 +440,8 @@ class Trainer(TrainerBase):
             mini_epoch_contd,
             self.test_cfg.training_mode,
             devices[0],
-            cf.with_ddp,
-            cf.with_fsdp,
+            with_ddp=False,
+            with_fsdp=cf.with_fsdp,
         )
 
         # get target_aux calculators for different loss terms

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -446,6 +446,12 @@ class Trainer(TrainerBase):
         if is_root():
             config.save(self.cf, mini_epoch=0)
 
+        if self.test_cfg.get("skip_target_values", False):
+            logger.warning(
+                "skip_target_values is active: target values are neither read nor written "
+                "(the output zarr has no target datasets) and no validation losses are computed."
+            )
+
         logger.info(f"Starting inference with id={self.cf.general.run_id}.")
 
         # inference validation set
@@ -456,6 +462,16 @@ class Trainer(TrainerBase):
         # general initalization
         self.init(cf, devices)
         cf = self.cf
+
+        # skip_target_values is inference-only: without target values there is nothing
+        # to train against and validation losses would be meaningless
+        if self.training_cfg.get("skip_target_values", False) or self.validation_cfg.get(
+            "skip_target_values", False
+        ):
+            raise ValueError(
+                "skip_target_values is only allowed in inference (test_config), "
+                "not in training_config or validation_config."
+            )
 
         device_type = torch.accelerator.current_accelerator()
         self.device = torch.device(f"{device_type}:{cf.local_rank}")
@@ -918,11 +934,14 @@ class Trainer(TrainerBase):
                                     targets_and_auxs,
                                 )
 
-                        _ = self.loss_calculator_val.compute_loss(
-                            preds=preds,
-                            targets_and_aux=targets_and_auxs,
-                            metadata=extract_batch_metadata(batch),
-                        )
+                        # skip_target_values: target values are not read (zero width),
+                        # so no loss can be computed
+                        if not mode_cfg.get("skip_target_values", False):
+                            _ = self.loss_calculator_val.compute_loss(
+                                preds=preds,
+                                targets_and_aux=targets_and_auxs,
+                                metadata=extract_batch_metadata(batch),
+                            )
                         pbar.update(batch_size * self.cf.world_size)
 
                         if (bidx * batch_size) > mode_cfg.samples_per_mini_epoch:

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -60,6 +60,10 @@ def write_output(
     fp32 = torch.float32
     preds_all, targets_all, targets_coords_all, targets_times_all = [], [], [], []
 
+    # skip_target_values: targets have zero width (values were never read) and no
+    # target datasets are written; the target arrays below only provide row counts
+    write_targets = not val_cfg.get("skip_target_values", False)
+
     # _get_output_length clamps to at least one output step, so this always holds
     assert len(batch.get_output_idxs()) > 0, "Batch carries no output steps."
     forecast_offset = batch.get_output_idxs()[0]
@@ -126,9 +130,10 @@ def write_output(
 
                 # handle forcing streams or if sample is empty
                 if preds is None:
-                    # preds are empty so create copy of target and add ensemble dimension
+                    # preds are empty so create empty preds with ensemble dimension
+                    # (explicit width: targets have zero width under skip_target_values)
                     assert targets[0].shape[0] == 0, "Empty preds but non-empty targets."
-                    preds = [target.clone().unsqueeze(0) for target in targets]
+                    preds = [target.new_zeros((1, 0, n_channels)) for target in targets]
 
                 for i_batch, (pred, target) in enumerate(zip(preds, targets, strict=True)):
                     target_data = target_aux_out.physical[t_idx][sname]
@@ -144,7 +149,12 @@ def write_output(
 
                     # denormalize data if requested and map to storage format
                     preds_s += [dn_data(sname, pred.to(fp32)).detach().cpu().numpy()]
-                    targets_s += [dn_data(sname, target.to(fp32)).detach().cpu().numpy()]
+                    if write_targets:
+                        targets_s += [dn_data(sname, target.to(fp32)).detach().cpu().numpy()]
+                    else:
+                        # zero-width targets cannot be denormalized (channel-count
+                        # mismatch); only their row counts are used, for targets_lens
+                        targets_s += [target.detach().cpu().numpy()]
 
                     # extract original target coords and times from target data
                     t_coords_s += [t_coords.cpu().numpy()]
@@ -231,6 +241,7 @@ def write_output(
         sample_start=sample_start,
         forecast_offset=forecast_offset,
         forecast_steps=timestep_idxs,
+        write_targets=write_targets,
     )
 
     store_path = config.get_path_results(cf, mini_epoch)


### PR DESCRIPTION
## Description

Don't write the target to the zarrs and drop the target channels as soon as possible. From my and Claude's understanding of anemoi zarr reading, we still need the bulk dataread to get the geoinfos.

Note this is only useful once we have the evaluation package able to read the target zarrs from predictions alone.

## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

- [x] tested: train+ validation space JEPA
- [x] tested: train+ validation temporal JEPA
- [ ] tested: train+ validation diffusion
- [ ] tested: train+ validation forecasting