### PR TITLE
chunking the members and latent cells for longer rollout

### DIFF
--- a/config/diffusion/config_diffusion_decoder.yml
+++ b/config/diffusion/config_diffusion_decoder.yml
@@ -135,6 +135,59 @@ diffusion_particle_guidance_fstep_decay: 0.0
 # trade-off only -- the cells are independent, so the result is identical either way.
 diffusion_particle_guidance_cell_chunk: 4096
 
+# --- Conditioning noise (per-member perturbation of the latent conditioning) ---
+# Inference-only: before denoising, each ensemble member's copy of the latent conditioning
+# tokens gets its own Gaussian perturbation, so the members forecast from slightly
+# different starting states instead of from identical information -- the
+# ensemble-of-initial-conditions idea applied in latent space. Complementary to particle
+# guidance: that pushes members apart inside one denoising pass, this hands them different
+# information to begin with, and the model's own dynamics amplify it over the rollout.
+# Amplitude as a fraction of the token norm (see the scope knob below), so 0.01 perturbs
+# each conditioning token by ~1% of its own magnitude. 0.0 disables it entirely, leaving
+# the conditioning and the RNG stream untouched. Start around 0.005-0.02 and raise it until
+# the ensemble spread moves, stopping before per-member forecast skill degrades. Applies to
+# single-sample inference too, so independent jobs differ from one another when the ensemble
+# is assembled from separate runs rather than from one batched pass.
+diffusion_conditioning_noise_std: 0.0
+# Time constant tau, in forecast steps, of an exponential fade exp(-fstep / tau) on the
+# amplitude across the rollout; 0 keeps it constant. Same reasoning as the particle
+# guidance fade: the conditioning is identical across members only at the first forecast
+# step, which is where the perturbation buys spread that is not already there. Later steps
+# start from conditioning that has diverged on its own, and re-injecting a fixed relative
+# perturbation every step compounds as (1+eps)^k. Measured from the rollout's first
+# generated step, so forecast.offset > 0 still starts at full amplitude.
+diffusion_conditioning_noise_fstep_decay: 0.0
+# Which norm the amplitude is relative to: "token" (each HEALPix token's own RMS, so the
+# perturbation follows the local token magnitude and stays proportional across the map) or
+# "member" (one RMS per member, i.e. a spatially uniform absolute amplitude, which
+# perturbs low-magnitude tokens relatively more).
+diffusion_conditioning_noise_norm_scope: "token"
+# How the perturbation is applied along the denoising trajectory:
+#   "cads"  CADS (Sadat et al., ICLR 2024, arXiv:2310.17347). The conditioning is
+#           re-corrupted at every denoising step as sqrt(gamma)*c + s*sqrt(1-gamma)*noise,
+#           with gamma rising from 0 to 1 along the trajectory: destroyed at high sigma,
+#           where the trajectory decides which mode it falls into and diversity is won, and
+#           fully restored by the end, where condition alignment is what matters. The member
+#           is therefore left with an unbiased conditioning.
+#   "fixed" One draw per forecast step, added to the conditioning and held constant through
+#           the whole ODE, so the member keeps a persistent perturbed state to forecast
+#           from -- the latent analogue of an ensemble of initial conditions.
+diffusion_conditioning_noise_schedule: "cads"
+# CADS gamma(t) thresholds on trajectory progress t (1.0 at the first denoising step, 0.0 at
+# the last): conditioning is clean for t <= tau1, fully destroyed for t >= tau2, and mixed
+# linearly in between, so the corruption covers the first (1 - tau1) of the denoising steps.
+# Paper defaults are tau1=0.6, tau2=1.0, ablated as tau1=0.2 degrading quality and tau1=0.9
+# barely helping diversity. tau2 < 1.0 keeps some conditioning at every step, which is the
+# knob to reach for first if a forecast drifts away from its initial state.
+diffusion_conditioning_noise_tau1: 0.6
+diffusion_conditioning_noise_tau2: 1.0
+# CADS rescaling mix psi: after corruption the conditioning is renormalised back to the
+# clean per-member mean/std, and psi is how much of that renormalised version is used
+# (1.0 = fully rescaled, the paper's recommendation; 0.0 = no rescaling). It prevents
+# divergence at high noise scales at a small cost in diversity. With psi > 0 the scale s
+# above sets the noise-to-signal ratio inside the ramp rather than an absolute magnitude.
+diffusion_conditioning_noise_rescale_psi: 1.0
+
 healpix_level: 5
 
 # Use 2D RoPE instead of traditional global positional encoding

--- a/config/diffusion/config_diffusion_decoder.yml
+++ b/config/diffusion/config_diffusion_decoder.yml
@@ -121,6 +121,16 @@ diffusion_particle_guidance_sigma_power: 1.0
 # reflect differences in the predicted forecast) or "xt" (the noisy state, where at high
 # sigma the distances are dominated by the independent noise draws).
 diffusion_particle_guidance_kernel_space: "x0"
+# Time constant tau, in forecast steps, of an exponential fade exp(-fstep / tau) applied to
+# the strength across the rollout; 0 disables it. Worth setting: members share identical
+# conditioning only at the first forecast step, which is where the repulsion does real work
+# (picking different modes from the same information). Later steps start from per-member
+# conditioning that has already diverged, so more repulsion double-counts spread the
+# dynamics already produce -- and it compounds, k steps of a (1+eps) inflation giving
+# (1+eps)^k. Under the fade the total stays ~exp(eps*tau) regardless of rollout length.
+# tau of 2-4 is a sensible starting range. Measured from the rollout's first generated
+# step, so forecast.offset > 0 still starts at full strength.
+diffusion_particle_guidance_fstep_decay: 0.0
 # HEALPix cells per batch when computing the repulsion; 0 = all at once. Memory/speed
 # trade-off only -- the cells are independent, so the result is identical either way.
 diffusion_particle_guidance_cell_chunk: 4096

--- a/config/diffusion/config_diffusion_decoder.yml
+++ b/config/diffusion/config_diffusion_decoder.yml
@@ -103,6 +103,28 @@ sigma_min_quantile: 0.05
 # Number of ODE denoising steps at inference. If null, uses diffusion.forward's default.
 fe_diffusion_num_inference_steps: null
 
+# --- Particle guidance (diverse ensemble sampling) ---
+# Denoise the ensemble members jointly with a repulsive force between them instead of
+# independently (Corso et al. 2024, repulsion-only / "fixed potential" variant). The RBF
+# kernel acts per HEALPix cell, so the spread it creates is local. Only has an effect when
+# fe_diffusion_num_ensemble_members > 1; with it False the sampler is the plain EDM ODE.
+diffusion_particle_guidance: False
+# Repulsion magnitude as a fraction of the ODE drift at sigma_max, annealed by the schedule
+# below. 0.1 perturbs each step by ~10%; raise it until the member spread in the sampling
+# diagnostics plot moves, and stop before per-member forecast skill degrades.
+diffusion_particle_guidance_strength: 0.1
+# Exponent p in alpha(sigma) = strength * (sigma / sigma_max_eff) ** p. Repulsion is
+# strongest at high sigma, where the trajectory still decides which mode it falls into,
+# and anneals to zero so that members finish on-manifold.
+diffusion_particle_guidance_sigma_power: 1.0
+# Space in which pairwise member distances are measured: "x0" (denoiser output; distances
+# reflect differences in the predicted forecast) or "xt" (the noisy state, where at high
+# sigma the distances are dominated by the independent noise draws).
+diffusion_particle_guidance_kernel_space: "x0"
+# HEALPix cells per batch when computing the repulsion; 0 = all at once. Memory/speed
+# trade-off only -- the cells are independent, so the result is identical either way.
+diffusion_particle_guidance_cell_chunk: 4096
+
 healpix_level: 5
 
 # Use 2D RoPE instead of traditional global positional encoding

--- a/config/diffusion/config_diffusion_forecast.yml
+++ b/config/diffusion/config_diffusion_forecast.yml
@@ -135,6 +135,59 @@ diffusion_particle_guidance_fstep_decay: 0.0
 # trade-off only -- the cells are independent, so the result is identical either way.
 diffusion_particle_guidance_cell_chunk: 4096
 
+# --- Conditioning noise (per-member perturbation of the latent conditioning) ---
+# Inference-only: before denoising, each ensemble member's copy of the latent conditioning
+# tokens gets its own Gaussian perturbation, so the members forecast from slightly
+# different starting states instead of from identical information -- the
+# ensemble-of-initial-conditions idea applied in latent space. Complementary to particle
+# guidance: that pushes members apart inside one denoising pass, this hands them different
+# information to begin with, and the model's own dynamics amplify it over the rollout.
+# Amplitude as a fraction of the token norm (see the scope knob below), so 0.01 perturbs
+# each conditioning token by ~1% of its own magnitude. 0.0 disables it entirely, leaving
+# the conditioning and the RNG stream untouched. Start around 0.005-0.02 and raise it until
+# the ensemble spread moves, stopping before per-member forecast skill degrades. Applies to
+# single-sample inference too, so independent jobs differ from one another when the ensemble
+# is assembled from separate runs rather than from one batched pass.
+diffusion_conditioning_noise_std: 0.0
+# Time constant tau, in forecast steps, of an exponential fade exp(-fstep / tau) on the
+# amplitude across the rollout; 0 keeps it constant. Same reasoning as the particle
+# guidance fade: the conditioning is identical across members only at the first forecast
+# step, which is where the perturbation buys spread that is not already there. Later steps
+# start from conditioning that has diverged on its own, and re-injecting a fixed relative
+# perturbation every step compounds as (1+eps)^k. Measured from the rollout's first
+# generated step, so forecast.offset > 0 still starts at full amplitude.
+diffusion_conditioning_noise_fstep_decay: 0.0
+# Which norm the amplitude is relative to: "token" (each HEALPix token's own RMS, so the
+# perturbation follows the local token magnitude and stays proportional across the map) or
+# "member" (one RMS per member, i.e. a spatially uniform absolute amplitude, which
+# perturbs low-magnitude tokens relatively more).
+diffusion_conditioning_noise_norm_scope: "token"
+# How the perturbation is applied along the denoising trajectory:
+#   "cads"  CADS (Sadat et al., ICLR 2024, arXiv:2310.17347). The conditioning is
+#           re-corrupted at every denoising step as sqrt(gamma)*c + s*sqrt(1-gamma)*noise,
+#           with gamma rising from 0 to 1 along the trajectory: destroyed at high sigma,
+#           where the trajectory decides which mode it falls into and diversity is won, and
+#           fully restored by the end, where condition alignment is what matters. The member
+#           is therefore left with an unbiased conditioning.
+#   "fixed" One draw per forecast step, added to the conditioning and held constant through
+#           the whole ODE, so the member keeps a persistent perturbed state to forecast
+#           from -- the latent analogue of an ensemble of initial conditions.
+diffusion_conditioning_noise_schedule: "cads"
+# CADS gamma(t) thresholds on trajectory progress t (1.0 at the first denoising step, 0.0 at
+# the last): conditioning is clean for t <= tau1, fully destroyed for t >= tau2, and mixed
+# linearly in between, so the corruption covers the first (1 - tau1) of the denoising steps.
+# Paper defaults are tau1=0.6, tau2=1.0, ablated as tau1=0.2 degrading quality and tau1=0.9
+# barely helping diversity. tau2 < 1.0 keeps some conditioning at every step, which is the
+# knob to reach for first if a forecast drifts away from its initial state.
+diffusion_conditioning_noise_tau1: 0.6
+diffusion_conditioning_noise_tau2: 1.0
+# CADS rescaling mix psi: after corruption the conditioning is renormalised back to the
+# clean per-member mean/std, and psi is how much of that renormalised version is used
+# (1.0 = fully rescaled, the paper's recommendation; 0.0 = no rescaling). It prevents
+# divergence at high noise scales at a small cost in diversity. With psi > 0 the scale s
+# above sets the noise-to-signal ratio inside the ramp rather than an absolute magnitude.
+diffusion_conditioning_noise_rescale_psi: 1.0
+
 healpix_level: 5
 
 # Use 2D RoPE instead of traditional global positional encoding

--- a/config/diffusion/config_diffusion_forecast.yml
+++ b/config/diffusion/config_diffusion_forecast.yml
@@ -121,6 +121,16 @@ diffusion_particle_guidance_sigma_power: 1.0
 # reflect differences in the predicted forecast) or "xt" (the noisy state, where at high
 # sigma the distances are dominated by the independent noise draws).
 diffusion_particle_guidance_kernel_space: "x0"
+# Time constant tau, in forecast steps, of an exponential fade exp(-fstep / tau) applied to
+# the strength across the rollout; 0 disables it. Worth setting: members share identical
+# conditioning only at the first forecast step, which is where the repulsion does real work
+# (picking different modes from the same information). Later steps start from per-member
+# conditioning that has already diverged, so more repulsion double-counts spread the
+# dynamics already produce -- and it compounds, k steps of a (1+eps) inflation giving
+# (1+eps)^k. Under the fade the total stays ~exp(eps*tau) regardless of rollout length.
+# tau of 2-4 is a sensible starting range. Measured from the rollout's first generated
+# step, so forecast.offset > 0 still starts at full strength.
+diffusion_particle_guidance_fstep_decay: 0.0
 # HEALPix cells per batch when computing the repulsion; 0 = all at once. Memory/speed
 # trade-off only -- the cells are independent, so the result is identical either way.
 diffusion_particle_guidance_cell_chunk: 4096

--- a/config/diffusion/config_diffusion_forecast.yml
+++ b/config/diffusion/config_diffusion_forecast.yml
@@ -103,6 +103,28 @@ sigma_min_quantile: 0.05
 # Number of ODE denoising steps at inference. If null, uses diffusion.forward's default.
 fe_diffusion_num_inference_steps: null
 
+# --- Particle guidance (diverse ensemble sampling) ---
+# Denoise the ensemble members jointly with a repulsive force between them instead of
+# independently (Corso et al. 2024, repulsion-only / "fixed potential" variant). The RBF
+# kernel acts per HEALPix cell, so the spread it creates is local. Only has an effect when
+# fe_diffusion_num_ensemble_members > 1; with it False the sampler is the plain EDM ODE.
+diffusion_particle_guidance: False
+# Repulsion magnitude as a fraction of the ODE drift at sigma_max, annealed by the schedule
+# below. 0.1 perturbs each step by ~10%; raise it until the member spread in the sampling
+# diagnostics plot moves, and stop before per-member forecast skill degrades.
+diffusion_particle_guidance_strength: 0.1
+# Exponent p in alpha(sigma) = strength * (sigma / sigma_max_eff) ** p. Repulsion is
+# strongest at high sigma, where the trajectory still decides which mode it falls into,
+# and anneals to zero so that members finish on-manifold.
+diffusion_particle_guidance_sigma_power: 1.0
+# Space in which pairwise member distances are measured: "x0" (denoiser output; distances
+# reflect differences in the predicted forecast) or "xt" (the noisy state, where at high
+# sigma the distances are dominated by the independent noise draws).
+diffusion_particle_guidance_kernel_space: "x0"
+# HEALPix cells per batch when computing the repulsion; 0 = all at once. Memory/speed
+# trade-off only -- the cells are independent, so the result is identical either way.
+diffusion_particle_guidance_cell_chunk: 4096
+
 healpix_level: 5
 
 # Use 2D RoPE instead of traditional global positional encoding

--- a/packages/common/src/weathergen/common/io.py
+++ b/packages/common/src/weathergen/common/io.py
@@ -602,6 +602,10 @@ class OutputBatchData:
     forecast_offset: int
     forecast_steps: list[int]
 
+    # if False, no target datasets are built/written (skip_target_values inference);
+    # self.targets then only provides row counts via targets_lens
+    write_targets: bool = True
+
     @functools.cached_property
     def samples(self):
         """Continous indices of all samples accross all batches."""
@@ -691,20 +695,26 @@ class OutputBatchData:
                 datapoints
             ]
 
-        assert len(data_coords.channels) == target_data.shape[1], (
-            "Number of channel names does not align with target data."
-        )
         assert len(data_coords.channels) == preds_data.shape[1], (
             "Number of channel names does not align with prediction data."
         )
 
-        target_dataset = OutputDataset(
-            "target",
-            key,
-            source_interval,
-            target_data,
-            **dataclasses.asdict(data_coords),
-        )
+        if self.write_targets:
+            assert len(data_coords.channels) == target_data.shape[1], (
+                "Number of channel names does not align with target data."
+            )
+            target_dataset = OutputDataset(
+                "target",
+                key,
+                source_interval,
+                target_data,
+                **dataclasses.asdict(data_coords),
+            )
+        else:
+            # target values were never read (skip_target_values); coords/times are
+            # still written as part of the prediction dataset
+            target_dataset = None
+
         prediction_dataset = OutputDataset(
             "prediction",
             key,

--- a/packages/common/src/weathergen/common/io.py
+++ b/packages/common/src/weathergen/common/io.py
@@ -492,6 +492,10 @@ class ZarrIO:
 
     @functools.cached_property
     def forecast_offset(self) -> int:
+        # Stores written with test_config.forecast.offset=1 and num_steps_input=1 have no
+        # step-0 source group and begin at forecast step 1; a missing step 0 implies offset=1.
+        if self.example_key.forecast_step != 0:
+            return 1
         fstep0_datasets = self._get_datasets(self.example_key)
         return ItemKey._infer_forecast_offset(fstep0_datasets)
 
@@ -500,7 +504,7 @@ class ZarrIO:
         try:
             sample, example_sample = next(self.data_root.groups())
             stream, example_stream = next(example_sample.groups())
-            fstep = 0
+            fstep = min((int(s) for s in example_stream.group_keys()), default=0)
         except StopIteration as e:
             msg = f"Data store at: {self._store_path} is empty."
             raise FileNotFoundError(msg) from e
@@ -526,12 +530,13 @@ class ZarrIO:
         _, example_sample = next(self.data_root.groups())
         _, example_stream = next(example_sample.groups())
 
-        all_steps = sorted(list(example_stream.group_keys()))
+        all_steps = sorted(example_stream.group_keys(), key=int)
 
-        if self.forecast_offset == 1:
-            return all_steps[1:]  # exclude fstep with no targets/preds
-        else:
-            return all_steps
+        # Drop the leading step only when it is the step-0 source slot; stores that already
+        # begin at step 1 (offset=1, num_steps_input=1) keep every step.
+        if self.forecast_offset == 1 and all_steps and int(all_steps[0]) == 0:
+            return all_steps[1:]
+        return all_steps
 
 
 class ZipZarrIO(ZarrIO):

--- a/packages/common/src/weathergen/common/io.py
+++ b/packages/common/src/weathergen/common/io.py
@@ -597,6 +597,10 @@ class OutputBatchData:
     forecast_offset: int
     forecast_steps: list[int]
 
+    # if False, no target datasets are built/written (skip_target_values inference);
+    # self.targets then only provides row counts via targets_lens
+    write_targets: bool = True
+
     @functools.cached_property
     def samples(self):
         """Continous indices of all samples accross all batches."""
@@ -686,20 +690,26 @@ class OutputBatchData:
                 datapoints
             ]
 
-        assert len(data_coords.channels) == target_data.shape[1], (
-            "Number of channel names does not align with target data."
-        )
         assert len(data_coords.channels) == preds_data.shape[1], (
             "Number of channel names does not align with prediction data."
         )
 
-        target_dataset = OutputDataset(
-            "target",
-            key,
-            source_interval,
-            target_data,
-            **dataclasses.asdict(data_coords),
-        )
+        if self.write_targets:
+            assert len(data_coords.channels) == target_data.shape[1], (
+                "Number of channel names does not align with target data."
+            )
+            target_dataset = OutputDataset(
+                "target",
+                key,
+                source_interval,
+                target_data,
+                **dataclasses.asdict(data_coords),
+            )
+        else:
+            # target values were never read (skip_target_values); coords/times are
+            # still written as part of the prediction dataset
+            target_dataset = None
+
         prediction_dataset = OutputDataset(
             "prediction",
             key,

--- a/packages/evaluate/src/weathergen/evaluate/io/data/io_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/data/io_orchestration.py
@@ -15,6 +15,7 @@ focused on the public API and caching.
 """
 
 import contextlib
+import errno
 import logging
 import os
 import resource
@@ -25,8 +26,9 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import xarray as xr
-from joblib import Parallel, delayed
+from joblib import Parallel, delayed, parallel_config
 from joblib.externals.loky import get_reusable_executor
+from joblib.externals.loky.process_executor import TerminatedWorkerError
 from numpy.typing import NDArray
 
 from weathergen.evaluate.io.data.dataarray_builders import (
@@ -90,16 +92,17 @@ class IOState:
 # ---------------------------------------------------------------------------
 
 
-def get_num_workers(*, check_process_headroom: bool = False, max_workers: int | None = None) -> int:
+def get_num_workers(*, check_process_headroom: bool = True, max_workers: int | None = None) -> int:
     """Determine safe number of parallel workers.
 
     Parameters
     ----------
     check_process_headroom : bool
-        When *True* (useful for ``loky`` / process-based backends), also
-        verify that the user has enough ``RLIMIT_NPROC`` headroom before
-        returning > 1.  If headroom is dangerously low the function
-        returns 1 regardless of the CPU-based estimate.
+        When *True* (the default), cap the result at the number of workers
+        that fit in the process's remaining *task* budget -- see
+        :func:`_apply_process_headroom`.  Defaults to *True* because every
+        call site wants it: a pool that does not fit does not fail cheaply,
+        it falls back to sequential and costs minutes.
     max_workers : int | None
         Optional hard cap for max workers.  When set from the eval config
         (``max_workers`` key in the YAML), it overrides the default of 36.
@@ -136,39 +139,191 @@ def get_num_workers(*, check_process_headroom: bool = False, max_workers: int | 
     return n
 
 
-def _apply_process_headroom(n: int) -> int:
-    """Reduce *n* to 1 when the user's RLIMIT_NPROC headroom is dangerously low."""
+# Threads a worker may use for BLAS / OpenMP.  Pinned rather than left to
+# joblib, which hands each worker ``cpu_count // n_jobs`` threads -- so
+# *shrinking* the pool makes every worker *more* expensive, exactly backwards
+# when we are shrinking it to fit a budget.  Measured import cost per worker:
+# inner=2 -> 5 threads, inner=6 -> 17, inner=12 -> 35, inner=24 -> 71.
+WORKER_INNER_THREADS = 2
+
+# What we pin zarr's per-process ThreadPoolExecutor to inside a worker.  Left
+# unpinned, zarr falls through to asyncio's default executor --
+# ``min(32, cpu_count + 4)`` threads per worker, more than everything else in
+# the worker combined, and not scaled down by joblib.
+ZARR_WORKER_THREADS = 4
+
+# Tasks (threads, not processes) one worker occupies while running
+# _read_sample, measured on the santis login node with both pins applied:
+# ~5 BLAS + 4 zarr + the loky and asyncio bookkeeping threads, ~12 total.
+TASKS_PER_WORKER = 16
+
+# Tasks left free for the parent process and for whatever else the user is
+# running (an IDE session on a login node easily holds 300+).
+TASK_RESERVE = 96
+
+
+def _cgroup_task_budget() -> tuple[int, int] | None:
+    """Return ``(used, limit)`` tasks from the tightest cgroup v2 ancestor.
+
+    The pids controller counts *tasks* -- threads, not processes -- and the
+    limit that binds is whichever ancestor has the least headroom, which on a
+    systemd login node is normally ``user.slice/user-<uid>.slice`` via
+    logind's ``TasksMax``.  Returns *None* when no cgroup v2 pids limit
+    applies (cgroup v1, no controller, or every ancestor set to ``max``).
+    """
     try:
-        soft_limit, _ = resource.getrlimit(resource.RLIMIT_NPROC)
-        if soft_limit == resource.RLIM_INFINITY:
-            soft_limit = 65536
+        rel = ""
+        for line in Path("/proc/self/cgroup").read_text().splitlines():
+            hid, ctrl, path = line.split(":", 2)
+            if hid == "0" and ctrl == "":  # cgroup v2 unified line
+                rel = path.lstrip("/")
+                break
+        else:
+            return None
 
-        result = subprocess.run(
-            ["ps", "-u", str(os.getuid()), "--no-headers", "-o", "pid"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        user_procs = len(result.stdout.strip().splitlines()) if result.returncode == 0 else 0
+        tightest: tuple[int, int] | None = None
+        node = Path("/sys/fs/cgroup") / rel
+        root = Path("/sys/fs/cgroup")
+        while True:
+            try:
+                limit_raw = (node / "pids.max").read_text().strip()
+                used = int((node / "pids.current").read_text().strip())
+            except OSError:
+                limit_raw, used = "max", 0
+            if limit_raw != "max":
+                limit = int(limit_raw)
+                if tightest is None or (limit - used) < (tightest[1] - tightest[0]):
+                    tightest = (used, limit)
+            if node == root:
+                break
+            node = node.parent
+        return tightest
+    except Exception:
+        return None
 
-        available = soft_limit - user_procs
-        if available < 64:
-            _logger.info(
-                f"Low process headroom ({available}/{soft_limit} slots free). Forcing n_workers=1."
+
+def _apply_process_headroom(n: int) -> int:
+    """Cap *n* to the number of workers that actually fit in the task budget.
+
+    Prefers the cgroup v2 pids limit, which is what binds in practice on a
+    login node; ``RLIMIT_NPROC`` is typically ~1e6 there and never fires.
+    """
+    try:
+        budget = _cgroup_task_budget()
+        if budget is not None:
+            used, limit = budget
+            source = "cgroup pids"
+        else:
+            soft_limit, _ = resource.getrlimit(resource.RLIMIT_NPROC)
+            if soft_limit == resource.RLIM_INFINITY:
+                soft_limit = 65536
+            result = subprocess.run(
+                ["ps", "-u", str(os.getuid()), "--no-headers", "-o", "nlwp"],
+                capture_output=True,
+                text=True,
+                timeout=5,
             )
-            return 1
+            used = sum(int(x) for x in result.stdout.split()) if result.returncode == 0 else 0
+            limit, source = soft_limit, "RLIMIT_NPROC"
 
-        capped = min(n, available // 8)
+        available = limit - used - TASK_RESERVE
+        capped = max(1, available // TASKS_PER_WORKER)
         if capped < n:
-            _logger.info(
-                f"Process headroom {available}/{soft_limit} free. "
+            _logger.warning(
+                f"Task headroom is tight: {used}/{limit} {source} tasks in use, "
+                f"{max(0, available)} usable after a {TASK_RESERVE}-task reserve, "
+                f"~{TASKS_PER_WORKER} tasks per worker. "
                 f"Capping n_workers from {n} to {capped}."
             )
-        return max(1, capped)
+            return capped
+        return n
 
     except Exception as exc:
-        _logger.debug(f"Could not check process headroom ({exc}). Keeping n_workers={n}.")
+        _logger.debug(f"Could not check task headroom ({exc}). Keeping n_workers={n}.")
         return n
+
+
+def _run_pool(calls: list, n_workers: int, backend: str, verbose: int) -> list:
+    """Run *calls* on a pool of *n_workers*, pinning each worker's inner threads.
+
+    ``inner_max_num_threads`` has to be set on the backend held by the
+    ``parallel_config`` context, so ``Parallel`` is deliberately constructed
+    *without* a ``backend=`` argument here -- passing one would build a fresh
+    backend instance and drop the pin.
+    """
+    if backend != "loky":
+        return Parallel(n_jobs=n_workers, backend=backend, verbose=verbose)(calls)
+    with parallel_config(backend=backend, inner_max_num_threads=WORKER_INNER_THREADS):
+        return Parallel(n_jobs=n_workers, verbose=verbose)(calls)
+
+
+def _fit_pool_to_budget(n_workers: int, backend: str, desc: str) -> int:
+    """Re-measure the task budget immediately before the pool is created.
+
+    ``get_num_workers`` runs once, when the reader is built; the pool starts
+    minutes later, by which time another job (or another rank of this one) may
+    have taken the headroom.  Sizing off the stale number is how an 8-worker
+    pool ends up failing to start.
+    """
+    if backend != "loky" or n_workers <= 1:
+        return n_workers
+    fitted = _apply_process_headroom(n_workers)
+    if fitted < n_workers:
+        _logger.info(
+            f"{desc}: {_task_budget_str()}; using {fitted} workers instead of {n_workers}."
+        )
+    return fitted
+
+
+def _shutdown_loky(backend: str) -> None:
+    """Release the loky pool between dispatches so its tasks return to the budget.
+
+    ``reuse=True`` is what makes this shut down *the pool joblib just used*.
+    Called with no arguments, ``get_reusable_executor()`` defaults
+    ``max_workers`` to ``cpu_count()``, concludes the existing (smaller) pool
+    "cannot be reused", tears it down and builds a fresh executor object --
+    which we would then immediately shut down again.
+    """
+    if backend != "loky":
+        return
+    with contextlib.suppress(Exception):
+        get_reusable_executor(reuse=True).shutdown(wait=True)
+
+
+def _is_pool_resource_error(exc: BaseException) -> bool:
+    """True when *exc* is the pool failing to start, not the work failing.
+
+    An exhausted task budget surfaces from loky as ``RuntimeError: can't start
+    new thread`` (pthread_create -> EAGAIN) or as an ``OSError`` with EAGAIN /
+    ENOMEM from ``fork()``; a worker killed under memory pressure surfaces as
+    ``TerminatedWorkerError``.  Anything else came out of the dispatched
+    function itself and must not be hidden behind a silent sequential retry --
+    that turns a real bug into a slow run that still reports success.
+    """
+    if isinstance(exc, TerminatedWorkerError | MemoryError):
+        return True
+    if isinstance(exc, OSError) and exc.errno in (errno.EAGAIN, errno.ENOMEM):
+        return True
+    return isinstance(exc, RuntimeError) and "can't start new thread" in str(exc)
+
+
+def _task_budget_str() -> str:
+    """Human-readable cgroup task budget, for diagnosing pool failures from a log."""
+    budget = _cgroup_task_budget()
+    if budget is None:
+        return "no cgroup pids limit found"
+    used, limit = budget
+    return f"{used}/{limit} cgroup tasks in use, {limit - used} free"
+
+
+def _relax_zarr_threads(calls: list) -> None:
+    """Undo the worker-sized zarr pin before a sequential retry.
+
+    The retry runs alone in this process, where the wide pool is a pure win.
+    """
+    for c in calls:
+        if isinstance(c[2], dict) and "zarr_threads" in c[2]:
+            c[2]["zarr_threads"] = None
 
 
 # Generic parallel dispatch with fallback
@@ -214,27 +369,30 @@ def dispatch_parallel(
     if n_tasks == 0:
         return []
 
-    effective = min(n_workers, n_tasks)
+    effective = _fit_pool_to_budget(min(n_workers, n_tasks), backend, desc)
 
     # skip Parallel entirely when sequential loky to avoid pool-creation overhead
     if effective <= 1 and backend == "loky":
+        _relax_zarr_threads(calls)
         results = [c[0](*c[1], **c[2]) for c in calls]
 
     # parallel: try, then fall back to sequential on pool-creation failure.
     else:
         try:
-            results = Parallel(n_jobs=effective, backend=backend, verbose=verbose)(calls)
-            if backend == "loky":
-                with contextlib.suppress(Exception):
-                    get_reusable_executor().shutdown(wait=True)
+            results = _run_pool(calls, effective, backend, verbose)
+            _shutdown_loky(backend)
         except Exception as exc:
+            if not _is_pool_resource_error(exc):
+                _shutdown_loky(backend)
+                raise
             _logger.warning(
-                f"{desc}: parallel pool failed ({type(exc).__name__}: {exc}). "
+                f"{desc}: could not start a {effective}-worker {backend} pool "
+                f"({type(exc).__name__}: {exc}); {_task_budget_str()}, "
+                f"~{TASKS_PER_WORKER} tasks needed per worker. "
                 f"Falling back to sequential."
             )
-            if backend == "loky":
-                with contextlib.suppress(Exception):
-                    get_reusable_executor().shutdown(wait=True)
+            _shutdown_loky(backend)
+            _relax_zarr_threads(calls)
             results = [c[0](*c[1], **c[2]) for c in calls]
 
     return results
@@ -324,6 +482,7 @@ def _parallel_read(
         ``(results, fell_back)`` — the per-sample results and whether
         the dispatch fell back from parallel to sequential execution.
     """
+    effective = _fit_pool_to_budget(min(n_workers, len(samples)), backend, label)
     kwargs = dict(
         zarr_path=zarr_path,
         stream=stream,
@@ -333,27 +492,32 @@ def _parallel_read(
         read_coords=need_coords,
         is_gridded=is_gridded,
         regrid_opts=regrid_opts,
+        zarr_threads=ZARR_WORKER_THREADS if effective > 1 else None,
     )
 
     calls = [delayed(_read_sample)(sample=s, **kwargs) for s in samples]
-    effective = min(n_workers, len(calls))
 
     if effective <= 1:
+        _relax_zarr_threads(calls)
         results = [c[0](*c[1], **c[2]) for c in calls]
         return results, False
 
     try:
-        results = Parallel(n_jobs=effective, backend=backend, verbose=5)(calls)
-        with contextlib.suppress(Exception):
-            get_reusable_executor().shutdown(wait=True)
+        results = _run_pool(calls, effective, backend, verbose=5)
+        _shutdown_loky(backend)
         return results, False
     except Exception as exc:
+        if not _is_pool_resource_error(exc):
+            _shutdown_loky(backend)
+            raise
         _logger.warning(
-            f"{label}: parallel pool failed ({type(exc).__name__}: {exc}). "
+            f"{label}: could not start a {effective}-worker {backend} pool "
+            f"({type(exc).__name__}: {exc}); {_task_budget_str()}, "
+            f"~{TASKS_PER_WORKER} tasks needed per worker. "
             f"Falling back to sequential."
         )
-        with contextlib.suppress(Exception):
-            get_reusable_executor().shutdown(wait=True)
+        _shutdown_loky(backend)
+        _relax_zarr_threads(calls)
         results = [c[0](*c[1], **c[2]) for c in calls]
         return results, True
 
@@ -623,6 +787,7 @@ def get_data_zipstore(state: IOState) -> ReaderOutput:
         read_coords=not state.is_gridded,
         is_gridded=state.is_gridded,
         regrid_opts=state.regrid_opts,
+        zarr_threads=(ZARR_WORKER_THREADS if min(state.n_workers, n_total) > 1 else None),
     )
     calls = [
         delayed(_read_sample)(sample=s, fsteps=[fs], **kwargs)

--- a/packages/evaluate/src/weathergen/evaluate/io/data/io_workers.py
+++ b/packages/evaluate/src/weathergen/evaluate/io/data/io_workers.py
@@ -25,6 +25,26 @@ from weathergen.evaluate.utils.derived_channels import is_derivable_channel
 _logger = logging.getLogger(__name__)
 
 
+def _pin_zarr_threads(max_workers: int | None) -> None:
+    """Bound zarr's per-process I/O thread pool to *max_workers*.
+
+    ``zarr.core.sync`` only installs its own executor when
+    ``threading.max_workers`` is set; left unset it falls through to asyncio's
+    default executor, which is ``ThreadPoolExecutor(max_workers=None)`` ->
+    ``min(32, cpu_count + 4)`` threads *per process*.  Inside a loky pool that
+    is ~32 extra tasks per worker, and the cgroup pids controller counts tasks,
+    not processes -- it is what exhausts the limit long before the BLAS pools
+    joblib already sizes down do.
+
+    A no-op when *max_workers* is None, which keeps the wide pool for
+    single-process (sequential) reads where it is a pure win.
+    """
+    if max_workers is None:
+        return
+    with contextlib.suppress(Exception):
+        zarr.config.set({"threading.max_workers": max_workers})
+
+
 def _compute_early_channel_selection(
     read_channels: list[str],
     requested_channels: list[str],
@@ -92,6 +112,7 @@ def _read_sample(
     read_coords: bool = False,
     is_gridded: bool = True,
     regrid_opts: dict | None = None,
+    zarr_threads: int | None = None,
 ) -> tuple[list[NDArray], list[NDArray], list[NDArray], dict]:
     """
     Read all forecast steps for one sample via direct zarr array access.
@@ -121,6 +142,11 @@ def _read_sample(
         with multiple forecast sub-steps per fstep).  If False (scatter/obs data),
         keep all observations in a single array per fstep — each observation has
         its own time and splitting would create one array per observation.
+    zarr_threads : int | None
+        Bound zarr's I/O thread pool to this many threads in the calling
+        process (see :func:`_pin_zarr_threads`).  Pass a small number when
+        running inside a worker pool, ``None`` (the default, ~32 threads) when
+        reading sequentially.
 
     Returns
     -------
@@ -136,6 +162,8 @@ def _read_sample(
                     "coords": list[np.ndarray | None]} where coords has
                     one entry per fstep (each may be None or shape (n_ip, 2)).
     """
+    _pin_zarr_threads(zarr_threads)
+
     if is_zip:
         store = zarr.storage.ZipStore(zarr_path, mode="r")
         ds = zarr.open_group(store=store, mode="r")

--- a/packages/evaluate/src/weathergen/evaluate/plotting/line_plots.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/line_plots.py
@@ -278,6 +278,7 @@ class LinePlots:
         print_summary: bool = False,
         title: str | None = None,
         colors: list[str | None] | None = None,
+        line: float | None = None,
     ) -> None:
         """
         Plot a line graph comparing multiple datasets.
@@ -296,6 +297,9 @@ class LinePlots:
             Name of the dimension to be used for the y-axis.
         print_summary:
             If True, print a summary of the values from the graph.
+        line:
+            If provided, draw a horizontal reference line at the given y-value
+            (e.g. the optimal value of a metric).
         Returns
         -------
             None
@@ -350,6 +354,7 @@ class LinePlots:
             x_dim_opts,
             y_dim,
             print_summary,
+            line=line,
             title=title,
             out_plot_dir=self.out_plot_dir_lines,
         )

--- a/packages/evaluate/src/weathergen/evaluate/plotting/line_plots.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/line_plots.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.lines import Line2D
 import seaborn as sns
 import xarray as xr
 
@@ -28,6 +29,24 @@ from weathergen.evaluate.plotting.plot_utils import (
 
 _logger = logging.getLogger(__name__)
 _logger.setLevel(logging.INFO)
+
+# Visual encoding shared by every ensemble line plot. Colour identifies the run, these
+# styles identify what the curve is. Faded == derived from the individual members;
+# full opacity == a score computed once on the ensemble as a whole.
+ENSEMBLE_STYLES = {
+    "members": {"linestyle": "--", "alpha": 0.2},
+    "members_mean": {"linestyle": "-", "alpha": 0.2},
+    "ensemble_score": {"linestyle": "-", "alpha": 1.0},
+}
+
+
+def _is_constant_over(data: xr.DataArray, dim: str) -> bool:
+    """Whether *data* carries no information along *dim* (all slices identical)."""
+    if dim not in data.dims or data.sizes[dim] <= 1:
+        return True
+    # move *dim* first so the leading slice broadcasts against the full array
+    arr = np.asarray(data.transpose(dim, ...).values)
+    return bool(np.allclose(arr, arr[:1], equal_nan=True))
 
 
 class LinePlots:
@@ -148,6 +167,63 @@ class LinePlots:
                 _logger.info("--------------------------")
         return
 
+    def _build_style_legend(
+        self,
+        drew_members: bool,
+        drew_ensemble_score: bool,
+        overlay_names: list[str] | None,
+    ) -> list[Line2D]:
+        """Build neutral proxy handles explaining the line-style encoding.
+
+        The main legend names the runs (one entry per model, colour-coded). This second
+        legend says what each line *style* means, so the styles are self-documenting
+        without adding a legend entry per metric. Returns an empty list when the plot
+        uses a single style and needs no explanation.
+
+        Parameters
+        ----------
+        drew_members: bool
+            Whether individual members and their mean were drawn.
+        drew_ensemble_score: bool
+            Whether an overlaid whole-ensemble score was drawn.
+        overlay_names: list[str] | None
+            Names of the overlaid metrics, used to label the ensemble-score entry.
+
+        Returns
+        -------
+        list[Line2D]
+            Proxy artists for the style legend.
+        """
+        if not (drew_members and drew_ensemble_score):
+            return []
+
+        entries = []
+        if drew_members:
+            member_label = {
+                "std": "member spread (std)",
+                "minmax": "member spread (min-max)",
+            }.get(self.plot_ensemble, "individual members")
+            entries.append((member_label, ENSEMBLE_STYLES["members"]))
+            entries.append(("mean over members", ENSEMBLE_STYLES["members_mean"]))
+        if drew_ensemble_score:
+            label = ", ".join(overlay_names) if overlay_names else "whole-ensemble score"
+            entries.append((label, ENSEMBLE_STYLES["ensemble_score"]))
+
+        # A key drawn at the true alpha=0.2 is illegible, so lift faded entries to a
+        # readable value that still reads as lighter than the full-opacity one.
+        return [
+            Line2D(
+                [],
+                [],
+                color="0.3",
+                linewidth=1.4,
+                label=lbl,
+                linestyle=style["linestyle"],
+                alpha=1.0 if style["alpha"] >= 1.0 else 0.5,
+            )
+            for lbl, style in entries
+        ]
+
     def _plot_ensemble(
         self, data: xr.DataArray, x_dim: str, label: str, color: str | None = None
     ) -> None:
@@ -172,12 +248,15 @@ class LinePlots:
             x_dim
         )
 
+        # Faded marks a quantity derived from the individual members (this solid line is
+        # their mean); a full-opacity solid line is a score computed once on the ensemble
+        # as a whole (e.g. rmse_ens_mean, crps). See ENSEMBLE_STYLES.
         plot_kwargs = dict(
             label=label,
             marker="o",
             markersize=4,
             linewidth=1.2,
-            linestyle="-",
+            **ENSEMBLE_STYLES["members_mean"],
         )
         if color is not None:
             plot_kwargs["color"] = color
@@ -224,7 +303,7 @@ class LinePlots:
                     ens[x_dim],
                     ens.isel(ens=j).values,
                     color=color,
-                    alpha=0.2,
+                    **ENSEMBLE_STYLES["members"],
                 )
         else:
             _logger.warning(
@@ -279,6 +358,7 @@ class LinePlots:
         title: str | None = None,
         colors: list[str | None] | None = None,
         line: float | None = None,
+        overlay_names: list[str] | None = None,
     ) -> None:
         """
         Plot a line graph comparing multiple datasets.
@@ -315,22 +395,36 @@ class LinePlots:
         fig = plt.figure(figsize=(12, 6), dpi=self.dpi_val)
         ax = fig.add_subplot(111)
 
+        # Curves whose label starts with "_" are overlaid ensemble scores belonging to a
+        # run already in the legend; they are styled apart instead of labelled again.
+        drew_members = False
+        drew_ensemble_score = False
+
         for i, data in enumerate(data_list):
             non_zero_dims = [dim for dim in data.dims if dim != x_dim and data[dim].shape[0] > 1]
             color = colors[i] if colors and i < len(colors) else None
 
-            if self.plot_ensemble and "ens" in non_zero_dims:
+            # Metrics that consume the ensemble dimension (e.g. rmse_ens_mean, crps) are
+            # broadcast across the ens slots and carry no per-member information, so the
+            # ensemble overlay would just draw identical lines on top of each other.
+            varies_over_ens = "ens" in non_zero_dims and not _is_constant_over(data, "ens")
+
+            if self.plot_ensemble and varies_over_ens:
                 _logger.info(f"LinePlot:: Plotting ensemble with option {self.plot_ensemble}.")
                 self._plot_ensemble(data, x_dim, label_list[i], color=color)
+                drew_members = True
             else:
                 averaged = self._preprocess_data(data, x_dim)
+
+                is_overlay = str(label_list[i]).startswith("_")
+                drew_ensemble_score = drew_ensemble_score or is_overlay
 
                 plot_kwargs = dict(
                     label=label_list[i],
                     marker="o",
                     markersize=4,
                     linewidth=1.2,
-                    linestyle="-",
+                    **(ENSEMBLE_STYLES["ensemble_score"] if is_overlay else {"linestyle": "-"}),
                 )
                 if color is not None:
                     plot_kwargs["color"] = color
@@ -340,6 +434,10 @@ class LinePlots:
                     averaged.values,
                     **plot_kwargs,
                 )
+
+        style_legend = self._build_style_legend(
+            drew_members, drew_ensemble_score, overlay_names
+        )
 
         parts = ["compare", tag]
         name = "_".join(filter(None, parts))
@@ -357,6 +455,7 @@ class LinePlots:
             line=line,
             title=title,
             out_plot_dir=self.out_plot_dir_lines,
+            style_legend=style_legend,
         )
 
     def _plot_base(
@@ -371,6 +470,7 @@ class LinePlots:
         title: str | None = None,
         out_plot_dir: Path = None,
         range: tuple[float, float] | None = None,
+        style_legend: list[Line2D] | None = None,
     ) -> None:
         """
         Apply labels, title, legend, save and optionally print summary.
@@ -429,7 +529,25 @@ class LinePlots:
             fontsize=11,
             fontweight="medium",
         )
-        ax.legend(frameon=False, fancybox=False, edgecolor="0.6", fontsize=8)
+        run_legend = ax.legend(frameon=False, fancybox=False, edgecolor="0.6", fontsize=8)
+
+        # The run's representative curve may be faded (it is the mean over members), but
+        # the legend swatch identifies the model and has to stay readable.
+        for handle in getattr(run_legend, "legend_handles", []):
+            handle.set_alpha(1.0)
+
+        if style_legend:
+            # Keep the run legend, then add a second one explaining the line styles.
+            ax.add_artist(run_legend)
+            ax.legend(
+                handles=style_legend,
+                loc="lower right",
+                frameon=False,
+                fontsize=7,
+                labelcolor="0.3",
+                title="line style",
+                title_fontsize=7,
+            )
         ax.tick_params(axis="both", labelsize=9, direction="in", top=True, right=True)
 
         # Thin spines

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_orchestration.py
@@ -370,7 +370,9 @@ def _plot_score_maps_per_stream(
         metric=[m for m, _ in valid],
     ).compute()
 
-    if "ens" in preds.dims:
+    # Probabilistic scores (crps, ssr, ...) consume the ensemble dimension, so it only
+    # needs re-attaching when it actually survived into the concatenated scores.
+    if "ens" in plot_metrics.dims and "ens" in preds.coords:
         plot_metrics["ens"] = preds.ens
 
     has_ens = "ens" in plot_metrics.coords
@@ -1120,6 +1122,11 @@ def plot_summary(cfg: dict, scores_dict: dict, summary_dir: Path):
         "baseline": eval_opt.get("baseline", None),
     }
 
+    # Optional co-plotting of related metrics in a single figure, e.g.
+    #   overlay_metrics: {rmse: ["rmse_ens_mean"]}
+    # draws the ensemble-mean RMSE into the per-member RMSE figure.
+    overlay_metrics = eval_opt.get("overlay_metrics", {}) or {}
+
     plotter = LinePlots(plot_cfg, summary_dir)
     sc_plotter = ScoreCards(plot_cfg, summary_dir)
     br_plotter = BarPlots(plot_cfg, summary_dir)
@@ -1132,7 +1139,15 @@ def plot_summary(cfg: dict, scores_dict: dict, summary_dir: Path):
                 elif metric == "qq_analysis":
                     quantile_plot_metric_region(metric, region, runs, scores_dict, quantile_plotter)
                 else:
-                    plot_metric_region(metric, region, runs, scores_dict, plotter, print_summary)
+                    plot_metric_region(
+                        metric,
+                        region,
+                        runs,
+                        scores_dict,
+                        plotter,
+                        print_summary,
+                        overlay_metrics=list(overlay_metrics.get(metric, [])),
+                    )
             if eval_opt.get("ratio_plots", False):
                 ratio_plot_metric_region(metric, region, runs, scores_dict, plotter, print_summary)
             if eval_opt.get("heat_maps", False):

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_utils.py
@@ -390,6 +390,9 @@ def plot_metric_region(
 
                 title = f"{metric.upper()} | {stream} | {ch}"
 
+                ref_line_dict = {"ssr_adj": 1.0}
+                line = ref_line_dict.get(metric)
+
                 plotter.plot(
                     selected_data,
                     labels,
@@ -399,6 +402,7 @@ def plot_metric_region(
                     print_summary=print_summary,
                     title=title,
                     colors=colors,
+                    line=line,
                 )
 
 

--- a/packages/evaluate/src/weathergen/evaluate/plotting/plot_utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/plotting/plot_utils.py
@@ -12,11 +12,33 @@ import logging
 import re
 from collections.abc import Iterable, Sequence
 
+import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
 from numpy.typing import NDArray
 
 _logger = logging.getLogger(__name__)
+
+
+def resolve_run_colors(run_ids: Sequence[str], runs: dict) -> dict[str, str]:
+    """Assign one fixed colour per run.
+
+    A run's configured ``color`` wins; otherwise the run takes the next entry of
+    matplotlib's default property cycle, which reproduces the colours matplotlib would
+    have picked anyway. Pinning them explicitly lets every curve belonging to the same
+    run (members, per-member mean, overlaid ensemble scores) share a single colour.
+    """
+    cycle = plt.rcParams["axes.prop_cycle"].by_key().get("color", [])
+
+    run_colors: dict[str, str] = {}
+    for i, run_id in enumerate(run_ids):
+        configured = runs.get(run_id, {}).get("color")
+        if configured:
+            run_colors[run_id] = configured
+        elif cycle:
+            run_colors[run_id] = cycle[i % len(cycle)]
+
+    return run_colors
 
 
 # Shared helpers
@@ -60,7 +82,18 @@ def calculate_average_over_dim(
 
 def lower_is_better(metric: str) -> bool:
     """Determine whether lower or higher is better."""
-    return metric in {"l1", "l2", "mae", "mse", "rmse", "vrmse", "bias", "crps", "spread"}
+    return metric in {
+        "l1",
+        "l2",
+        "mae",
+        "mse",
+        "rmse",
+        "rmse_ens_mean",
+        "vrmse",
+        "bias",
+        "crps",
+        "spread",
+    }
 
 
 def compute_offsets(n, spacing=0.11):
@@ -343,6 +376,7 @@ def plot_metric_region(
     scores_dict: dict,
     plotter: object,
     print_summary: bool,
+    overlay_metrics: list[str] | None = None,
 ) -> None:
     """Plot data for all streams and channels for a given metric and region.
 
@@ -360,10 +394,15 @@ def plot_metric_region(
         Plotter object to handle the plotting part
     print_summary: bool
         Option to print plot values to screen
+    overlay_metrics: list[str] | None
+        Additional metrics to draw into the same figure as ``metric``, e.g. overlaying
+        ``rmse_ens_mean`` onto the ``rmse`` plot to compare the ensemble-mean skill with
+        the individual members. Each overlay is drawn as its own labelled curve.
 
     """
     streams_set = collect_streams(runs)
     channels_set = collect_channels(scores_dict, metric, region, runs)
+    run_colors = resolve_run_colors(list(runs), runs)
 
     for stream in streams_set:
         for ch in channels_set:
@@ -377,18 +416,44 @@ def plot_metric_region(
                 selected_data.append(data.sel(channel=ch))
                 labels.append(runs[run_id].get("label", run_id))
                 run_ids.append(run_id)
-                colors.append(runs[run_id].get("color", None))
+                colors.append(run_colors.get(run_id))
+
+            for ov_metric in overlay_metrics or []:
+                ov_scores = scores_dict.get(ov_metric, {}).get(region, {}).get(stream, {})
+                if not ov_scores:
+                    _logger.warning(
+                        f"Overlay metric '{ov_metric}' requested for '{metric}' but no scores "
+                        f"are available for {region} - {stream}. It is skipped; make sure it "
+                        "is listed under evaluation.metrics."
+                    )
+                    continue
+                for run_id, data in ov_scores.items():
+                    if ch not in np.atleast_1d(data.channel.values) or data.isnull().all():
+                        continue
+
+                    selected_data.append(data.sel(channel=ch))
+                    # Overlays belong to the same model as the base curve, so they share its
+                    # colour and are kept out of the legend (matplotlib skips "_"-prefixed
+                    # labels); the line style alone distinguishes them.
+                    run_label = runs[run_id].get("label", run_id)
+                    labels.append(f"_{run_label} - {ov_metric}")
+                    run_ids.append(run_id)
+                    colors.append(run_colors.get(run_id))
 
             if selected_data:
                 _logger.info(f"Creating line plot for {metric} - {region} - {stream} - {ch}.")
 
+                plotted_metrics = [metric, *(overlay_metrics or [])]
+
                 name = create_filename(
-                    prefix=[metric, region], middle=sorted(set(run_ids)), suffix=[stream, ch]
+                    prefix=[*plotted_metrics, region],
+                    middle=sorted(set(run_ids)),
+                    suffix=[stream, ch],
                 )
 
                 selected_data, time_dim = _assign_time_coord(selected_data)
 
-                title = f"{metric.upper()} | {stream} | {ch}"
+                title = f"{' + '.join(m.upper() for m in plotted_metrics)} | {stream} | {ch}"
 
                 ref_line_dict = {"ssr_adj": 1.0}
                 line = ref_line_dict.get(metric)
@@ -403,6 +468,7 @@ def plot_metric_region(
                     title=title,
                     colors=colors,
                     line=line,
+                    overlay_names=list(overlay_metrics or []),
                 )
 
 

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -22,6 +22,9 @@ from weathergen.evaluate.scores.score_utils import calc_latitude_weights, to_lis
 
 _logger = logging.getLogger(__name__)
 
+# Upper bound on the number of rank-histogram entries serialized into score attributes.
+_RANK_HISTOGRAM_MAX_ATTR_SIZE = 100_000
+
 try:
     import xskillscore
     from xhistogram.xarray import histogram
@@ -213,6 +216,8 @@ class Scores:
             "crps": self.calc_crps,
             "rank_histogram": self.calc_rank_histogram,
             "spread": self.calc_spread,
+            # RMSE of the ensemble-mean field; complements the per-member "rmse" above
+            "rmse_ens_mean": self.calc_rmse_ens_mean,
         }
 
     def get_score(
@@ -265,12 +270,15 @@ class Scores:
             f = self.det_metrics_dict[score_name]
             _logger.debug(f"Using deterministic metric: {score_name}")
         elif score_name in self.prob_metrics_dict.keys():
-            assert self._ens_dim in data.prediction.dims, (
-                f"Probablistic score {score_name} chosen, but ensemble dimension {self._ens_dim} "
-                "not found in prediction data. Skipping score calculation."
-            )
-            return None
+            if self._ens_dim not in data.prediction.dims:
+                _logger.warning(
+                    f"Probabilistic score '{score_name}' chosen, but ensemble dimension "
+                    f"'{self._ens_dim}' not found in prediction data dims "
+                    f"{data.prediction.dims}. Skipping score calculation."
+                )
+                return None
             f = self.prob_metrics_dict[score_name]
+            _logger.debug(f"Using probabilistic metric: {score_name}")
         else:
             raise ValueError(
                 f"Unknown score chosen. Supported scores: {
@@ -1542,6 +1550,40 @@ class Scores:
             return np.sqrt((ens_size + 1) / ens_size) * spread / rmse
         return spread / rmse
 
+    def calc_rmse_ens_mean(
+        self,
+        p: xr.DataArray,
+        gt: xr.DataArray,
+        latitude_weights: xr.DataArray | None = None,
+    ) -> xr.DataArray:
+        """
+        Calculate the RMSE of the ensemble mean forecast w.r.t. reference data.
+
+        The ensemble members are averaged into a single field *before* the RMSE is taken.
+        This is the skill component of the spread-skill ratio (see ``calc_ssr``) and is a
+        different quantity from the ``rmse`` score, which is evaluated per member and hence
+        does not benefit from the error cancellation of ensemble averaging. Both scores can
+        be requested side by side.
+
+        Parameters
+        ----------
+        p: xr.DataArray
+            Forecast data array with ensemble dimension
+        gt: xr.DataArray
+            Ground truth data array
+        latitude_weights: xr.DataArray | None
+            Optional latitude weights for area-weighted averaging.
+            If provided, the RMSE will be weighted by these values.
+
+        Returns
+        -------
+        xr.DataArray
+            Root mean squared error of the ensemble mean
+        """
+        ens_mean = p.mean(dim=self._ens_dim)
+
+        return self.calc_rmse(ens_mean, gt, latitude_weights=latitude_weights)
+
     def calc_crps(
         self,
         p: xr.DataArray,
@@ -1665,9 +1707,11 @@ class Scores:
                     da.random.random(size=fcst_stacked.shape, chunks=fcst_stacked.chunks)
                     * noise_fac
                 )
-        # preserve the other coordinates
+        # preserve the other coordinates, keeping their dimension names so that
+        # non-dimension coordinates (e.g. init_times on "sample") are reattached
+        # to the correct dimension instead of spawning a new one
         preserved_coords = {
-            c: obs_stacked[c].values
+            c: (obs_stacked[c].dims, obs_stacked[c].values)
             for c in obs_stacked.coords
             if all(dim not in {self._ens_dim, "npoints"} for dim in obs_stacked[c].dims)
         }
@@ -1684,18 +1728,58 @@ class Scores:
         )
 
         # Reattach preserved coordinates by broadcasting
-        for coord_name, coord_values in preserved_coords.items():
+        for coord_name, (coord_dims, coord_values) in preserved_coords.items():
             # Only keep unique values along npoints if necessary
             if coord_name in rank_counts.coords:
                 continue
-            rank_counts = rank_counts.assign_coords({coord_name: coord_values})
+            # Coordinates whose dimensions did not survive the histogram cannot be
+            # reattached (e.g. dims consumed by the aggregation).
+            if not all(dim in rank_counts.dims for dim in coord_dims):
+                continue
+            rank_counts = rank_counts.assign_coords({coord_name: (coord_dims, coord_values)})
+
+        npoints = len(fcst_stacked["npoints"])
 
         # provide normalized rank counts if desired
         if norm:
-            npoints = len(fcst_stacked["npoints"])
             rank_counts = rank_counts / npoints
 
-        return rank_counts
+        # The histogram carries a bin dimension which the score storage array cannot
+        # hold (it only has sample/forecast_step/channel/metric/ens). Following the
+        # same convention as the PSD and Q-Q metrics, the full histogram is stored in
+        # the attributes for JSON serialization and a scalar summary is returned.
+        bin_dim = next((d for d in rank_counts.dims if d not in rank.dims), None)
+        if bin_dim is None:
+            return rank_counts
+
+        rank_freq = rank_counts if norm else rank_counts / npoints
+        n_bins = rank_counts.sizes[bin_dim]
+
+        # Reliability index (Delle Monache et al., 2006): summed absolute deviation of
+        # the observed rank frequencies from the uniform frequency 1/(M+1) of a
+        # perfectly calibrated ensemble. 0 means a perfectly flat rank histogram.
+        reliability_index = np.abs(rank_freq - 1.0 / n_bins).sum(dim=bin_dim)
+
+        attrs = {
+            "rank_bins": np.asarray(rank_counts[bin_dim].values).tolist(),
+            "normalized": bool(norm),
+            "n_points": int(npoints),
+        }
+        # Only serialize the histogram itself when it is small enough to be a useful
+        # JSON payload. On the score-map path the spatial dimension survives, which
+        # would otherwise produce a nested list with one histogram per grid point.
+        if rank_freq.size <= _RANK_HISTOGRAM_MAX_ATTR_SIZE:
+            attrs["rank_counts"] = np.asarray(rank_freq.values).tolist()
+            attrs["rank_counts_dims"] = list(rank_freq.dims)
+        else:
+            _logger.debug(
+                f"Rank histogram with {rank_freq.size} entries exceeds the attribute "
+                f"limit of {_RANK_HISTOGRAM_MAX_ATTR_SIZE}; storing only the scalar "
+                "reliability index."
+            )
+        reliability_index.attrs.update(attrs)
+
+        return reliability_index
 
     def calc_rank_histogram_xskillscore(self, p: xr.DataArray, gt: xr.DataArray) -> xr.DataArray:
         """

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -265,8 +265,8 @@ class Scores:
             f = self.det_metrics_dict[score_name]
             _logger.debug(f"Using deterministic metric: {score_name}")
         elif score_name in self.prob_metrics_dict.keys():
-            assert self.ens_dim in data.prediction.dims, (
-                f"Probablistic score {score_name} chosen, but ensemble dimension {self.ens_dim} "
+            assert self._ens_dim in data.prediction.dims, (
+                f"Probablistic score {score_name} chosen, but ensemble dimension {self._ens_dim} "
                 "not found in prediction data. Skipping score calculation."
             )
             return None

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -16,7 +16,7 @@ import pandas as pd
 import xarray as xr
 from scipy.spatial import cKDTree
 
-from weathergen.evaluate.scores.score_utils import to_list
+from weathergen.evaluate.scores.score_utils import calc_latitude_weights, to_list
 
 # from common.io import MockIO
 
@@ -76,11 +76,14 @@ class VerifiedData:
     prediction_next: xr.DataArray | None
     ground_truth_next: xr.DataArray | None
     climatology: xr.DataArray | None
+    latitude_weights: xr.DataArray | None = None
 
     def __post_init__(self):
         # Perform checks on initialization
         self._validate_dimensions()
         self._validate_broadcastability()
+        if self.latitude_weights is None:
+            object.__setattr__(self, "latitude_weights", self._compute_latitude_weights())
 
     # TODO: add checks for prediction_next, ground_truth_next, climatology
     def _validate_dimensions(self):
@@ -98,6 +101,12 @@ class VerifiedData:
             xr.broadcast(self.prediction, self.ground_truth)
         except ValueError as e:
             raise ValueError(f"Forecast and truth are not broadcastable: {e}") from e
+
+    def _compute_latitude_weights(self) -> xr.DataArray | None:
+        found = [c for c in ("lat", "latitude", "rlat", "clat") if c in self.prediction.coords]
+        if not found:
+            return None
+        return calc_latitude_weights(self.prediction, lat_coord_name=found[0])
 
 
 def get_score(
@@ -311,6 +320,22 @@ class Scores:
             if an in kwargs:
                 args[an] = kwargs[an]
 
+        # Inject latitude weights if requested via parameters.
+        # Config example: {rmse: {latitude_weighting: true}}
+        # Weights are pre-computed on VerifiedData construction; None if no lat coord found.
+        if "latitude_weighting" in parameters:
+            parameters = dict(parameters)  # don't mutate caller's dict
+            use_lat_weights = parameters.pop("latitude_weighting")
+            if use_lat_weights and "latitude_weights" in inspect.getfullargspec(f).args:
+                if data.latitude_weights is not None:
+                    parameters["latitude_weights"] = data.latitude_weights
+                else:
+                    _logger.warning(
+                        "Latitude weighting was requested for score '%s', but no latitude "
+                        "coordinate was found. Proceeding without weighting.",
+                        score_name,
+                    )
+
         if group_by_coord is not None and self._validate_groupby_coord(data, group_by_coord):
             # Apply groupby to all DataArrays in args
             grouped_args = {
@@ -429,6 +454,10 @@ class Scores:
             Averaged data
         """
         return data.mean(dim=self._agg_dims)
+
+    def _weighted_mean(self, data: xr.DataArray, weights: xr.DataArray) -> xr.DataArray:
+        _, w = xr.broadcast(data, weights)
+        return (data * w).mean(dim=self._agg_dims) / w.mean(dim=self._agg_dims)
 
     def get_2x2_event_counts(
         self,
@@ -650,7 +679,12 @@ class Scores:
 
         return l2
 
-    def calc_mae(self, p: xr.DataArray, gt: xr.DataArray) -> xr.DataArray:
+    def calc_mae(
+        self,
+        p: xr.DataArray,
+        gt: xr.DataArray,
+        latitude_weights: xr.DataArray | None = None,
+    ) -> xr.DataArray:
         """
         Calculate mean absolute error (MAE) of forecast data w.r.t. reference data.
 
@@ -660,6 +694,9 @@ class Scores:
             Forecast data array
         gt: xr.DataArray
             Ground truth data array
+        latitude_weights: xr.DataArray | None
+            Optional latitude weights for area-weighted averaging.
+            If None, unweighted mean is used.
         """
         if self._agg_dims is None:
             raise ValueError(
@@ -667,9 +704,17 @@ class Scores:
                 "(agg_dims=None)."
             )
 
-        return self._mean(np.abs(p - gt))
+        mae = np.abs(p - gt)
+        if latitude_weights is not None:
+            return self._weighted_mean(mae, latitude_weights)
+        return self._mean(mae)
 
-    def calc_mse(self, p: xr.DataArray, gt: xr.DataArray) -> xr.DataArray:
+    def calc_mse(
+        self,
+        p: xr.DataArray,
+        gt: xr.DataArray,
+        latitude_weights: xr.DataArray | None = None,
+    ) -> xr.DataArray:
         """
         Calculate mean squared error (MSE) of forecast data w.r.t. reference data.
 
@@ -679,6 +724,9 @@ class Scores:
             Forecast data array
         gt: xr.DataArray
             Ground truth data array
+        latitude_weights: xr.DataArray | None
+            Optional latitude weights for area-weighted averaging.
+            If provided, the MSE will be weighted by these values.
         Returns
         -------
         xr.DataArray
@@ -690,17 +738,30 @@ class Scores:
                 "(agg_dims=None)."
             )
 
-        return self._mean(np.square(p - gt))
+        mse = np.square(p - gt)
 
-    def calc_rmse(self, p: xr.DataArray, gt: xr.DataArray) -> xr.DataArray:
+        if latitude_weights is not None:
+            return self._weighted_mean(mse, latitude_weights)
+        return self._mean(mse)
+
+    def calc_rmse(
+        self,
+        p: xr.DataArray,
+        gt: xr.DataArray,
+        latitude_weights: xr.DataArray | None = None,
+    ) -> xr.DataArray:
         """
         Calculate root mean squared error (RMSE) of forecast data w.r.t. reference data
+
         Parameters
         ----------
         p: xr.DataArray
             Forecast data array
         gt: xr.DataArray
             Ground truth data array
+        latitude_weights: xr.DataArray | None
+            Optional latitude weights for area-weighted averaging.
+            If provided, the RMSE will be weighted by these values.
         Returns
         -------
         xr.DataArray
@@ -713,7 +774,7 @@ class Scores:
                 "(agg_dims=None)."
             )
 
-        rmse = np.sqrt(self.calc_mse(p, gt))
+        rmse = np.sqrt(self.calc_mse(p, gt, latitude_weights=latitude_weights))
 
         return rmse
 
@@ -982,6 +1043,7 @@ class Scores:
         p: xr.DataArray,
         gt: xr.DataArray,
         c: xr.DataArray,
+        latitude_weights: xr.DataArray | None = None,
     ) -> xr.DataArray:
         """
         Calculate anomaly correlation coefficient (ACC).
@@ -998,6 +1060,9 @@ class Scores:
             Ground truth data array
         c: xr.DataArray
             Climatological mean data array, which is used to calculate anomalies
+        latitude_weights: xr.DataArray | None
+            Optional latitude weights for area-weighted summation.
+            If None, unweighted sums are used.
 
         Returns
         -------
@@ -1014,10 +1079,15 @@ class Scores:
         # Calculate anomalies
         fcst_ano, obs_ano = p - c, gt - c
 
-        # Calculate ACC over spatial dimensions (no grouping)
-        acc = (fcst_ano * obs_ano).sum(self._agg_dims) / np.sqrt(
-            (fcst_ano**2).sum(self._agg_dims) * (obs_ano**2).sum(self._agg_dims)
-        )
+        if latitude_weights is not None:
+            _, w = xr.broadcast(fcst_ano, latitude_weights)
+            acc = (w * fcst_ano * obs_ano).sum(self._agg_dims) / np.sqrt(
+                (w * fcst_ano**2).sum(self._agg_dims) * (w * obs_ano**2).sum(self._agg_dims)
+            )
+        else:
+            acc = (fcst_ano * obs_ano).sum(self._agg_dims) / np.sqrt(
+                (fcst_ano**2).sum(self._agg_dims) * (obs_ano**2).sum(self._agg_dims)
+            )
 
         return acc
 
@@ -1155,7 +1225,12 @@ class Scores:
 
         return (1.0 - rps_fcst / rps_clim).where(rps_clim != 0, np.nan)
 
-    def calc_bias(self, p: xr.DataArray, gt: xr.DataArray) -> xr.DataArray:
+    def calc_bias(
+        self,
+        p: xr.DataArray,
+        gt: xr.DataArray,
+        latitude_weights: xr.DataArray | None = None,
+    ) -> xr.DataArray:
         """
         Calculate mean bias of forecast data w.r.t. reference data
 
@@ -1165,14 +1240,18 @@ class Scores:
             Forecast data array
         gt: xr.DataArray
             Ground truth data array
+        latitude_weights: xr.DataArray | None
+            Optional latitude weights for area-weighted averaging.
+            If None, unweighted mean is used.
         Returns
         -------
         xr.DataArray
             Mean bias
         """
-        bias = self._mean(p - gt)
-
-        return bias
+        bias = p - gt
+        if latitude_weights is not None:
+            return self._weighted_mean(bias, latitude_weights)
+        return self._mean(bias)
 
     def calc_psnr(
         self,
@@ -1385,26 +1464,53 @@ class Scores:
 
     ### Probablistic scores
 
-    def calc_spread(self, p: xr.DataArray, **kwargs) -> xr.DataArray:
+    def calc_spread(
+        self,
+        p: xr.DataArray,
+        latitude_weights: xr.DataArray | None = None,
+        adjusted: bool = True,
+        **kwargs,
+    ) -> xr.DataArray:
         """
-        Calculate the spread of the forecast ensemble
+        Calculate the spread of the forecast ensemble.
+
         Parameters
         ----------
         p: xr.DataArray
             Forecast data array with ensemble dimension
+        latitude_weights: xr.DataArray | None
+            Optional latitude weights for area-weighted averaging.
+        adjusted: bool
+            If True (default), use the unbiased (``ddof=1``) ensemble variance following
+            the GenCast convention (Price et al., https://arxiv.org/pdf/2312.15796, Eq. A.6).
+            The finite-ensemble inflation factor ``sqrt((M + 1) / M)`` is applied in the
+            spread-skill ratio (see ``calc_ssr``), not here.
+            If False, use the biased (``ddof=0``) variance.
 
         Returns
         -------
         xr.DataArray
             Spread of the forecast ensemble
         """
-        ens_std = p.std(dim=self._ens_dim)
+        ddof = 1 if adjusted else 0
+        ens_var = p.var(dim=self._ens_dim, ddof=ddof)
 
-        return self._mean(np.sqrt(ens_std**2))
+        if latitude_weights is not None:
+            var_mean = self._weighted_mean(ens_var, latitude_weights)
+        else:
+            var_mean = self._mean(ens_var)
 
-    def calc_ssr(self, p: xr.DataArray, gt: xr.DataArray) -> xr.DataArray:
+        return np.sqrt(var_mean)
+
+    def calc_ssr(
+        self,
+        p: xr.DataArray,
+        gt: xr.DataArray,
+        latitude_weights: xr.DataArray | None = None,
+        adjusted: bool = True,
+    ) -> xr.DataArray:
         """
-        Calculate the Spread-Skill Ratio (SSR) of the forecast ensemble data w.r.t. reference data
+        Calculate the Spread-Skill Ratio (SSR) of the forecast ensemble data w.r.t. reference data.
 
         Parameters
         ----------
@@ -1412,14 +1518,29 @@ class Scores:
             Forecast data array with ensemble dimension
         gt: xr.DataArray
             Ground truth data array
+        latitude_weights: xr.DataArray | None
+            Optional latitude weights for area-weighted averaging, applied to both spread and RMSE
+            components. Can be computed via ``calc_latitude_weights`` or by passing
+            ``latitude_weighting=True`` in the ``parameters`` dict of ``get_score``.
+            Default is None.
+        adjusted: bool
+            If True (default), apply the ensemble-size correction ``sqrt((M + 1) / M)`` following
+            GenCast (Price et al., https://arxiv.org/pdf/2312.15796, Eq. A.9) and use the unbiased
+            (``ddof=1``) spread. A perfectly calibrated ensemble of size M then yields SSR = 1.
+            If False, use the biased spread with no correction.
+
         Returns
         -------
         xr.DataArray
             Spread-Skill Ratio (SSR)
         """
-        ssr = self.calc_spread(p) / self.calc_rmse(p, gt)  # spread/rmse
-
-        return ssr
+        ens_mean = p.mean(dim=self._ens_dim)
+        spread = self.calc_spread(p, latitude_weights=latitude_weights, adjusted=adjusted)
+        rmse = self.calc_rmse(ens_mean, gt, latitude_weights=latitude_weights)
+        if adjusted:
+            ens_size = p.sizes[self._ens_dim]
+            return np.sqrt((ens_size + 1) / ens_size) * spread / rmse
+        return spread / rmse
 
     def calc_crps(
         self,

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -265,12 +265,12 @@ class Scores:
             f = self.det_metrics_dict[score_name]
             _logger.debug(f"Using deterministic metric: {score_name}")
         elif score_name in self.prob_metrics_dict.keys():
-            assert self.ens_dim in data.prediction.dims, (
-                f"Probablistic score {score_name} chosen, but ensemble dimension {self.ens_dim} "
+            assert self._ens_dim in data.prediction.dims, (
+                f"Probablistic score {score_name} chosen, but ensemble dimension {self._ens_dim} "
                 "not found in prediction data. Skipping score calculation."
             )
-            return None
             f = self.prob_metrics_dict[score_name]
+            _logger.debug(f"Using probabilistic metric: {score_name}")
         else:
             raise ValueError(
                 f"Unknown score chosen. Supported scores: {
@@ -1666,8 +1666,10 @@ class Scores:
                     * noise_fac
                 )
         # preserve the other coordinates
+        # keep the dims alongside the values: after the histogram reduction we must drop
+        # any coord whose dimension no longer exists (npoints -> rank_bin).
         preserved_coords = {
-            c: obs_stacked[c].values
+            c: (obs_stacked[c].dims, obs_stacked[c].values)
             for c in obs_stacked.coords
             if all(dim not in {self._ens_dim, "npoints"} for dim in obs_stacked[c].dims)
         }
@@ -1684,11 +1686,17 @@ class Scores:
         )
 
         # Reattach preserved coordinates by broadcasting
-        for coord_name, coord_values in preserved_coords.items():
+        for coord_name, (coord_dims, coord_values) in preserved_coords.items():
             # Only keep unique values along npoints if necessary
             if coord_name in rank_counts.coords:
                 continue
-            rank_counts = rank_counts.assign_coords({coord_name: coord_values})
+            # The histogram collapses npoints into rank_bin, so coordinates carried on
+            # dimensions that no longer exist (e.g. init_times) cannot be attached.
+            if not set(coord_dims).issubset(set(rank_counts.dims)):
+                continue
+            rank_counts = rank_counts.assign_coords(
+                {coord_name: (coord_dims, coord_values) if coord_dims else coord_values}
+            )
 
         # provide normalized rank counts if desired
         if norm:

--- a/packages/evaluate/src/weathergen/evaluate/scores/score.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score.py
@@ -22,6 +22,9 @@ from weathergen.evaluate.scores.score_utils import calc_latitude_weights, to_lis
 
 _logger = logging.getLogger(__name__)
 
+# Upper bound on the number of rank-histogram entries serialized into score attributes.
+_RANK_HISTOGRAM_MAX_ATTR_SIZE = 100_000
+
 try:
     import xskillscore
     from xhistogram.xarray import histogram
@@ -213,6 +216,8 @@ class Scores:
             "crps": self.calc_crps,
             "rank_histogram": self.calc_rank_histogram,
             "spread": self.calc_spread,
+            # RMSE of the ensemble-mean field; complements the per-member "rmse" above
+            "rmse_ens_mean": self.calc_rmse_ens_mean,
         }
 
     def get_score(
@@ -265,10 +270,13 @@ class Scores:
             f = self.det_metrics_dict[score_name]
             _logger.debug(f"Using deterministic metric: {score_name}")
         elif score_name in self.prob_metrics_dict.keys():
-            assert self._ens_dim in data.prediction.dims, (
-                f"Probablistic score {score_name} chosen, but ensemble dimension {self._ens_dim} "
-                "not found in prediction data. Skipping score calculation."
-            )
+            if self._ens_dim not in data.prediction.dims:
+                _logger.warning(
+                    f"Probabilistic score '{score_name}' chosen, but ensemble dimension "
+                    f"'{self._ens_dim}' not found in prediction data dims "
+                    f"{data.prediction.dims}. Skipping score calculation."
+                )
+                return None
             f = self.prob_metrics_dict[score_name]
             _logger.debug(f"Using probabilistic metric: {score_name}")
         else:
@@ -1542,6 +1550,40 @@ class Scores:
             return np.sqrt((ens_size + 1) / ens_size) * spread / rmse
         return spread / rmse
 
+    def calc_rmse_ens_mean(
+        self,
+        p: xr.DataArray,
+        gt: xr.DataArray,
+        latitude_weights: xr.DataArray | None = None,
+    ) -> xr.DataArray:
+        """
+        Calculate the RMSE of the ensemble mean forecast w.r.t. reference data.
+
+        The ensemble members are averaged into a single field *before* the RMSE is taken.
+        This is the skill component of the spread-skill ratio (see ``calc_ssr``) and is a
+        different quantity from the ``rmse`` score, which is evaluated per member and hence
+        does not benefit from the error cancellation of ensemble averaging. Both scores can
+        be requested side by side.
+
+        Parameters
+        ----------
+        p: xr.DataArray
+            Forecast data array with ensemble dimension
+        gt: xr.DataArray
+            Ground truth data array
+        latitude_weights: xr.DataArray | None
+            Optional latitude weights for area-weighted averaging.
+            If provided, the RMSE will be weighted by these values.
+
+        Returns
+        -------
+        xr.DataArray
+            Root mean squared error of the ensemble mean
+        """
+        ens_mean = p.mean(dim=self._ens_dim)
+
+        return self.calc_rmse(ens_mean, gt, latitude_weights=latitude_weights)
+
     def calc_crps(
         self,
         p: xr.DataArray,
@@ -1665,9 +1707,11 @@ class Scores:
                     da.random.random(size=fcst_stacked.shape, chunks=fcst_stacked.chunks)
                     * noise_fac
                 )
-        # preserve the other coordinates
-        # keep the dims alongside the values: after the histogram reduction we must drop
-        # any coord whose dimension no longer exists (npoints -> rank_bin).
+        # preserve the other coordinates, keeping their dimension names so that
+        # non-dimension coordinates (e.g. init_times on "sample") are reattached
+        # to the correct dimension instead of spawning a new one; after the histogram
+        # reduction we must drop any coord whose dimension no longer exists
+        # (npoints -> rank_bin).
         preserved_coords = {
             c: (obs_stacked[c].dims, obs_stacked[c].values)
             for c in obs_stacked.coords
@@ -1690,20 +1734,54 @@ class Scores:
             # Only keep unique values along npoints if necessary
             if coord_name in rank_counts.coords:
                 continue
-            # The histogram collapses npoints into rank_bin, so coordinates carried on
-            # dimensions that no longer exist (e.g. init_times) cannot be attached.
-            if not set(coord_dims).issubset(set(rank_counts.dims)):
+            # Coordinates whose dimensions did not survive the histogram cannot be
+            # reattached (e.g. dims consumed by the aggregation).
+            if not all(dim in rank_counts.dims for dim in coord_dims):
                 continue
-            rank_counts = rank_counts.assign_coords(
-                {coord_name: (coord_dims, coord_values) if coord_dims else coord_values}
-            )
+            rank_counts = rank_counts.assign_coords({coord_name: (coord_dims, coord_values)})
+
+        npoints = len(fcst_stacked["npoints"])
 
         # provide normalized rank counts if desired
         if norm:
-            npoints = len(fcst_stacked["npoints"])
             rank_counts = rank_counts / npoints
 
-        return rank_counts
+        # The histogram carries a bin dimension which the score storage array cannot
+        # hold (it only has sample/forecast_step/channel/metric/ens). Following the
+        # same convention as the PSD and Q-Q metrics, the full histogram is stored in
+        # the attributes for JSON serialization and a scalar summary is returned.
+        bin_dim = next((d for d in rank_counts.dims if d not in rank.dims), None)
+        if bin_dim is None:
+            return rank_counts
+
+        rank_freq = rank_counts if norm else rank_counts / npoints
+        n_bins = rank_counts.sizes[bin_dim]
+
+        # Reliability index (Delle Monache et al., 2006): summed absolute deviation of
+        # the observed rank frequencies from the uniform frequency 1/(M+1) of a
+        # perfectly calibrated ensemble. 0 means a perfectly flat rank histogram.
+        reliability_index = np.abs(rank_freq - 1.0 / n_bins).sum(dim=bin_dim)
+
+        attrs = {
+            "rank_bins": np.asarray(rank_counts[bin_dim].values).tolist(),
+            "normalized": bool(norm),
+            "n_points": int(npoints),
+        }
+        # Only serialize the histogram itself when it is small enough to be a useful
+        # JSON payload. On the score-map path the spatial dimension survives, which
+        # would otherwise produce a nested list with one histogram per grid point.
+        if rank_freq.size <= _RANK_HISTOGRAM_MAX_ATTR_SIZE:
+            attrs["rank_counts"] = np.asarray(rank_freq.values).tolist()
+            attrs["rank_counts_dims"] = list(rank_freq.dims)
+        else:
+            _logger.debug(
+                f"Rank histogram with {rank_freq.size} entries exceeds the attribute "
+                f"limit of {_RANK_HISTOGRAM_MAX_ATTR_SIZE}; storing only the scalar "
+                "reliability index."
+            )
+        reliability_index.attrs.update(attrs)
+
+        return reliability_index
 
     def calc_rank_histogram_xskillscore(self, p: xr.DataArray, gt: xr.DataArray) -> xr.DataArray:
         """

--- a/packages/evaluate/src/weathergen/evaluate/scores/score_utils.py
+++ b/packages/evaluate/src/weathergen/evaluate/scores/score_utils.py
@@ -12,6 +12,8 @@ import logging
 from typing import Any
 
 # Third-party
+import numpy as np
+import xarray as xr
 from omegaconf.listconfig import ListConfig
 
 _logger = logging.getLogger(__name__)
@@ -36,3 +38,56 @@ def to_list(obj: Any) -> list:
     elif not isinstance(obj, list):
         obj = [obj]
     return obj
+
+
+def calc_latitude_weights(
+    data: xr.DataArray,
+    min_value: float = 1e-3,
+    max_value: float = 1.0,
+    lat_coord_name: str | None = None,
+) -> xr.DataArray:
+    """
+    Calculate latitude weights based on cosine of latitude.
+
+    This function computes weights that account for the convergence of meridians
+    towards the poles, giving less weight to high-latitude grid points.
+
+    Parameters
+    ----------
+    data : xr.DataArray
+        Data array with latitude coordinate
+    min_value : float
+        Minimum weight value (at poles). Default is 1e-3.
+    max_value : float
+        Maximum weight value (at equator). Default is 1.0.
+    lat_coord_name : str | None
+        Name of the latitude coordinate. If None, will search for standard
+        latitude coordinate names ('lat', 'latitude', 'rlat', 'clat').
+
+    Returns
+    -------
+    xr.DataArray
+        Latitude weights as an xarray DataArray with the same dimensions as
+        the latitude coordinate in the input data.
+
+    Raises
+    ------
+    ValueError
+        If no latitude coordinate is found in the data.
+    """
+    if lat_coord_name is None:
+        lat_names = ["lat", "latitude", "rlat", "clat"]
+        found_coords = [name for name in lat_names if name in data.coords]
+        if not found_coords:
+            raise ValueError(
+                f"No latitude coordinate found. Please specify lat_coord_name. "
+                f"Searched for: {lat_names}"
+            )
+        lat_coord_name = found_coords[0]
+
+    lat_values = data.coords[lat_coord_name]
+    lat_radians = np.deg2rad(lat_values)
+    weights = (max_value - min_value) * np.cos(lat_radians) + min_value
+
+    lat_dim = lat_values.dims[0] if len(lat_values.dims) > 0 else lat_coord_name
+    return xr.DataArray(weights, coords={lat_coord_name: lat_values}, dims=[lat_dim])

--- a/scripts/inference_cw6a4szu_40step_array.sbatch
+++ b/scripts/inference_cw6a4szu_40step_array.sbatch
@@ -23,7 +23,7 @@
 #SBATCH --gres=gpu:1
 #SBATCH --time=01:30:00
 #SBATCH --array=0-15%16
-#SBATCH --job-name=wg-cw6-f40
+#SBATCH --job-name=wg-cw8-f40
 #SBATCH --output=logs/%x-%A_%a.out
 #SBATCH --error=logs/%x-%A_%a.err
 
@@ -31,7 +31,7 @@ set -euo pipefail
 
 FROM_RUN_ID=cw6a4szu
 MINI_EPOCH=8
-RUN_PREFIX=cw6
+RUN_PREFIX=cw8
 FORECAST_STEPS=40
 FORECAST_CHUNK_SIZE=4
 RESULTS_ROOT=/iopsstor/scratch/cscs/thunter/shared_work/results

--- a/scripts/inference_cw6a4szu_40step_array.sbatch
+++ b/scripts/inference_cw6a4szu_40step_array.sbatch
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# (C) Copyright 2025 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+# One independent 40-step inference sample per array task.
+# Task i writes run cw6iiiii for source window
+# 2023-06-01T12:00 + i * 12 hours. Each task uses a local test date range that
+# contains exactly that one valid input window.
+#
+# Submit from the WeatherGenerator root with:
+#   sbatch scripts/inference_cw6a4szu_40step_array.sbatch
+#
+# Santis normal is node-exclusive: every one-GPU array task reserves one full
+# four-GPU GH200 node. The shared partition can avoid this, but is limited to 1h.
+
+#SBATCH -A ch17
+#SBATCH --partition=normal
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=18
+#SBATCH --gres=gpu:1
+#SBATCH --time=01:30:00
+#SBATCH --array=0-15%16
+#SBATCH --job-name=wg-cw8-f40
+#SBATCH --output=logs/%x-%A_%a.out
+#SBATCH --error=logs/%x-%A_%a.err
+
+set -euo pipefail
+
+FROM_RUN_ID=cw6a4szu
+MINI_EPOCH=8
+RUN_PREFIX=cw8
+FORECAST_STEPS=40
+FORECAST_CHUNK_SIZE=4
+RESULTS_ROOT=/iopsstor/scratch/cscs/thunter/shared_work/results
+FIRST_SOURCE_START=2023-06-01T12:00
+SOURCE_CADENCE_HOURS=12
+INPUT_STEP_HOURS=6
+# 1 input step + 1 selected window + (40 forecast steps + offset 1) * 6 h.
+LOCAL_TEST_RANGE_HOURS=258
+
+task_id=${SLURM_ARRAY_TASK_ID:?This script must run as a Slurm array task.}
+run_id=$(printf '%s%05d' "$RUN_PREFIX" "$task_id")
+source_start=$(date -u --date="$FIRST_SOURCE_START UTC + $((task_id * SOURCE_CADENCE_HOURS)) hours" '+%Y-%m-%dT%H:%M')
+source_end=$(date -u --date="$source_start UTC + $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
+test_start=$(date -u --date="$source_start UTC - $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
+test_end=$(date -u --date="$test_start UTC + $LOCAL_TEST_RANGE_HOURS hours" '+%Y-%m-%dT%H:%M')
+expected_result="$RESULTS_ROOT/$run_id/validation_chkpt00000_rank0000.zip"
+
+if [[ -e "$expected_result" ]]; then
+    echo "Refusing to overwrite existing inference output: $expected_result" >&2
+    exit 2
+fi
+
+# The Santis virtual environment bundles Python 3.12 and CUDA 12.6 PyTorch.
+# Do not load the former Jupiter modules or force its Mellanox UCX device names.
+export OMP_NUM_THREADS="$SLURM_CPUS_PER_TASK"
+export MKL_NUM_THREADS="$SLURM_CPUS_PER_TASK"
+export OPENBLAS_NUM_THREADS="$SLURM_CPUS_PER_TASK"
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+
+# Slurm executes a spooled copy of this script, so BASH_SOURCE[0] points into
+# /var/spool/slurmd rather than this checkout. Submit from the repository root.
+weathergen_home=${SLURM_SUBMIT_DIR:?Submit this script from the WeatherGenerator root.}
+if [[ ! -f "$weathergen_home/.venv/bin/activate" ]]; then
+    echo "WeatherGenerator virtual environment not found: $weathergen_home/.venv" >&2
+    exit 2
+fi
+private_config="$(dirname "$weathergen_home")/WeatherGenerator-private/hpc/santis/config/paths.yml"
+if [[ ! -f "$private_config" ]]; then
+    echo "Missing Santis private config: $private_config" >&2
+    exit 2
+fi
+cd "$weathergen_home"
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+echo "run_id=$run_id source_interval=[$source_start, $source_end)"
+echo "test_interval=[$test_start, $test_end)"
+srun --ntasks=1 --cpus-per-task="$SLURM_CPUS_PER_TASK" \
+    python -u src/weathergen/run_train.py inference \
+    --from-run-id "$FROM_RUN_ID" \
+    --mini-epoch "$MINI_EPOCH" \
+    --run-id "$run_id" \
+    --private-config "$private_config" \
+    --options \
+        data_loading.num_workers=1 \
+        data_loading.persistent_workers=false \
+        test_config.samples_per_mini_epoch=1 \
+        test_config.shuffle=false \
+        test_config.start_date="$test_start" \
+        test_config.end_date="$test_end" \
+        test_config.output.num_samples=1 \
+        test_config.forecast.num_steps="$FORECAST_STEPS" \
+        test_config.forecast.chunk_size="$FORECAST_CHUNK_SIZE" \
+        test_config.compute_full_validation_loss=false
+
+test -s "$expected_result"

--- a/scripts/inference_cw6a4szu_40step_array.sbatch
+++ b/scripts/inference_cw6a4szu_40step_array.sbatch
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# (C) Copyright 2025 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+# One independent 40-step inference sample per array task.
+# Task i writes run cw6iiiii for source window
+# 2023-06-01T12:00 + i * 12 hours. Each task uses a local test date range that
+# contains exactly that one valid input window.
+#
+# Submit from the WeatherGenerator root with:
+#   sbatch scripts/inference_cw6a4szu_40step_array.sbatch
+#
+# Santis normal is node-exclusive: every one-GPU array task reserves one full
+# four-GPU GH200 node. The shared partition can avoid this, but is limited to 1h.
+
+#SBATCH -A ch17
+#SBATCH --partition=normal
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=18
+#SBATCH --gres=gpu:1
+#SBATCH --time=01:30:00
+#SBATCH --array=0-15%16
+#SBATCH --job-name=wg-cw6-f40
+#SBATCH --output=logs/%x-%A_%a.out
+#SBATCH --error=logs/%x-%A_%a.err
+
+set -euo pipefail
+
+FROM_RUN_ID=cw6a4szu
+MINI_EPOCH=8
+RUN_PREFIX=cw6
+FORECAST_STEPS=40
+FORECAST_CHUNK_SIZE=4
+RESULTS_ROOT=/iopsstor/scratch/cscs/thunter/shared_work/results
+FIRST_SOURCE_START=2023-06-01T12:00
+SOURCE_CADENCE_HOURS=12
+INPUT_STEP_HOURS=6
+# 1 input step + 1 selected window + (40 forecast steps + offset 1) * 6 h.
+LOCAL_TEST_RANGE_HOURS=258
+
+task_id=${SLURM_ARRAY_TASK_ID:?This script must run as a Slurm array task.}
+run_id=$(printf '%s%05d' "$RUN_PREFIX" "$task_id")
+source_start=$(date -u --date="$FIRST_SOURCE_START UTC + $((task_id * SOURCE_CADENCE_HOURS)) hours" '+%Y-%m-%dT%H:%M')
+source_end=$(date -u --date="$source_start UTC + $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
+test_start=$(date -u --date="$source_start UTC - $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
+test_end=$(date -u --date="$test_start UTC + $LOCAL_TEST_RANGE_HOURS hours" '+%Y-%m-%dT%H:%M')
+expected_result="$RESULTS_ROOT/$run_id/validation_chkpt00000_rank0000.zip"
+
+if [[ -e "$expected_result" ]]; then
+    echo "Refusing to overwrite existing inference output: $expected_result" >&2
+    exit 2
+fi
+
+# The Santis virtual environment bundles Python 3.12 and CUDA 12.6 PyTorch.
+# Do not load the former Jupiter modules or force its Mellanox UCX device names.
+export OMP_NUM_THREADS="$SLURM_CPUS_PER_TASK"
+export MKL_NUM_THREADS="$SLURM_CPUS_PER_TASK"
+export OPENBLAS_NUM_THREADS="$SLURM_CPUS_PER_TASK"
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+
+# Slurm executes a spooled copy of this script, so BASH_SOURCE[0] points into
+# /var/spool/slurmd rather than this checkout. Submit from the repository root.
+weathergen_home=${SLURM_SUBMIT_DIR:?Submit this script from the WeatherGenerator root.}
+if [[ ! -f "$weathergen_home/.venv/bin/activate" ]]; then
+    echo "WeatherGenerator virtual environment not found: $weathergen_home/.venv" >&2
+    exit 2
+fi
+private_config="$(dirname "$weathergen_home")/WeatherGenerator-private/hpc/santis/config/paths.yml"
+if [[ ! -f "$private_config" ]]; then
+    echo "Missing Santis private config: $private_config" >&2
+    exit 2
+fi
+cd "$weathergen_home"
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+echo "run_id=$run_id source_interval=[$source_start, $source_end)"
+echo "test_interval=[$test_start, $test_end)"
+srun --ntasks=1 --cpus-per-task="$SLURM_CPUS_PER_TASK" \
+    python -u src/weathergen/run_train.py inference \
+    --from-run-id "$FROM_RUN_ID" \
+    --mini-epoch "$MINI_EPOCH" \
+    --run-id "$run_id" \
+    --private-config "$private_config" \
+    --options \
+        data_loading.num_workers=1 \
+        data_loading.persistent_workers=false \
+        test_config.samples_per_mini_epoch=1 \
+        test_config.shuffle=false \
+        test_config.start_date="$test_start" \
+        test_config.end_date="$test_end" \
+        test_config.output.num_samples=1 \
+        test_config.forecast.num_steps="$FORECAST_STEPS" \
+        test_config.forecast.chunk_size="$FORECAST_CHUNK_SIZE" \
+        test_config.compute_full_validation_loss=false
+
+test -s "$expected_result"

--- a/scripts/inference_cw6a4szu_40step_array_ag.sbatch
+++ b/scripts/inference_cw6a4szu_40step_array_ag.sbatch
@@ -27,9 +27,9 @@
 #SBATCH --gpus-per-node=4
 #SBATCH --cpus-per-task=32
 #SBATCH --mem=0
-#SBATCH --time=06:00:00
+#SBATCH --time=02:00:00
 #SBATCH --array=0-15%16
-#SBATCH --job-name=wg-cw6-f40
+#SBATCH --job-name=wg-cw8-f40
 #SBATCH --output=logs/%x-%A_%a.out
 #SBATCH --error=logs/%x-%A_%a.err
 
@@ -37,7 +37,7 @@ set -euo pipefail
 
 FROM_RUN_ID=cw6a4szu
 MINI_EPOCH=8
-RUN_PREFIX=cw6
+RUN_PREFIX=cw8
 FORECAST_STEPS=40
 FORECAST_CHUNK_SIZE=1                 # value proven interactively on ag for this checkpoint
 FIRST_SOURCE_START=2023-06-01T12:00

--- a/scripts/inference_cw6a4szu_40step_array_ag.sbatch
+++ b/scripts/inference_cw6a4szu_40step_array_ag.sbatch
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# (C) Copyright 2025 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+# ag (GH200) twin of inference_cw6a4szu_40step_array_jupiter.sbatch: IDENTICAL
+# sampling/date logic, only the platform layer differs --
+#   * ECMWF ag account/qos instead of the JSC account/partition;
+#   * the self-contained aarch64 uv venv + three runtime exports instead of the
+#     module / UCX / MASTER_ADDR block;
+#   * torchrun for the 4-way single-node DDP instead of srun --ntasks=4;
+#   * this checkpoint is really cw6a4szu (the Jupiter file runs xq65fhca).
+#
+# Eight 40-step inference samples per array task. Task i writes run cw6iiiii for
+# the 8 source windows starting 2023-06-01T12:00 + i * 48 hours
+# (NUM_SAMPLES_PER_TASK * INPUT_STEP_HOURS), so tasks tile consecutive dates
+# without overlap.
+#
+# Submit from the WeatherGenerator root:
+#   sbatch scripts/inference_cw6a4szu_40step_array_ag.sbatch
+
+#SBATCH --qos=ng
+#SBATCH --account=ecwegen
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --gpus-per-node=4
+#SBATCH --cpus-per-task=32
+#SBATCH --mem=0
+#SBATCH --time=02:00:00
+#SBATCH --array=0-15%16
+#SBATCH --job-name=wg-cw8-f40
+#SBATCH --output=logs/%x-%A_%a.out
+#SBATCH --error=logs/%x-%A_%a.err
+
+set -euo pipefail
+
+FROM_RUN_ID=xq65fhca
+MINI_EPOCH=8
+RUN_PREFIX="${FROM_RUN_ID:0:4}"
+FORECAST_STEPS=40
+FORECAST_CHUNK_SIZE=1                 # value proven interactively on ag for this checkpoint
+FIRST_SOURCE_START=2023-06-01T12:00
+INPUT_STEP_HOURS=6
+NUM_SAMPLES_PER_TASK=8
+# 1 input step + 1 selected window + (40 forecast steps + offset 1) * 6 h,
+# widened by NUM_SAMPLES_PER_TASK windows so all 8 samples survive check_samples.
+LOCAL_TEST_RANGE_HOURS=258
+
+task_id=${SLURM_ARRAY_TASK_ID:?This script must run as a Slurm array task.}
+run_id=$(printf '%s%04d' "$RUN_PREFIX" "$task_id")
+# Advance each task by exactly its own NUM_SAMPLES_PER_TASK windows
+# (INPUT_STEP_HOURS each) so consecutive tasks tile without overlap or grid drift.
+source_start=$(date -u --date="$FIRST_SOURCE_START UTC + $((task_id * INPUT_STEP_HOURS * NUM_SAMPLES_PER_TASK)) hours" '+%Y-%m-%dT%H:%M')
+source_end=$(date -u --date="$source_start UTC + $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
+test_start=$(date -u --date="$source_start UTC - $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
+test_end=$(date -u --date="$test_start UTC + $((LOCAL_TEST_RANGE_HOURS + NUM_SAMPLES_PER_TASK * INPUT_STEP_HOURS)) hours" '+%Y-%m-%dT%H:%M')
+
+weathergen_home=${SLURM_SUBMIT_DIR:?Submit this script from the WeatherGenerator root.}
+RESULTS_ROOT="$weathergen_home/results"
+expected_result="$RESULTS_ROOT/$run_id/validation_chkpt00000_rank0000.zip"
+if [[ -e "$expected_result" ]]; then
+    echo "Refusing to overwrite existing inference output: $expected_result" >&2
+    exit 2
+fi
+if [[ ! -x "$weathergen_home/.venv/bin/torchrun" ]]; then
+    echo "WeatherGenerator venv not found: $weathergen_home/.venv" >&2
+    exit 2
+fi
+private_config="$(dirname "$weathergen_home")/WeatherGenerator-private/hpc/hpc2020/config/paths.yml"
+if [[ ! -f "$private_config" ]]; then
+    echo "Missing ag private config: $private_config" >&2
+    exit 2
+fi
+
+# ag (aarch64) runtime -- the three fixes from the N320 port: resolve the
+# checkpoint via the private config (platform-env.py has no ag rule), give
+# flash-attn its GLIBCXX (gcc/15.2.0), and de-fragment the allocator (the var
+# was renamed from PYTORCH_CUDA_ALLOC_CONF in torch 2.9).
+export WEATHERGEN_PRIVATE_CONF="$private_config"
+export LD_LIBRARY_PATH="/usr/local/apps/gcc/15.2.0/lib64:${LD_LIBRARY_PATH:-}"
+export PYTORCH_ALLOC_CONF=expandable_segments:True
+
+cd "$weathergen_home"
+echo "run_id=$run_id source_interval=[$source_start, $source_end)"
+echo "test_interval=[$test_start, $test_end)"
+.venv/bin/torchrun --nproc-per-node=4 \
+    src/weathergen/run_train.py inference \
+    --from-run-id "$FROM_RUN_ID" \
+    --mini-epoch "$MINI_EPOCH" \
+    --run-id "$run_id" \
+    --private-config "$private_config" \
+    --options \
+        data_loading.num_workers=0 \
+        data_loading.num_workers_validation=0 \
+        data_loading.persistent_workers=false \
+        test_config.samples_per_mini_epoch="$NUM_SAMPLES_PER_TASK" \
+        test_config.output.num_samples="$NUM_SAMPLES_PER_TASK" \
+        test_config.shuffle=false \
+        test_config.start_date="$test_start" \
+        test_config.end_date="$test_end" \
+        test_config.forecast.num_steps="$FORECAST_STEPS" \
+        test_config.forecast.chunk_size="$FORECAST_CHUNK_SIZE" \
+        test_config.compute_full_validation_loss=false \
+        test_config.skip_target_values=true
+
+test -s "$expected_result"

--- a/scripts/inference_cw6a4szu_40step_array_ag.sbatch
+++ b/scripts/inference_cw6a4szu_40step_array_ag.sbatch
@@ -35,9 +35,9 @@
 
 set -euo pipefail
 
-FROM_RUN_ID=cw6a4szu
+FROM_RUN_ID=xq65fhca
 MINI_EPOCH=8
-RUN_PREFIX=cw8
+RUN_PREFIX="${FROM_RUN_ID:0:4}"
 FORECAST_STEPS=40
 FORECAST_CHUNK_SIZE=1                 # value proven interactively on ag for this checkpoint
 FIRST_SOURCE_START=2023-06-01T12:00
@@ -48,7 +48,7 @@ NUM_SAMPLES_PER_TASK=8
 LOCAL_TEST_RANGE_HOURS=258
 
 task_id=${SLURM_ARRAY_TASK_ID:?This script must run as a Slurm array task.}
-run_id=$(printf '%s%05d' "$RUN_PREFIX" "$task_id")
+run_id=$(printf '%s%04d' "$RUN_PREFIX" "$task_id")
 # Advance each task by exactly its own NUM_SAMPLES_PER_TASK windows
 # (INPUT_STEP_HOURS each) so consecutive tasks tile without overlap or grid drift.
 source_start=$(date -u --date="$FIRST_SOURCE_START UTC + $((task_id * INPUT_STEP_HOURS * NUM_SAMPLES_PER_TASK)) hours" '+%Y-%m-%dT%H:%M')

--- a/scripts/inference_cw6a4szu_40step_array_ag.sbatch
+++ b/scripts/inference_cw6a4szu_40step_array_ag.sbatch
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# (C) Copyright 2025 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+# ag (GH200) twin of inference_cw6a4szu_40step_array_jupiter.sbatch: IDENTICAL
+# sampling/date logic, only the platform layer differs --
+#   * ECMWF ag account/qos instead of the JSC account/partition;
+#   * the self-contained aarch64 uv venv + three runtime exports instead of the
+#     module / UCX / MASTER_ADDR block;
+#   * torchrun for the 4-way single-node DDP instead of srun --ntasks=4;
+#   * this checkpoint is really cw6a4szu (the Jupiter file runs xq65fhca).
+#
+# Eight 40-step inference samples per array task. Task i writes run cw6iiiii for
+# the 8 source windows starting 2023-06-01T12:00 + i * 48 hours
+# (NUM_SAMPLES_PER_TASK * INPUT_STEP_HOURS), so tasks tile consecutive dates
+# without overlap.
+#
+# Submit from the WeatherGenerator root:
+#   sbatch scripts/inference_cw6a4szu_40step_array_ag.sbatch
+
+#SBATCH --qos=ng
+#SBATCH --account=ecwegen
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --gpus-per-node=4
+#SBATCH --cpus-per-task=32
+#SBATCH --mem=0
+#SBATCH --time=06:00:00
+#SBATCH --array=0-15%16
+#SBATCH --job-name=wg-cw6-f40
+#SBATCH --output=logs/%x-%A_%a.out
+#SBATCH --error=logs/%x-%A_%a.err
+
+set -euo pipefail
+
+FROM_RUN_ID=cw6a4szu
+MINI_EPOCH=8
+RUN_PREFIX=cw6
+FORECAST_STEPS=40
+FORECAST_CHUNK_SIZE=1                 # value proven interactively on ag for this checkpoint
+FIRST_SOURCE_START=2023-06-01T12:00
+INPUT_STEP_HOURS=6
+NUM_SAMPLES_PER_TASK=8
+# 1 input step + 1 selected window + (40 forecast steps + offset 1) * 6 h,
+# widened by NUM_SAMPLES_PER_TASK windows so all 8 samples survive check_samples.
+LOCAL_TEST_RANGE_HOURS=258
+
+task_id=${SLURM_ARRAY_TASK_ID:?This script must run as a Slurm array task.}
+run_id=$(printf '%s%05d' "$RUN_PREFIX" "$task_id")
+# Advance each task by exactly its own NUM_SAMPLES_PER_TASK windows
+# (INPUT_STEP_HOURS each) so consecutive tasks tile without overlap or grid drift.
+source_start=$(date -u --date="$FIRST_SOURCE_START UTC + $((task_id * INPUT_STEP_HOURS * NUM_SAMPLES_PER_TASK)) hours" '+%Y-%m-%dT%H:%M')
+source_end=$(date -u --date="$source_start UTC + $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
+test_start=$(date -u --date="$source_start UTC - $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
+test_end=$(date -u --date="$test_start UTC + $((LOCAL_TEST_RANGE_HOURS + NUM_SAMPLES_PER_TASK * INPUT_STEP_HOURS)) hours" '+%Y-%m-%dT%H:%M')
+
+weathergen_home=${SLURM_SUBMIT_DIR:?Submit this script from the WeatherGenerator root.}
+RESULTS_ROOT="$weathergen_home/results"
+expected_result="$RESULTS_ROOT/$run_id/validation_chkpt00000_rank0000.zip"
+if [[ -e "$expected_result" ]]; then
+    echo "Refusing to overwrite existing inference output: $expected_result" >&2
+    exit 2
+fi
+if [[ ! -x "$weathergen_home/.venv/bin/torchrun" ]]; then
+    echo "WeatherGenerator venv not found: $weathergen_home/.venv" >&2
+    exit 2
+fi
+private_config="$(dirname "$weathergen_home")/WeatherGenerator-private/hpc/hpc2020/config/paths.yml"
+if [[ ! -f "$private_config" ]]; then
+    echo "Missing ag private config: $private_config" >&2
+    exit 2
+fi
+
+# ag (aarch64) runtime -- the three fixes from the N320 port: resolve the
+# checkpoint via the private config (platform-env.py has no ag rule), give
+# flash-attn its GLIBCXX (gcc/15.2.0), and de-fragment the allocator (the var
+# was renamed from PYTORCH_CUDA_ALLOC_CONF in torch 2.9).
+export WEATHERGEN_PRIVATE_CONF="$private_config"
+export LD_LIBRARY_PATH="/usr/local/apps/gcc/15.2.0/lib64:${LD_LIBRARY_PATH:-}"
+export PYTORCH_ALLOC_CONF=expandable_segments:True
+
+cd "$weathergen_home"
+echo "run_id=$run_id source_interval=[$source_start, $source_end)"
+echo "test_interval=[$test_start, $test_end)"
+.venv/bin/torchrun --nproc-per-node=4 \
+    src/weathergen/run_train.py inference \
+    --from-run-id "$FROM_RUN_ID" \
+    --mini-epoch "$MINI_EPOCH" \
+    --run-id "$run_id" \
+    --private-config "$private_config" \
+    --options \
+        data_loading.num_workers=0 \
+        data_loading.num_workers_validation=0 \
+        data_loading.persistent_workers=false \
+        test_config.samples_per_mini_epoch="$NUM_SAMPLES_PER_TASK" \
+        test_config.output.num_samples="$NUM_SAMPLES_PER_TASK" \
+        test_config.shuffle=false \
+        test_config.start_date="$test_start" \
+        test_config.end_date="$test_end" \
+        test_config.forecast.num_steps="$FORECAST_STEPS" \
+        test_config.forecast.chunk_size="$FORECAST_CHUNK_SIZE" \
+        test_config.compute_full_validation_loss=false \
+        test_config.skip_target_values=true
+
+test -s "$expected_result"

--- a/scripts/inference_cw6a4szu_40step_array_jupiter.sbatch
+++ b/scripts/inference_cw6a4szu_40step_array_jupiter.sbatch
@@ -16,14 +16,14 @@
 # four-GPU GH200 node. The shared partition can avoid this, but is limited to 1h.
 
 #SBATCH --account=e-ext-2025e01-128
-#SBATCH --time=01:00:00
+#SBATCH --time=01:30:00
 #SBATCH --nodes=1
 #SBATCH --ntasks=4
 #SBATCH --cpus-per-task=72
 #SBATCH --gres=gpu:4
 #SBATCH --chdir=.
 #SBATCH --partition=booster
-#SBATCH --array=0-15%16
+#SBATCH --array=0-92%92
 #SBATCH --output=logs/weathergen-%x.%j.out
 #SBATCH --error=logs/weathergen-%x.%j.err
 
@@ -66,13 +66,13 @@ fi
 echo "MASTER_ADDR: $MASTER_ADDR"
 set -euo pipefail
 
-FROM_RUN_ID=xq65fhca
-MINI_EPOCH=14
-RUN_PREFIX=xq65
+FROM_RUN_ID=cw6a4szu
+MINI_EPOCH=8
+RUN_PREFIX="${FROM_RUN_ID:0:4}"
 FORECAST_STEPS=40
 FORECAST_CHUNK_SIZE=1
 RESULTS_ROOT=/e/scratch/weatherai/shared_work/results
-FIRST_SOURCE_START=2023-06-01T12:00
+FIRST_SOURCE_START=2023-06-01T00:00
 INPUT_STEP_HOURS=6
 NUM_SAMPLES_PER_TASK=8
 # SOURCE_CADENCE_HOURS=12
@@ -80,8 +80,8 @@ NUM_SAMPLES_PER_TASK=8
 LOCAL_TEST_RANGE_HOURS=258
 
 task_id=${SLURM_ARRAY_TASK_ID:?This script must run as a Slurm array task.}
-run_id=$(printf '%s%05d' "$RUN_PREFIX" "$task_id")
-source_start=$(date -u --date="$FIRST_SOURCE_START UTC + $((task_id * 4 * NUM_SAMPLES_PER_TASK)) hours" '+%Y-%m-%dT%H:%M')
+run_id=$(printf '%s%04d' "$RUN_PREFIX" "$task_id")
+source_start=$(date -u --date="$FIRST_SOURCE_START UTC + $((task_id * INPUT_STEP_HOURS * NUM_SAMPLES_PER_TASK)) hours" '+%Y-%m-%dT%H:%M')
 source_end=$(date -u --date="$source_start UTC + $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
 test_start=$(date -u --date="$source_start UTC - $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
 test_end=$(date -u --date="$test_start UTC + $((LOCAL_TEST_RANGE_HOURS + NUM_SAMPLES_PER_TASK * INPUT_STEP_HOURS)) hours" '+%Y-%m-%dT%H:%M')

--- a/scripts/inference_cw6a4szu_40step_array_jupiter.sbatch
+++ b/scripts/inference_cw6a4szu_40step_array_jupiter.sbatch
@@ -1,0 +1,140 @@
+#!/bin/bash -x
+# (C) Copyright 2025 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+# One independent 40-step inference sample per array task.
+# Task i writes run cw6iiiii for source window
+# 2023-06-01T12:00 + i * 12 hours. Each task uses a local test date range that
+# contains exactly that one valid input window.
+#
+# Submit from the WeatherGenerator root with:
+#   sbatch scripts/inference_cw6a4szu_40step_array.sbatch
+#
+# Jupiter normal is node-exclusive: every one-GPU array task reserves one full
+# four-GPU GH200 node. The shared partition can avoid this, but is limited to 1h.
+
+#SBATCH --account=e-ext-2025e01-128
+#SBATCH --time=01:30:00
+#SBATCH --nodes=1
+#SBATCH --ntasks=4
+#SBATCH --cpus-per-task=72
+#SBATCH --gres=gpu:4
+#SBATCH --chdir=.
+#SBATCH --partition=booster
+#SBATCH --array=0-92%92
+#SBATCH --output=logs/weathergen-%x.%j.out
+#SBATCH --error=logs/weathergen-%x.%j.err
+
+echo "shell $SHELL"
+if [ -f "$HOME/.local/bin/env" ]; then
+    . "$HOME/.local/bin/env"
+fi
+
+. "$HOME/.bashrc"
+echo "LMOD_ROOT $LMOD_ROOT"
+# Does not get loaded automatically. Unsure why.
+. $LMOD_ROOT/lmod/init/bash
+# Load basic modules from software stack
+module --force purge
+module load Stages/2025
+
+module load GCC/13.3.0
+module load GCCcore/.13.3.0
+
+ml git/2.45.1
+ml Python/3.12.3
+
+
+# set some environment variables to ensure that GPU-devices are used properly
+export UCX_TLS="^cma"
+export UCX_NET_DEVICES=mlx5_0:1,mlx5_1:1,mlx5_4:1,mlx5_5:1
+
+export SRUN_CPUS_PER_TASK=${SLURM_CPUS_PER_TASK}
+export CUDA_VISIBLE_DEVICES=0,1,2,3
+
+# so processes know who to talk to
+export MASTER_ADDR="$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)"
+if [ "$SYSTEMNAME" = juwelsbooster ] \
+       || [ "$SYSTEMNAME" = juwels ] \
+       || [ "$SYSTEMNAME" = jurecadc ] \
+       || [ "$SYSTEMNAME" = jusuf ]; then
+    # Allow communication over InfiniBand cells on JSC machines.
+    MASTER_ADDR="$MASTER_ADDR"i
+fi
+echo "MASTER_ADDR: $MASTER_ADDR"
+set -euo pipefail
+
+FROM_RUN_ID=cw6a4szu
+MINI_EPOCH=8
+RUN_PREFIX="${FROM_RUN_ID:0:4}"
+FORECAST_STEPS=40
+FORECAST_CHUNK_SIZE=1
+RESULTS_ROOT=/e/scratch/weatherai/shared_work/results
+FIRST_SOURCE_START=2023-06-01T00:00
+INPUT_STEP_HOURS=6
+NUM_SAMPLES_PER_TASK=8
+# SOURCE_CADENCE_HOURS=12
+# 1 input step + 1 selected window + (40 forecast steps + offset 1) * 6 h.
+LOCAL_TEST_RANGE_HOURS=258
+
+task_id=${SLURM_ARRAY_TASK_ID:?This script must run as a Slurm array task.}
+run_id=$(printf '%s%04d' "$RUN_PREFIX" "$task_id")
+source_start=$(date -u --date="$FIRST_SOURCE_START UTC + $((task_id * INPUT_STEP_HOURS * NUM_SAMPLES_PER_TASK)) hours" '+%Y-%m-%dT%H:%M')
+source_end=$(date -u --date="$source_start UTC + $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
+test_start=$(date -u --date="$source_start UTC - $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
+test_end=$(date -u --date="$test_start UTC + $((LOCAL_TEST_RANGE_HOURS + NUM_SAMPLES_PER_TASK * INPUT_STEP_HOURS)) hours" '+%Y-%m-%dT%H:%M')
+expected_result="$RESULTS_ROOT/$run_id/validation_chkpt00000_rank0000.zip"
+
+if [[ -e "$expected_result" ]]; then
+    echo "Refusing to overwrite existing inference output: $expected_result" >&2
+    exit 2
+fi
+
+# The Santis virtual environment bundles Python 3.12 and CUDA 12.6 PyTorch.
+# Do not load the former Jupiter modules or force its Mellanox UCX device names.
+export OMP_NUM_THREADS="$SLURM_CPUS_PER_TASK"
+export MKL_NUM_THREADS="$SLURM_CPUS_PER_TASK"
+export OPENBLAS_NUM_THREADS="$SLURM_CPUS_PER_TASK"
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+
+# Slurm executes a spooled copy of this script, so BASH_SOURCE[0] points into
+# /var/spool/slurmd rather than this checkout. Submit from the repository root.
+weathergen_home=${SLURM_SUBMIT_DIR:?Submit this script from the WeatherGenerator root.}
+if [[ ! -f "$weathergen_home/.venv/bin/activate" ]]; then
+    echo "WeatherGenerator virtual environment not found: $weathergen_home/.venv" >&2
+    exit 2
+fi
+private_config="$(dirname "$weathergen_home")/WeatherGenerator-private/hpc/jupiter/config/paths.yml"
+if [[ ! -f "$private_config" ]]; then
+    echo "Missing Jupiter private config: $private_config" >&2
+    exit 2
+fi
+cd "$weathergen_home"
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+echo "run_id=$run_id source_interval=[$source_start, $source_end)"
+echo "test_interval=[$test_start, $test_end)"
+srun --ntasks=4 --cpus-per-task="$SLURM_CPUS_PER_TASK" \
+    python -u src/weathergen/run_train.py inference \
+    --from-run-id "$FROM_RUN_ID" \
+    --mini-epoch "$MINI_EPOCH" \
+    --run-id "$run_id" \
+    --private-config "$private_config" \
+    --options \
+        data_loading.num_workers=0 \
+        data_loading.num_workers_validation=0 \
+        data_loading.persistent_workers=false \
+        test_config.samples_per_mini_epoch="$NUM_SAMPLES_PER_TASK" \
+        test_config.output.num_samples="$NUM_SAMPLES_PER_TASK" \
+        test_config.shuffle=false \
+        test_config.start_date="$test_start" \
+        test_config.end_date="$test_end" \
+        test_config.forecast.num_steps="$FORECAST_STEPS" \
+        test_config.forecast.chunk_size="$FORECAST_CHUNK_SIZE" \
+        test_config.compute_full_validation_loss=false \
+        test_config.skip_target_values=true
+
+test -s "$expected_result"

--- a/scripts/inference_cw6a4szu_40step_array_jupiter.sbatch
+++ b/scripts/inference_cw6a4szu_40step_array_jupiter.sbatch
@@ -1,0 +1,140 @@
+#!/bin/bash -x
+# (C) Copyright 2025 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+# One independent 40-step inference sample per array task.
+# Task i writes run cw6iiiii for source window
+# 2023-06-01T12:00 + i * 12 hours. Each task uses a local test date range that
+# contains exactly that one valid input window.
+#
+# Submit from the WeatherGenerator root with:
+#   sbatch scripts/inference_cw6a4szu_40step_array.sbatch
+#
+# Jupiter normal is node-exclusive: every one-GPU array task reserves one full
+# four-GPU GH200 node. The shared partition can avoid this, but is limited to 1h.
+
+#SBATCH --account=e-ext-2025e01-128
+#SBATCH --time=01:00:00
+#SBATCH --nodes=1
+#SBATCH --ntasks=4
+#SBATCH --cpus-per-task=72
+#SBATCH --gres=gpu:4
+#SBATCH --chdir=.
+#SBATCH --partition=booster
+#SBATCH --array=0-15%16
+#SBATCH --output=logs/weathergen-%x.%j.out
+#SBATCH --error=logs/weathergen-%x.%j.err
+
+echo "shell $SHELL"
+if [ -f "$HOME/.local/bin/env" ]; then
+    . "$HOME/.local/bin/env"
+fi
+
+. "$HOME/.bashrc"
+echo "LMOD_ROOT $LMOD_ROOT"
+# Does not get loaded automatically. Unsure why.
+. $LMOD_ROOT/lmod/init/bash
+# Load basic modules from software stack
+module --force purge
+module load Stages/2025
+
+module load GCC/13.3.0
+module load GCCcore/.13.3.0
+
+ml git/2.45.1
+ml Python/3.12.3
+
+
+# set some environment variables to ensure that GPU-devices are used properly
+export UCX_TLS="^cma"
+export UCX_NET_DEVICES=mlx5_0:1,mlx5_1:1,mlx5_4:1,mlx5_5:1
+
+export SRUN_CPUS_PER_TASK=${SLURM_CPUS_PER_TASK}
+export CUDA_VISIBLE_DEVICES=0,1,2,3
+
+# so processes know who to talk to
+export MASTER_ADDR="$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)"
+if [ "$SYSTEMNAME" = juwelsbooster ] \
+       || [ "$SYSTEMNAME" = juwels ] \
+       || [ "$SYSTEMNAME" = jurecadc ] \
+       || [ "$SYSTEMNAME" = jusuf ]; then
+    # Allow communication over InfiniBand cells on JSC machines.
+    MASTER_ADDR="$MASTER_ADDR"i
+fi
+echo "MASTER_ADDR: $MASTER_ADDR"
+set -euo pipefail
+
+FROM_RUN_ID=xq65fhca
+MINI_EPOCH=16
+RUN_PREFIX=xq65
+FORECAST_STEPS=40
+FORECAST_CHUNK_SIZE=1
+RESULTS_ROOT=/e/scratch/weatherai/shared_work/results
+FIRST_SOURCE_START=2023-06-01T12:00
+INPUT_STEP_HOURS=6
+NUM_SAMPLES_PER_TASK=8
+# SOURCE_CADENCE_HOURS=12
+# 1 input step + 1 selected window + (40 forecast steps + offset 1) * 6 h.
+LOCAL_TEST_RANGE_HOURS=258
+
+task_id=${SLURM_ARRAY_TASK_ID:?This script must run as a Slurm array task.}
+run_id=$(printf '%s%05d' "$RUN_PREFIX" "$task_id")
+source_start=$(date -u --date="$FIRST_SOURCE_START UTC + $((task_id * NUM_SAMPLES_PER_TASK)) hours" '+%Y-%m-%dT%H:%M')
+source_end=$(date -u --date="$source_start UTC + $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
+test_start=$(date -u --date="$source_start UTC - $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
+test_end=$(date -u --date="$test_start UTC + $LOCAL_TEST_RANGE_HOURS hours" '+%Y-%m-%dT%H:%M')
+expected_result="$RESULTS_ROOT/$run_id/validation_chkpt00000_rank0000.zip"
+
+if [[ -e "$expected_result" ]]; then
+    echo "Refusing to overwrite existing inference output: $expected_result" >&2
+    exit 2
+fi
+
+# The Santis virtual environment bundles Python 3.12 and CUDA 12.6 PyTorch.
+# Do not load the former Jupiter modules or force its Mellanox UCX device names.
+export OMP_NUM_THREADS="$SLURM_CPUS_PER_TASK"
+export MKL_NUM_THREADS="$SLURM_CPUS_PER_TASK"
+export OPENBLAS_NUM_THREADS="$SLURM_CPUS_PER_TASK"
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+
+# Slurm executes a spooled copy of this script, so BASH_SOURCE[0] points into
+# /var/spool/slurmd rather than this checkout. Submit from the repository root.
+weathergen_home=${SLURM_SUBMIT_DIR:?Submit this script from the WeatherGenerator root.}
+if [[ ! -f "$weathergen_home/.venv/bin/activate" ]]; then
+    echo "WeatherGenerator virtual environment not found: $weathergen_home/.venv" >&2
+    exit 2
+fi
+private_config="$(dirname "$weathergen_home")/WeatherGenerator-private/hpc/jupiter/config/paths.yml"
+if [[ ! -f "$private_config" ]]; then
+    echo "Missing Jupiter private config: $private_config" >&2
+    exit 2
+fi
+cd "$weathergen_home"
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+echo "run_id=$run_id source_interval=[$source_start, $source_end)"
+echo "test_interval=[$test_start, $test_end)"
+srun --ntasks=4 --cpus-per-task="$SLURM_CPUS_PER_TASK" \
+    python -u src/weathergen/run_train.py inference \
+    --from-run-id "$FROM_RUN_ID" \
+    --mini-epoch "$MINI_EPOCH" \
+    --run-id "$run_id" \
+    --private-config "$private_config" \
+    --options \
+        data_loading.num_workers=0 \
+        data_loading.num_workers_validation=0 \
+        data_loading.persistent_workers=false \
+        test_config.samples_per_mini_epoch="$NUM_SAMPLES_PER_TASK" \
+        test_config.shuffle=false \
+        test_config.start_date="$test_start" \
+        test_config.end_date="$test_end" \
+        test_config.output.num_samples="$NUM_SAMPLES_PER_TASK" \
+        test_config.forecast.num_steps="$FORECAST_STEPS" \
+        test_config.forecast.chunk_size="$FORECAST_CHUNK_SIZE" \
+        test_config.compute_full_validation_loss=false \
+        test_config.skip_target_values=true
+
+test -s "$expected_result"

--- a/scripts/inference_cw6a4szu_40step_array_jupiter.sbatch
+++ b/scripts/inference_cw6a4szu_40step_array_jupiter.sbatch
@@ -67,7 +67,7 @@ echo "MASTER_ADDR: $MASTER_ADDR"
 set -euo pipefail
 
 FROM_RUN_ID=xq65fhca
-MINI_EPOCH=16
+MINI_EPOCH=14
 RUN_PREFIX=xq65
 FORECAST_STEPS=40
 FORECAST_CHUNK_SIZE=1
@@ -81,10 +81,10 @@ LOCAL_TEST_RANGE_HOURS=258
 
 task_id=${SLURM_ARRAY_TASK_ID:?This script must run as a Slurm array task.}
 run_id=$(printf '%s%05d' "$RUN_PREFIX" "$task_id")
-source_start=$(date -u --date="$FIRST_SOURCE_START UTC + $((task_id * NUM_SAMPLES_PER_TASK)) hours" '+%Y-%m-%dT%H:%M')
+source_start=$(date -u --date="$FIRST_SOURCE_START UTC + $((task_id * 4 * NUM_SAMPLES_PER_TASK)) hours" '+%Y-%m-%dT%H:%M')
 source_end=$(date -u --date="$source_start UTC + $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
 test_start=$(date -u --date="$source_start UTC - $INPUT_STEP_HOURS hours" '+%Y-%m-%dT%H:%M')
-test_end=$(date -u --date="$test_start UTC + $LOCAL_TEST_RANGE_HOURS hours" '+%Y-%m-%dT%H:%M')
+test_end=$(date -u --date="$test_start UTC + $((LOCAL_TEST_RANGE_HOURS + NUM_SAMPLES_PER_TASK * INPUT_STEP_HOURS)) hours" '+%Y-%m-%dT%H:%M')
 expected_result="$RESULTS_ROOT/$run_id/validation_chkpt00000_rank0000.zip"
 
 if [[ -e "$expected_result" ]]; then
@@ -128,10 +128,10 @@ srun --ntasks=4 --cpus-per-task="$SLURM_CPUS_PER_TASK" \
         data_loading.num_workers_validation=0 \
         data_loading.persistent_workers=false \
         test_config.samples_per_mini_epoch="$NUM_SAMPLES_PER_TASK" \
+        test_config.output.num_samples="$NUM_SAMPLES_PER_TASK" \
         test_config.shuffle=false \
         test_config.start_date="$test_start" \
         test_config.end_date="$test_end" \
-        test_config.output.num_samples="$NUM_SAMPLES_PER_TASK" \
         test_config.forecast.num_steps="$FORECAST_STEPS" \
         test_config.forecast.chunk_size="$FORECAST_CHUNK_SIZE" \
         test_config.compute_full_validation_loss=false \

--- a/src/weathergen/datasets/batch.py
+++ b/src/weathergen/datasets/batch.py
@@ -79,12 +79,14 @@ class Sample:
         include_target_coords: bool = True,
         include_target_tokens: bool = True,
     ) -> None:
-        for key in self.meta_info.keys():
-            self.meta_info[key].mask = (
-                self.meta_info[key].mask.to(device, non_blocking=True)
-                if self.meta_info[key].mask is not None
-                else None
-            )
+        for info in self.meta_info.values():
+            # meta_info is keyed by stream name, but the diffusion rollout also stashes
+            # model-side state here (LATENT_CONDITIONING_TOKENS, a bare tensor already on
+            # device). Chunked inference re-enters to_device after the model has run, so
+            # only touch entries that actually carry stream metadata.
+            mask = getattr(info, "mask", None)
+            if mask is not None:
+                info.mask = mask.to(device, non_blocking=True)
 
         for key, val in self.streams_data.items():
             if val is not None:
@@ -378,8 +380,15 @@ class ModelBatch:
 
         return self
 
-    def to_device_for_chunked_inference(self, device, loss_steps: list[int]):
-        """Move source inputs and the targets required for the final chunk loss."""
+    def to_device_for_chunked_inference(
+        self, device, loss_steps: list[int], include_target_source: bool = False
+    ):
+        """Move source inputs and the targets required for the final chunk loss.
+
+        include_target_source additionally moves the target samples' source view, which
+        target/aux calculators that encode the target window (SSL teachers, the diffusion
+        latent target) need. It is left on the host otherwise.
+        """
         self.source_samples.to_device(
             device,
             target_steps=[],
@@ -389,7 +398,7 @@ class ModelBatch:
         self.target_samples.to_device(
             device,
             target_steps=loss_steps,
-            include_source=False,
+            include_source=include_target_source,
             include_target_coords=False,
         )
         self.device = device

--- a/src/weathergen/datasets/batch.py
+++ b/src/weathergen/datasets/batch.py
@@ -381,20 +381,27 @@ class ModelBatch:
         return self
 
     def to_device_for_chunked_inference(
-        self, device, loss_steps: list[int], include_target_source: bool = False
+        self, device, loss_steps: list[int], include_target_source: bool = False,
+        include_source_tokens: bool = True,
     ):
         """Move source inputs and the targets required for the final chunk loss.
 
         include_target_source additionally moves the target samples' source view, which
         target/aux calculators that encode the target window (SSL teachers, the diffusion
         latent target) need. It is left on the host otherwise.
+
+        include_source_tokens controls whether encoder input tokens are moved now.
+        Pass False to defer the load to just before the first encoder forward (via
+        load_source_tokens_to_device), which avoids occupying GPU HBM during the
+        DataLoader prefetch window and any pre-forward target computation.
         """
-        self.source_samples.to_device(
-            device,
-            target_steps=[],
-            include_target_coords=False,
-            include_target_tokens=False,
-        )
+        if include_source_tokens:
+            self.source_samples.to_device(
+                device,
+                target_steps=[],
+                include_target_coords=False,
+                include_target_tokens=False,
+            )
         self.target_samples.to_device(
             device,
             target_steps=loss_steps,
@@ -419,6 +426,67 @@ class ModelBatch:
     def clear_output_chunk_coordinates(self, target_steps: list[int]) -> None:
         """Release decoder coordinates after output for a forecast chunk was written."""
         self.source_samples.clear_target_coordinates(target_steps)
+
+    def offload_source_tokens(self) -> None:
+        """Move source observation tokens back to CPU after the encoder has run.
+
+        Source tokens (source_tokens_cells / source_tokens_lens / source_idxs_embed)
+        are only needed for the encoder, which runs on the *first* rollout chunk.
+        Offloading them immediately after that frees several hundred MiB of GPU memory
+        that would otherwise be held for the entire multi-step decoder rollout.
+        Only target coordinates (loaded per-chunk via to_device_for_output_chunk) and
+        the latent conditioning token stored in meta_info are needed on-device
+        for continuation chunks.
+        """
+        self.source_samples.to_device(
+            "cpu",
+            target_steps=[],
+            include_target_coords=False,
+            include_target_tokens=False,
+        )
+
+    def load_source_tokens_to_device(self, device) -> None:
+        """Move source observation tokens (encoder input) to *device*.
+
+        Counterpart to offload_source_tokens(). Calling this immediately before the
+        first chunk's encoder forward (instead of eagerly in to_device_for_chunked_inference)
+        keeps the tokens off the GPU during the DataLoader prefetch window and any
+        pre-forward target computation, reducing peak GPU HBM usage by the token
+        footprint (~456 MiB for this model).
+        """
+        self.source_samples.to_device(
+            device,
+            target_steps=[],
+            include_target_coords=False,
+            include_target_tokens=False,
+        )
+
+    def drop_source_observations(self) -> None:
+        """Drop all source observation data from memory after the encoder has run.
+
+        After offload_source_tokens() has moved the encoder inputs back to CPU, the
+        Python objects holding them (source_tokens_cells / source_tokens_lens /
+        source_idxs_embed / source_raw) are still alive in RAM.  This method nulls
+        them out so Python's reference-counting can reclaim the memory immediately.
+
+        ``target_coords`` and ``target_coords_lens`` inside each StreamData are
+        intentionally preserved: the decoder loads them per-chunk via
+        ``to_device_for_output_chunk`` and clears them via
+        ``clear_output_chunk_coordinates`` after each write.
+
+        ``meta_info`` is also preserved: the diffusion rollout stashes
+        ``LATENT_CONDITIONING_TOKENS`` there for continuation chunks.
+        """
+        for sample in self.source_samples.get_samples():
+            for stream_data in sample.streams_data.values():
+                if stream_data is None:
+                    continue
+                n_src = len(stream_data.source_tokens_cells)
+                stream_data.source_tokens_cells = [None] * n_src
+                stream_data.source_tokens_lens = [None] * n_src
+                stream_data.source_idxs_embed = [None] * n_src
+                stream_data.source_idxs_embed_pe = [None] * n_src
+                stream_data.source_raw = [None] * n_src
 
     def add_source_stream(
         self,

--- a/src/weathergen/datasets/data_reader_base.py
+++ b/src/weathergen/datasets/data_reader_base.py
@@ -389,7 +389,7 @@ class DataReaderBase(metaclass=ABCMeta):
 
         return rdata
 
-    def get_target(self, idx: TIndex) -> ReaderData:
+    def get_target(self, idx: TIndex, coords_geoinfos_only: bool = False) -> ReaderData:
         """
         Get target data for idx
 
@@ -397,13 +397,33 @@ class DataReaderBase(metaclass=ABCMeta):
         ----------
         idx : int
             Index of temporal window
+        coords_geoinfos_only : bool
+            If True, only coords, geoinfos and datetimes are provided; data has zero
+            width (shape (num_datapoints, 0)) so no target values are read or stored.
 
         Returns
         -------
         target data (coords, geoinfos, data, datetimes)
         """
 
+        if coords_geoinfos_only:
+            return self._get_coords_geoinfos_only(idx, self.target_idx)
+
         rdata = self._get(idx, self.target_idx)
+
+        return rdata
+
+    def _get_coords_geoinfos_only(self, idx: TIndex, channels_idx: list[int]) -> ReaderData:
+        """
+        Get data for window with zero-width data values (coords, geoinfos, datetimes only)
+
+        Default implementation performs a full read and drops the values; subclasses can
+        override to avoid reading the values altogether. The width-0 slice keeps the row
+        count so all row-alignment invariants (is_empty, shuffle, tokenization) hold.
+        """
+
+        rdata = self._get(idx, channels_idx)
+        rdata.data = rdata.data[:, :0]
 
         return rdata
 

--- a/src/weathergen/datasets/data_reader_obs.py
+++ b/src/weathergen/datasets/data_reader_obs.py
@@ -243,7 +243,7 @@ class DataReaderObs(DataReaderBase):
         self.properties["vars"] = self.data.attrs["vars"]
 
     @override
-    def _get(self, idx: int, channels_idx: list[int]) -> ReaderData:
+    def _get(self, idx: int, channels_idx: list[int], read_values: bool = True) -> ReaderData:
         """
         Get data for window
 
@@ -253,6 +253,8 @@ class DataReaderObs(DataReaderBase):
             Index of temporal window
         channels_idx : np.array
             Selection of channels
+        read_values : bool
+            If False, skip reading the data values; data has zero width.
 
         Returns
         -------
@@ -279,7 +281,11 @@ class DataReaderObs(DataReaderBase):
             else np.zeros((coords.shape[0], 0), np.float32)
         )
 
-        data = self.data.oindex[start_row:end_row, channels_idx]
+        data = (
+            self.data.oindex[start_row:end_row, channels_idx]
+            if read_values
+            else np.zeros((coords.shape[0], 0), np.float32)
+        )
         datetimes = self.dt[start_row:end_row][:, 0]
 
         # indices_start, indices_end above work with [t_start, t_end] and violate
@@ -297,5 +303,14 @@ class DataReaderObs(DataReaderBase):
 
         dtr = self.time_window_handler.window(idx)
         check_reader_data(rdata, dtr)
+
+        return rdata
+
+    @override
+    def _get_coords_geoinfos_only(self, idx: int, channels_idx: list[int]) -> ReaderData:
+        # skip the data-columns read entirely; coords/geoinfos/datetimes read as usual
+        rdata = self._get(idx, channels_idx, read_values=False)
+        # the empty-window early returns in _get yield (0, len(channels_idx)) data
+        rdata.data = rdata.data[:, :0]
 
         return rdata

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -8,6 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 import dataclasses
+import functools
 import logging
 import pathlib
 from collections.abc import Sequence
@@ -35,7 +36,11 @@ from weathergen.datasets.utils import (
 from weathergen.readers_extra.registry import get_extra_reader
 from weathergen.train.utils import Stage, get_batch_size_from_config
 from weathergen.utils.distributed import is_root
-from weathergen.utils.utils import is_stream_diagnostic, is_stream_forcing
+from weathergen.utils.utils import (
+    is_stream_diagnostic,
+    is_stream_forcing,
+    is_stream_reconstructed,
+)
 
 type AnyDataReader = DataReaderBase | DataReaderAnemoi | DataReaderObs
 type StreamName = str
@@ -50,11 +55,15 @@ FORECAST_DEFAULTS = {
 }
 
 
-def collect_datasources(stream_datasets: list, idx: int, type: str, rng) -> IOReaderData:
+def collect_datasources(
+    stream_datasets: list, idx: int, type: str, rng, coords_geoinfos_only: bool = False
+) -> IOReaderData:
     """
     Utility function to collect all sources / targets from streams list
 
     rng and num_subset are used to drop data
+
+    coords_geoinfos_only (targets only): skip reading the data values; data has zero width
     """
 
     rdatas = []
@@ -68,7 +77,9 @@ def collect_datasources(stream_datasets: list, idx: int, type: str, rng) -> IORe
             normalize_channels = ds.normalize_source_channels
             shuffle = ds.stream_info.get("shuffle_source", False)
         elif type == "target":
-            get_reader_data = ds.get_target
+            get_reader_data = functools.partial(
+                ds.get_target, coords_geoinfos_only=coords_geoinfos_only
+            )
             normalize_channels = ds.normalize_target_channels
             num_subset = ds.stream_info.get("max_num_targets", -1)
             shuffle = ds.stream_info.get("shuffle_target", False)
@@ -79,7 +90,9 @@ def collect_datasources(stream_datasets: list, idx: int, type: str, rng) -> IORe
         rdata = (
             get_reader_data(idx).shuffle(rng, shuffle, num_subset).remove_nan_coords_and_geoinfos()
         )
-        rdata.data = normalize_channels(rdata.data)
+        if not coords_geoinfos_only:
+            # zero-width data has nothing to normalize (and would fail the channel-count check)
+            rdata.data = normalize_channels(rdata.data)
         rdata.geoinfos = ds.normalize_geoinfos(rdata.geoinfos)
         rdatas += [rdata]
 
@@ -136,6 +149,17 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                     "Ignoring teacher_time_offset (setting to 0)."
                 )
             self.teacher_time_offset = 0
+
+        # skip_target_values: inference-only; do not read/store target values for physically
+        # reconstructed streams, only coords/geoinfos/datetimes (data gets zero width)
+        self.skip_target_values = bool(mode_cfg.get("skip_target_values", False))
+        if self.skip_target_values and (
+            "student_teacher" in training_mode or "latent_loss" in training_mode
+        ):
+            raise ValueError(
+                "skip_target_values is incompatible with student_teacher/latent_loss modes: "
+                "target values are needed to build the teacher's network input."
+            )
 
         self.batch_size = get_batch_size_from_config(mode_cfg)
         self.num_workers = cf.data_loading.num_workers
@@ -618,11 +642,23 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
         # target data: collect for all forecast steps
         output_data = []
         if not is_stream_forcing(stream_ds[0].stream_info, self._stage):
+            # skip target values only for physically reconstructed streams; forcing streams
+            # are skipped entirely above and reconstruct:false (teacher-only) streams keep
+            # their values
+            coords_geoinfos_only = self.skip_target_values and is_stream_reconstructed(
+                stream_ds[0].stream_info, self._stage
+            )
             num_output_steps = self._get_output_length(num_forecast_steps)
             for timestep_idx in range(self.output_offset, num_output_steps):
                 step_forecast_dt = base_idx + (self.time_step * timestep_idx) // self.step_timedelta
 
-                rdata = collect_datasources(stream_ds, step_forecast_dt, "target", self.rng)
+                rdata = collect_datasources(
+                    stream_ds,
+                    step_forecast_dt,
+                    "target",
+                    self.rng,
+                    coords_geoinfos_only=coords_geoinfos_only,
+                )
 
                 if rdata.is_empty():
                     # work around for https://github.com/pytorch/pytorch/issues/158719
@@ -632,7 +668,10 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                         self.healpix_level,
                         time_win.start,
                         stream_ds[0].get_geoinfo_size(),
-                        len(stream_ds[0].mean[stream_ds[0].target_idx]),
+                        # zero width to match the coords_geoinfos_only data downstream
+                        0
+                        if coords_geoinfos_only
+                        else len(stream_ds[0].mean[stream_ds[0].target_idx]),
                     )
                     rdata.is_spoof = True
 

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -959,9 +959,9 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
         worker_info = torch.utils.data.get_worker_info()
 
         if worker_info is None:
-            # assert self.world_size == 1, self.world_size
-            iter_start = 0
-            iter_end = len(self)
+            # no loader workers: each DDP rank still takes its own disjoint slice
+            iter_start = local_start
+            iter_end = local_end
 
         else:
             # ensure the rng seed is fully unique across workers and mini_epochs

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -35,7 +35,7 @@ from weathergen.datasets.utils import (
 from weathergen.readers_extra.registry import get_extra_reader
 from weathergen.train.utils import Stage, get_batch_size_from_config
 from weathergen.utils.distributed import is_root
-from weathergen.utils.utils import is_stream_diagnostic
+from weathergen.utils.utils import is_stream_diagnostic, is_stream_forcing
 
 type AnyDataReader = DataReaderBase | DataReaderAnemoi | DataReaderObs
 type StreamName = str
@@ -478,6 +478,11 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
 
         """
 
+        # output_data is empty for forcing streams (_get_data_windows skips them);
+        # nothing to add in that case.
+        if not output_data:
+            return stream_data
+
         # collect for all forecast steps
         num_output_steps = self._get_output_length(num_forecast_steps)
         for step, timestep_idx in enumerate(range(self.output_offset, num_output_steps)):
@@ -590,46 +595,48 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
 
         # source data: iterate overall input steps
         input_data = []
-        for idx in range(base_idx - num_steps_input_max + 1, base_idx + 1):
-            # TODO: check that we are not out of bounds when we go back in time
+        if not is_stream_diagnostic(stream_ds[0].stream_info, self._stage):
+            for idx in range(base_idx - num_steps_input_max + 1, base_idx + 1):
+                # TODO: check that we are not out of bounds when we go back in time
 
-            rdata = collect_datasources(stream_ds, idx, "source", self.rng)
+                rdata = collect_datasources(stream_ds, idx, "source", self.rng)
 
-            if rdata.is_empty():
-                # work around for https://github.com/pytorch/pytorch/issues/158719
-                # create non-empty mean data instead of empty tensor
-                time_win = self.time_window_handler.window(idx)
-                rdata = spoof(
-                    self.healpix_level,
-                    time_win.start,
-                    stream_ds[0].get_geoinfo_size(),
-                    len(stream_ds[0].mean[stream_ds[0].source_idx]),
-                )
-                rdata.is_spoof = True
+                if rdata.is_empty():
+                    # work around for https://github.com/pytorch/pytorch/issues/158719
+                    # create non-empty mean data instead of empty tensor
+                    time_win = self.time_window_handler.window(idx)
+                    rdata = spoof(
+                        self.healpix_level,
+                        time_win.start,
+                        stream_ds[0].get_geoinfo_size(),
+                        len(stream_ds[0].mean[stream_ds[0].source_idx]),
+                    )
+                    rdata.is_spoof = True
 
-            input_data += [rdata]
+                input_data += [rdata]
 
         # target data: collect for all forecast steps
         output_data = []
-        num_output_steps = self._get_output_length(num_forecast_steps)
-        for timestep_idx in range(self.output_offset, num_output_steps):
-            step_forecast_dt = base_idx + (self.time_step * timestep_idx) // self.step_timedelta
+        if not is_stream_forcing(stream_ds[0].stream_info, self._stage):
+            num_output_steps = self._get_output_length(num_forecast_steps)
+            for timestep_idx in range(self.output_offset, num_output_steps):
+                step_forecast_dt = base_idx + (self.time_step * timestep_idx) // self.step_timedelta
 
-            rdata = collect_datasources(stream_ds, step_forecast_dt, "target", self.rng)
+                rdata = collect_datasources(stream_ds, step_forecast_dt, "target", self.rng)
 
-            if rdata.is_empty():
-                # work around for https://github.com/pytorch/pytorch/issues/158719
-                # create non-empty mean data instead of empty tensor
-                time_win = self.time_window_handler.window(step_forecast_dt)
-                rdata = spoof(
-                    self.healpix_level,
-                    time_win.start,
-                    stream_ds[0].get_geoinfo_size(),
-                    len(stream_ds[0].mean[stream_ds[0].target_idx]),
-                )
-                rdata.is_spoof = True
+                if rdata.is_empty():
+                    # work around for https://github.com/pytorch/pytorch/issues/158719
+                    # create non-empty mean data instead of empty tensor
+                    time_win = self.time_window_handler.window(step_forecast_dt)
+                    rdata = spoof(
+                        self.healpix_level,
+                        time_win.start,
+                        stream_ds[0].get_geoinfo_size(),
+                        len(stream_ds[0].mean[stream_ds[0].target_idx]),
+                    )
+                    rdata.is_spoof = True
 
-            output_data += [rdata]
+                output_data += [rdata]
 
         return (input_data, output_data)
 

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -8,6 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 import dataclasses
+import functools
 import logging
 import pathlib
 from collections.abc import Sequence
@@ -35,7 +36,11 @@ from weathergen.datasets.utils import (
 from weathergen.readers_extra.registry import get_extra_reader
 from weathergen.train.utils import Stage, get_batch_size_from_config
 from weathergen.utils.distributed import is_root
-from weathergen.utils.utils import is_stream_diagnostic, is_stream_forcing
+from weathergen.utils.utils import (
+    is_stream_diagnostic,
+    is_stream_forcing,
+    is_stream_reconstructed,
+)
 
 type AnyDataReader = DataReaderBase | DataReaderAnemoi | DataReaderObs
 type StreamName = str
@@ -50,11 +55,15 @@ FORECAST_DEFAULTS = {
 }
 
 
-def collect_datasources(stream_datasets: list, idx: int, type: str, rng) -> IOReaderData:
+def collect_datasources(
+    stream_datasets: list, idx: int, type: str, rng, coords_geoinfos_only: bool = False
+) -> IOReaderData:
     """
     Utility function to collect all sources / targets from streams list
 
     rng and num_subset are used to drop data
+
+    coords_geoinfos_only (targets only): skip reading the data values; data has zero width
     """
 
     rdatas = []
@@ -68,7 +77,9 @@ def collect_datasources(stream_datasets: list, idx: int, type: str, rng) -> IORe
             normalize_channels = ds.normalize_source_channels
             shuffle = ds.stream_info.get("shuffle_source", False)
         elif type == "target":
-            get_reader_data = ds.get_target
+            get_reader_data = functools.partial(
+                ds.get_target, coords_geoinfos_only=coords_geoinfos_only
+            )
             normalize_channels = ds.normalize_target_channels
             num_subset = ds.stream_info.get("max_num_targets", -1)
             shuffle = ds.stream_info.get("shuffle_target", False)
@@ -79,7 +90,9 @@ def collect_datasources(stream_datasets: list, idx: int, type: str, rng) -> IORe
         rdata = (
             get_reader_data(idx).shuffle(rng, shuffle, num_subset).remove_nan_coords_and_geoinfos()
         )
-        rdata.data = normalize_channels(rdata.data)
+        if not coords_geoinfos_only:
+            # zero-width data has nothing to normalize (and would fail the channel-count check)
+            rdata.data = normalize_channels(rdata.data)
         rdata.geoinfos = ds.normalize_geoinfos(rdata.geoinfos)
         rdatas += [rdata]
 
@@ -136,6 +149,17 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                     "Ignoring teacher_time_offset (setting to 0)."
                 )
             self.teacher_time_offset = 0
+
+        # skip_target_values: inference-only; do not read/store target values for physically
+        # reconstructed streams, only coords/geoinfos/datetimes (data gets zero width)
+        self.skip_target_values = bool(mode_cfg.get("skip_target_values", False))
+        if self.skip_target_values and (
+            "student_teacher" in training_mode or "latent_loss" in training_mode
+        ):
+            raise ValueError(
+                "skip_target_values is incompatible with student_teacher/latent_loss modes: "
+                "target values are needed to build the teacher's network input."
+            )
 
         self.batch_size = get_batch_size_from_config(mode_cfg)
         self.num_workers = cf.data_loading.num_workers
@@ -271,8 +295,9 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                         raise FileNotFoundError(msg)
 
                     # The same dataset can exist on different locations in the filesystem,
-                    # so we need to choose here.
-                    filename = filenames[0]
+                    # so pick the first data_paths root that actually has it (the check
+                    # above guarantees at least one exists).
+                    filename = next(f for f in filenames if f.exists())
 
                 ds_type = stream_info["type"]
                 if is_root():
@@ -586,7 +611,14 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
 
         return stream_data
 
-    def _get_data_windows(self, base_idx, num_forecast_steps, num_steps_input_max, stream_ds):
+    def _get_data_windows(
+        self,
+        base_idx,
+        num_forecast_steps,
+        num_steps_input_max,
+        stream_ds,
+        coords_geoinfos_only: bool = False,
+    ):
         """
         Collect all data needed for current stream to potentially amortize costs by
         generating multiple samples
@@ -622,7 +654,13 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
             for timestep_idx in range(self.output_offset, num_output_steps):
                 step_forecast_dt = base_idx + (self.time_step * timestep_idx) // self.step_timedelta
 
-                rdata = collect_datasources(stream_ds, step_forecast_dt, "target", self.rng)
+                rdata = collect_datasources(
+                    stream_ds,
+                    step_forecast_dt,
+                    "target",
+                    self.rng,
+                    coords_geoinfos_only=coords_geoinfos_only,
+                )
 
                 if rdata.is_empty():
                     # work around for https://github.com/pytorch/pytorch/issues/158719
@@ -632,7 +670,10 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                         self.healpix_level,
                         time_win.start,
                         stream_ds[0].get_geoinfo_size(),
-                        len(stream_ds[0].mean[stream_ds[0].target_idx]),
+                        # zero width to match the coords_geoinfos_only data downstream
+                        0
+                        if coords_geoinfos_only
+                        else len(stream_ds[0].mean[stream_ds[0].target_idx]),
                     )
                     rdata.is_spoof = True
 
@@ -919,9 +960,9 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
         worker_info = torch.utils.data.get_worker_info()
 
         if worker_info is None:
-            # assert self.world_size == 1, self.world_size
-            iter_start = 0
-            iter_end = len(self)
+            # no loader workers: each DDP rank still takes its own disjoint slice
+            iter_start = local_start
+            iter_end = local_end
 
         else:
             # ensure the rng seed is fully unique across workers and mini_epochs

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -295,8 +295,9 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                         raise FileNotFoundError(msg)
 
                     # The same dataset can exist on different locations in the filesystem,
-                    # so we need to choose here.
-                    filename = filenames[0]
+                    # so pick the first data_paths root that actually has it (the check
+                    # above guarantees at least one exists).
+                    filename = next(f for f in filenames if f.exists())
 
                 ds_type = stream_info["type"]
                 if is_root():

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -650,6 +650,13 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
         # target data: collect for all forecast steps
         output_data = []
         if not is_stream_forcing(stream_ds[0].stream_info, self._stage):
+            # skip target values only for physically reconstructed streams; forcing streams
+            # are skipped entirely above and reconstruct:false (teacher-only) streams keep
+            # their values
+            coords_geoinfos_only = coords_geoinfos_only or (
+                self.skip_target_values
+                and is_stream_reconstructed(stream_ds[0].stream_info, self._stage)
+            )
             num_output_steps = self._get_output_length(num_forecast_steps)
             for timestep_idx in range(self.output_offset, num_output_steps):
                 step_forecast_dt = base_idx + (self.time_step * timestep_idx) // self.step_timedelta

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -8,6 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 import dataclasses
+import functools
 import logging
 import pathlib
 from collections.abc import Sequence
@@ -35,7 +36,11 @@ from weathergen.datasets.utils import (
 from weathergen.readers_extra.registry import get_extra_reader
 from weathergen.train.utils import Stage, get_batch_size_from_config
 from weathergen.utils.distributed import is_root
-from weathergen.utils.utils import is_stream_diagnostic, is_stream_forcing
+from weathergen.utils.utils import (
+    is_stream_diagnostic,
+    is_stream_forcing,
+    is_stream_reconstructed,
+)
 
 type AnyDataReader = DataReaderBase | DataReaderAnemoi | DataReaderObs
 type StreamName = str
@@ -50,11 +55,15 @@ FORECAST_DEFAULTS = {
 }
 
 
-def collect_datasources(stream_datasets: list, idx: int, type: str, rng) -> IOReaderData:
+def collect_datasources(
+    stream_datasets: list, idx: int, type: str, rng, coords_geoinfos_only: bool = False
+) -> IOReaderData:
     """
     Utility function to collect all sources / targets from streams list
 
     rng and num_subset are used to drop data
+
+    coords_geoinfos_only (targets only): skip reading the data values; data has zero width
     """
 
     rdatas = []
@@ -68,7 +77,9 @@ def collect_datasources(stream_datasets: list, idx: int, type: str, rng) -> IORe
             normalize_channels = ds.normalize_source_channels
             shuffle = ds.stream_info.get("shuffle_source", False)
         elif type == "target":
-            get_reader_data = ds.get_target
+            get_reader_data = functools.partial(
+                ds.get_target, coords_geoinfos_only=coords_geoinfos_only
+            )
             normalize_channels = ds.normalize_target_channels
             num_subset = ds.stream_info.get("max_num_targets", -1)
             shuffle = ds.stream_info.get("shuffle_target", False)
@@ -79,7 +90,9 @@ def collect_datasources(stream_datasets: list, idx: int, type: str, rng) -> IORe
         rdata = (
             get_reader_data(idx).shuffle(rng, shuffle, num_subset).remove_nan_coords_and_geoinfos()
         )
-        rdata.data = normalize_channels(rdata.data)
+        if not coords_geoinfos_only:
+            # zero-width data has nothing to normalize (and would fail the channel-count check)
+            rdata.data = normalize_channels(rdata.data)
         rdata.geoinfos = ds.normalize_geoinfos(rdata.geoinfos)
         rdatas += [rdata]
 
@@ -136,6 +149,17 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
                     "Ignoring teacher_time_offset (setting to 0)."
                 )
             self.teacher_time_offset = 0
+
+        # skip_target_values: inference-only; do not read/store target values for physically
+        # reconstructed streams, only coords/geoinfos/datetimes (data gets zero width)
+        self.skip_target_values = bool(mode_cfg.get("skip_target_values", False))
+        if self.skip_target_values and (
+            "student_teacher" in training_mode or "latent_loss" in training_mode
+        ):
+            raise ValueError(
+                "skip_target_values is incompatible with student_teacher/latent_loss modes: "
+                "target values are needed to build the teacher's network input."
+            )
 
         self.batch_size = get_batch_size_from_config(mode_cfg)
         self.num_workers = cf.data_loading.num_workers
@@ -271,8 +295,9 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                         raise FileNotFoundError(msg)
 
                     # The same dataset can exist on different locations in the filesystem,
-                    # so we need to choose here.
-                    filename = filenames[0]
+                    # so pick the first data_paths root that actually has it (the check
+                    # above guarantees at least one exists).
+                    filename = next(f for f in filenames if f.exists())
 
                 ds_type = stream_info["type"]
                 if is_root():
@@ -586,7 +611,14 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
 
         return stream_data
 
-    def _get_data_windows(self, base_idx, num_forecast_steps, num_steps_input_max, stream_ds):
+    def _get_data_windows(
+        self,
+        base_idx,
+        num_forecast_steps,
+        num_steps_input_max,
+        stream_ds,
+        coords_geoinfos_only: bool = False,
+    ):
         """
         Collect all data needed for current stream to potentially amortize costs by
         generating multiple samples
@@ -622,7 +654,13 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
             for timestep_idx in range(self.output_offset, num_output_steps):
                 step_forecast_dt = base_idx + (self.time_step * timestep_idx) // self.step_timedelta
 
-                rdata = collect_datasources(stream_ds, step_forecast_dt, "target", self.rng)
+                rdata = collect_datasources(
+                    stream_ds,
+                    step_forecast_dt,
+                    "target",
+                    self.rng,
+                    coords_geoinfos_only=coords_geoinfos_only,
+                )
 
                 if rdata.is_empty():
                     # work around for https://github.com/pytorch/pytorch/issues/158719
@@ -632,7 +670,10 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
                         self.healpix_level,
                         time_win.start,
                         stream_ds[0].get_geoinfo_size(),
-                        len(stream_ds[0].mean[stream_ds[0].target_idx]),
+                        # zero width to match the coords_geoinfos_only data downstream
+                        0
+                        if coords_geoinfos_only
+                        else len(stream_ds[0].mean[stream_ds[0].target_idx]),
                     )
                     rdata.is_spoof = True
 

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -919,9 +919,17 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
         worker_info = torch.utils.data.get_worker_info()
 
         if worker_info is None:
-            # assert self.world_size == 1, self.world_size
-            iter_start = 0
-            iter_end = len(self)
+            # num_workers=0 -> loading happens in the main process. This branch used to
+            # hardcode [0, len(self)), discarding the rank offset computed above, so every
+            # DDP rank iterated the same slice of the same permutation (reset() seeds from
+            # self.data_loader_rng_seed, which is only made rank-unique in the worker branch
+            # below) and therefore drew the SAME samples. Partition by rank instead.
+            iter_start = local_start
+            iter_end = local_end
+            logger.info(
+                f"{self.rank}::no-worker : dataset [{local_start},{local_end})"
+                + f" : [{iter_start},{iter_end})"
+            )
 
         else:
             # ensure the rng seed is fully unique across workers and mini_epochs

--- a/src/weathergen/datasets/stream_data.py
+++ b/src/weathergen/datasets/stream_data.py
@@ -366,8 +366,18 @@ class StreamData:
 
         # cat over forecast steps
         target_coords_empty = torch.cat(self.target_coords_lens).sum() == 0
-        target_tokens_empty = torch.cat(self.target_tokens).sum() == 0
-        return target_coords_empty and target_tokens_empty
+        # count coord rows rather than summing values: values may have zero width
+        # (skip_target_values), which a value-based check misreports as empty;
+        # spoofed windows carry no real points and still count as empty
+        target_points_empty = (
+            sum(
+                len(c)
+                for c, is_spoof in zip(self.target_coords_raw, self.target_is_spoof, strict=True)
+                if not is_spoof
+            )
+            == 0
+        )
+        return target_coords_empty and target_points_empty
 
     def source_empty(self) -> bool:
         """
@@ -402,7 +412,9 @@ class StreamData:
         """
 
         is_nan = torch.isnan(torch.cat(self.target_tokens))
-        return is_nan.all() if len(is_nan) > 0 else False
+        # numel, not len: zero-width values (skip_target_values) have rows but no
+        # elements, and .all() on an empty tensor is vacuously True
+        return is_nan.all() if is_nan.numel() > 0 else False
 
     def source_nan(self) -> bool:
         """

--- a/src/weathergen/datasets/stream_data.py
+++ b/src/weathergen/datasets/stream_data.py
@@ -412,7 +412,9 @@ class StreamData:
         """
 
         is_nan = torch.isnan(torch.cat(self.target_tokens))
-        return is_nan.all() if len(is_nan) > 0 else False
+        # numel, not len: zero-width values (skip_target_values) have rows but no
+        # elements, and .all() on an empty tensor is vacuously True
+        return is_nan.all() if is_nan.numel() > 0 else False
 
     def source_nan(self) -> bool:
         """

--- a/src/weathergen/datasets/stream_data.py
+++ b/src/weathergen/datasets/stream_data.py
@@ -366,8 +366,18 @@ class StreamData:
 
         # cat over forecast steps
         target_coords_empty = torch.cat(self.target_coords_lens).sum() == 0
-        target_tokens_empty = torch.cat(self.target_tokens).sum() == 0
-        return target_coords_empty and target_tokens_empty
+        # count coord rows rather than summing values: values may have zero width
+        # (skip_target_values), which a value-based check misreports as empty;
+        # spoofed windows carry no real points and still count as empty
+        target_points_empty = (
+            sum(
+                len(c)
+                for c, is_spoof in zip(self.target_coords_raw, self.target_is_spoof, strict=True)
+                if not is_spoof
+            )
+            == 0
+        )
+        return target_coords_empty and target_points_empty
 
     def source_empty(self) -> bool:
         """

--- a/src/weathergen/datasets/tokenizer_masking.py
+++ b/src/weathergen/datasets/tokenizer_masking.py
@@ -227,7 +227,9 @@ class TokenizerMasking(Tokenizer):
         )
 
         idxs_ord_inv = None
-        if data.numel() > 0:
+        # row count, not numel(): zero-width data (skip_target_values) still needs the
+        # inverse ordering so written coords/times/preds keep the original point order
+        if data.shape[0] > 0:
             # flatten per-token indices into one flat list
             idxs_flat = torch.cat([idxs for idxs_cell in idxs_cells for idxs in idxs_cell])
             # compute indices for inversion

--- a/src/weathergen/model/diffusion.py
+++ b/src/weathergen/model/diffusion.py
@@ -640,7 +640,14 @@ class DiffusionForecastEngine(torch.nn.Module):
                     track["x"].append(self.cur_token.cpu())
 
             if return_trajectory:
-                intermediate_x.append(x_next)
+                # Move to CPU immediately so the GPU segment containing x_next
+                # is fully freed after the next step's allocations.  Keeping all
+                # num_steps tensors live on GPU causes non-releasable fragmentation
+                # (each step's denoised/d_cur holes land in segments that also hold
+                # earlier x_next entries, so those segments can never be returned to
+                # CUDA even after empty_cache()).  The decoder/writer accesses the
+                # trajectory sequentially, so a .to(device) there is sufficient.
+                intermediate_x.append(x_next.cpu())
 
         if log_diagnostics:
             self._plot_sampling_diagnostics(track, num_steps)

--- a/src/weathergen/model/diffusion.py
+++ b/src/weathergen/model/diffusion.py
@@ -168,6 +168,16 @@ class DiffusionForecastEngine(torch.nn.Module):
         # When True, use EDM preconditioning (c_skip/c_out, EDM Eq. 7) in denoise().
         # When False (default), the network predicts x0 directly (c_skip=0, c_out=1).
         self.edm_preconditioning = self.cf.get("fe_diffusion_edm_preconditioning", False)
+
+        # EDM stochastic sampler (Karras et al. 2022, Algorithm 2) knobs — inference only.
+        # s_churn == 0 (the default) keeps the deterministic Heun sampler, bit-identical.
+        # See _stochastic_churn() and _run_ode().
+        self.s_churn = float(self.cf.get("fe_diffusion_s_churn", 0.0))
+        self.s_min = float(self.cf.get("fe_diffusion_s_min", 0.0))
+        _s_max = self.cf.get("fe_diffusion_s_max", None)
+        self.s_max = math.inf if _s_max is None else float(_s_max)
+        self.s_noise = float(self.cf.get("fe_diffusion_s_noise", 1.0))
+
         self.cur_token = None  # TODO: re move after single sample experiments
         self._noised_tokens: torch.Tensor | None = None
         self._fixed_noise_level: float | None = None
@@ -491,6 +501,48 @@ class DiffusionForecastEngine(torch.nn.Module):
         )
         return intermediate_x
 
+    def _stochastic_churn(
+        self, x_cur: torch.Tensor, t_cur: torch.Tensor, num_steps: int, sigma_max_eff: float
+    ) -> "tuple[torch.Tensor, torch.Tensor]":
+        """EDM Algorithm 2 churn step: temporarily raise the noise level from ``t_cur`` to
+        ``t_hat`` by injecting fresh Gaussian noise, so the subsequent denoise+Heun step acts
+        as a Langevin corrector. Returns ``(x_hat, t_hat)``.
+
+        With ``s_max = min(fe_diffusion_s_max, sigma_max_eff)`` and
+        ``gamma = min(s_churn / num_steps, sqrt(2) - 1)`` (only for ``t_cur`` inside
+        ``[s_min, s_max]``)::
+
+            t_hat = min((1 + gamma) * t_cur, s_max)
+            x_hat = x_cur + sqrt(t_hat**2 - t_cur**2) * s_noise * N(0, I)
+
+        ``fe_diffusion_s_max`` is capped at ``sigma_max_eff`` (the top of the training-aligned
+        inference schedule) so churn can neither operate at nor raise the noise level into the
+        untrained high-sigma tail.
+
+        No-op — returns ``(x_cur, t_cur)`` with the global RNG stream **untouched** — when
+        ``s_churn <= 0`` (the default), ``t_cur`` is outside ``[s_min, s_max]``, ``gamma``
+        rounds to 0, or the ``s_max`` cap leaves nothing to add. The RNG guard matters: an
+        unconditional ``torch.randn_like(...) * 0`` would still advance the RNG and shift the
+        initial noise of every later sample / forecast step.
+
+        Works for both trajectory mode (``x_cur`` is ``(1, H, D)``) and ensemble mode
+        (``x_cur`` is ``(N, H, D)`` — each member gets independent churn noise).
+        """
+        if self.s_churn <= 0.0:
+            return x_cur, t_cur
+        s_max = min(self.s_max, sigma_max_eff)
+        sigma = t_cur.item()
+        if not (self.s_min <= sigma <= s_max):
+            return x_cur, t_cur
+        gamma = min(self.s_churn / num_steps, math.sqrt(2.0) - 1.0)
+        sigma_hat = min((1.0 + gamma) * sigma, s_max)
+        if sigma_hat <= sigma:
+            # gamma == 0, or the s_max cap clamps t_hat back to t_cur — nothing to inject.
+            return x_cur, t_cur
+        t_hat = torch.full_like(t_cur, sigma_hat)
+        x_hat = x_cur + math.sqrt(sigma_hat**2 - sigma**2) * self.s_noise * torch.randn_like(x_cur)
+        return x_hat, t_hat
+
     def _run_ode(
         self,
         c: torch.Tensor | None,
@@ -560,12 +612,18 @@ class DiffusionForecastEngine(torch.nn.Module):
         sigma_max_eff = min(self.sigma_max, sigma_max_train)
         sigma_min_eff = max(self.sigma_min, sigma_min_from_dist, self.sigma_data * 0.01)
         if log_diagnostics:
+            _churn = (
+                f", stochastic churn: s_churn={self.s_churn}, s_min={self.s_min}, "
+                f"s_max={self.s_max}, s_noise={self.s_noise}"
+                if self.s_churn > 0
+                else " (deterministic Heun sampler)"
+            )
             logger.info(
                 f"Inference sigma schedule ({self.noise_distribution}): "
                 f"sigma_max_eff={sigma_max_eff:.4f} (config={self.sigma_max}, train_max={sigma_max_train:.4f}), "
                 f"sigma_min_eff={sigma_min_eff:.4f} "
                 f"(config={self.sigma_min}, dist q={sigma_min_quantile:.3f}/{sigma_min_from_dist:.4f}), "
-                f"sigma_data={self.sigma_data}, rho={self.rho}, num_steps={num_steps}"
+                f"sigma_data={self.sigma_data}, rho={self.rho}, num_steps={num_steps}{_churn}"
             )
 
         # --- Time step discretization (EDM Eq. 5) with training-aligned bounds ---
@@ -581,6 +639,7 @@ class DiffusionForecastEngine(torch.nn.Module):
         # --- Per-step tracking for diagnostics ---
         track = {
             "sigma": [],
+            "sigma_hat": [],  # post-churn sigma; == "sigma" for the deterministic sampler
             "x_std": [],
             "denoised_std": [],
             "l2_to_target": [],
@@ -606,12 +665,11 @@ class DiffusionForecastEngine(torch.nn.Module):
 
             x_cur = x_next
 
-            # Increase noise temporarily. (Stochastic sampling; not used for now)
-            # gamma = min(S_churn / num_steps, np.sqrt(2) - 1) if S_min <= t_cur <= S_max else 0
-            # t_hat = self.net.round_sigma(t_cur + gamma * t_cur)
-            # x_hat = x_cur + (t_hat**2 - t_cur**2).sqrt() * s_noise * torch.randn_like(x_cur)
-            x_hat = x_cur
-            t_hat = t_cur
+            # Increase noise temporarily (EDM Algorithm 2 churn). No-op — x_hat is x_cur,
+            # t_hat is t_cur, RNG untouched — when fe_diffusion_s_churn == 0 (the default),
+            # so the deterministic Heun sampler below is unchanged. sigma_max_eff caps the
+            # churn so it never reaches into the untrained high-sigma tail.
+            x_hat, t_hat = self._stochastic_churn(x_cur, t_cur, num_steps, sigma_max_eff)
 
             # Euler step.
             denoised = self.denoise(x=x_hat, c=c, sigma=t_hat, fstep=fstep, coords=coords)
@@ -628,6 +686,7 @@ class DiffusionForecastEngine(torch.nn.Module):
             with torch.no_grad():
                 s = t_cur.item()
                 track["sigma"].append(s)
+                track["sigma_hat"].append(t_hat.item())
                 track["c_skip"].append(self.sigma_data**2 / (s**2 + self.sigma_data**2))
                 track["x_std"].append(x_next.std().item())
                 track["denoised_std"].append(denoised.std().item())
@@ -668,7 +727,17 @@ class DiffusionForecastEngine(torch.nn.Module):
         fig, axes = plt.subplots(n_plots, 1, figsize=(10, 3 * n_plots), sharex=True)
 
         # 1) Sigma schedule
-        axes[0].semilogy(steps, track["sigma"], "o-", markersize=3)
+        axes[0].semilogy(steps, track["sigma"], "o-", markersize=3, label="sigma (schedule)")
+        if track.get("sigma_hat") and track["sigma_hat"] != track["sigma"]:
+            # Stochastic sampler: show the per-step noise bump from churn.
+            axes[0].semilogy(
+                steps,
+                track["sigma_hat"],
+                "x--",
+                markersize=4,
+                color="tab:green",
+                label="sigma_hat (post-churn)",
+            )
         axes[0].set_ylabel("sigma (noise level)")
         axes[0].set_title(
             f"Sampling diagnostics  |  sigma_max_eff={track['sigma'][0]:.2f}, "

--- a/src/weathergen/model/diffusion.py
+++ b/src/weathergen/model/diffusion.py
@@ -184,6 +184,15 @@ class DiffusionForecastEngine(torch.nn.Module):
         # Space in which pairwise member distances are measured: "x0" (denoiser output,
         # recommended) or "xt" (the noisy state itself).
         self.pg_kernel_space = self.cf.get("diffusion_particle_guidance_kernel_space", "x0")
+        # Time constant tau, in forecast steps, of the exponential fade applied across the
+        # rollout on top of the sigma schedule; 0 disables the fade.
+        self.pg_fstep_decay = self.cf.get("diffusion_particle_guidance_fstep_decay", 0.0)
+        # First forecast step of the rollout. The fade is measured from here so that it
+        # starts at 1.0 on the first step actually generated, rather than part-way down
+        # the curve when forecast.offset > 0.
+        self.pg_fstep_offset = (
+            self.cf.get("training_config", {}).get("forecast", {}).get("offset", 0)
+        )
         # Number of HEALPix cells whose particle systems are solved at once; 0 = all.
         # Purely a memory/speed trade-off, the result is identical either way.
         self.pg_cell_chunk = self.cf.get("diffusion_particle_guidance_cell_chunk", 4096)
@@ -515,6 +524,17 @@ class DiffusionForecastEngine(torch.nn.Module):
         )
         return intermediate_x
 
+    def _pg_fstep_fade(self, fstep: int) -> float:
+        """Across-rollout fade factor exp(-fstep / tau); 1.0 when the fade is disabled.
+
+        Measured from ``pg_fstep_offset`` (the rollout's first forecast step) and clamped
+        at zero below it, so the first generated step always receives the full strength
+        even when ``forecast.offset > 0``.
+        """
+        if not self.pg_fstep_decay:
+            return 1.0
+        return math.exp(-max(0, fstep - self.pg_fstep_offset) / self.pg_fstep_decay)
+
     @staticmethod
     def _pg_scale(drift: torch.Tensor, force: torch.Tensor, alpha: float) -> torch.Tensor:
         """Scale factor putting the repulsion at ``alpha`` times the ODE drift magnitude.
@@ -536,6 +556,7 @@ class DiffusionForecastEngine(torch.nn.Module):
         denoised: torch.Tensor,
         sigma: torch.Tensor,
         sigma_max_eff: float,
+        fstep: int,
     ) -> "tuple[torch.Tensor, float, float]":
         """Repulsive force between ensemble members, computed per HEALPix cell.
 
@@ -576,17 +597,30 @@ class DiffusionForecastEngine(torch.nn.Module):
         the forecast they encode -- repulsion there would push apart along noise
         directions, which the next denoiser call simply undoes.
 
+        On top of the sigma schedule the strength is faded across the rollout as
+        exp(-fstep / tau). This is not cosmetic: the members share identical conditioning
+        only at the first forecast step, which is the one place the repulsion is doing
+        real work -- choosing different modes from the same information. Afterwards the
+        conditioning is per-member and already diverged, so the model's own dynamics grow
+        the spread and further repulsion double-counts it. Worse, the effect compounds:
+        k steps of a (1 + eps) inflation give (1 + eps)^k, making the total injected
+        spread a function of how far you rolled out. Under the fade the product
+        telescopes to ~exp(eps * tau), bounded independently of rollout length.
+
         Args:
             x: Current noisy state, shape (N, T, D).
             denoised: Denoiser output D(x; sigma) at this step, shape (N, T, D).
             sigma: Current noise level (scalar tensor).
             sigma_max_eff: Upper bound of the sampling schedule, used to normalise the
                 annealing factor.
+            fstep: Global forecast step, used for the across-rollout fade. Counted from
+                the first generated step, so forecast.offset > 0 still starts at 1.0.
 
         Returns:
             ``(force, alpha, spread)``. *force* has shape (N, T, D) and points away from
             the other members (zero on the register/class tokens); it is unnormalised, the
-            caller sets its magnitude. *alpha* is the annealing factor at this sigma.
+            caller sets its magnitude. *alpha* is the annealing factor at this sigma and
+            forecast step.
             *spread* is the RMS pairwise member distance in kernel space -- the quantity
             particle guidance exists to increase, and the main diagnostic for tuning.
         """
@@ -594,6 +628,7 @@ class DiffusionForecastEngine(torch.nn.Module):
         n_special = self.cf.num_register_tokens + self.cf.num_class_tokens
 
         alpha = self.pg_strength * (float(sigma.item()) / sigma_max_eff) ** self.pg_sigma_power
+        alpha *= self._pg_fstep_fade(fstep)
 
         # Kernel coordinates (N, H, D) with the non-spatial tokens dropped, transposed to
         # (H, N, D) so that each HEALPix cell is one independent particle system.
@@ -730,10 +765,14 @@ class DiffusionForecastEngine(torch.nn.Module):
                 "fe_diffusion_num_ensemble_members > 1."
             )
         if log_diagnostics and pg_active:
+            # The sampling diagnostics plot is written to a fixed path and so only ever
+            # shows the last forecast step; this line is how the across-rollout fade is
+            # actually observable.
             logger.info(
                 f"Particle guidance active: strength={self.pg_strength}, "
                 f"sigma_power={self.pg_sigma_power}, kernel_space={self.pg_kernel_space}, "
-                f"members={batch_size}"
+                f"members={batch_size}, fstep={fstep}, tau={self.pg_fstep_decay}, "
+                f"fstep_fade={self._pg_fstep_fade(fstep):.4f}"
             )
 
         # --- Time step discretization (EDM Eq. 5) with training-aligned bounds ---
@@ -788,7 +827,7 @@ class DiffusionForecastEngine(torch.nn.Module):
             d_cur = (x_hat - denoised) / t_hat
             if pg_active:
                 pg_force, pg_alpha, pg_spread = self._particle_guidance_repulsion(
-                    x_hat, denoised, t_hat, sigma_max_eff
+                    x_hat, denoised, t_hat, sigma_max_eff, fstep
                 )
                 d_cur = d_cur - self._pg_scale(d_cur, pg_force, pg_alpha) * pg_force
             x_next = x_hat + (t_next - t_hat) * d_cur
@@ -799,7 +838,7 @@ class DiffusionForecastEngine(torch.nn.Module):
                 d_prime = (x_next - denoised) / t_next
                 if pg_active:
                     pg_force_p, pg_alpha_p, _ = self._particle_guidance_repulsion(
-                        x_next, denoised, t_next, sigma_max_eff
+                        x_next, denoised, t_next, sigma_max_eff, fstep
                     )
                     d_prime = d_prime - self._pg_scale(d_prime, pg_force_p, pg_alpha_p) * pg_force_p
                 x_next = x_hat + (t_next - t_hat) * (0.5 * d_cur + 0.5 * d_prime)

--- a/src/weathergen/model/diffusion.py
+++ b/src/weathergen/model/diffusion.py
@@ -201,6 +201,15 @@ class DiffusionForecastEngine(torch.nn.Module):
             f"(got '{self.pg_kernel_space}')"
         )
 
+        # EDM stochastic sampler (Karras et al. 2022, Algorithm 2) knobs — inference only.
+        # s_churn == 0 (the default) keeps the deterministic Heun sampler, bit-identical.
+        # See _stochastic_churn() and _run_ode().
+        self.s_churn = float(self.cf.get("fe_diffusion_s_churn", 0.0))
+        self.s_min = float(self.cf.get("fe_diffusion_s_min", 0.0))
+        _s_max = self.cf.get("fe_diffusion_s_max", None)
+        self.s_max = math.inf if _s_max is None else float(_s_max)
+        self.s_noise = float(self.cf.get("fe_diffusion_s_noise", 1.0))
+
         self.cur_token = None  # TODO: re move after single sample experiments
         self._noised_tokens: torch.Tensor | None = None
         self._fixed_noise_level: float | None = None
@@ -679,6 +688,48 @@ class DiffusionForecastEngine(torch.nn.Module):
         spread = math.sqrt(d2_sum.item() / d2_count)
         return out.to(x.dtype), alpha, spread
 
+    def _stochastic_churn(
+        self, x_cur: torch.Tensor, t_cur: torch.Tensor, num_steps: int, sigma_max_eff: float
+    ) -> "tuple[torch.Tensor, torch.Tensor]":
+        """EDM Algorithm 2 churn step: temporarily raise the noise level from ``t_cur`` to
+        ``t_hat`` by injecting fresh Gaussian noise, so the subsequent denoise+Heun step acts
+        as a Langevin corrector. Returns ``(x_hat, t_hat)``.
+
+        With ``s_max = min(fe_diffusion_s_max, sigma_max_eff)`` and
+        ``gamma = min(s_churn / num_steps, sqrt(2) - 1)`` (only for ``t_cur`` inside
+        ``[s_min, s_max]``)::
+
+            t_hat = min((1 + gamma) * t_cur, s_max)
+            x_hat = x_cur + sqrt(t_hat**2 - t_cur**2) * s_noise * N(0, I)
+
+        ``fe_diffusion_s_max`` is capped at ``sigma_max_eff`` (the top of the training-aligned
+        inference schedule) so churn can neither operate at nor raise the noise level into the
+        untrained high-sigma tail.
+
+        No-op — returns ``(x_cur, t_cur)`` with the global RNG stream **untouched** — when
+        ``s_churn <= 0`` (the default), ``t_cur`` is outside ``[s_min, s_max]``, ``gamma``
+        rounds to 0, or the ``s_max`` cap leaves nothing to add. The RNG guard matters: an
+        unconditional ``torch.randn_like(...) * 0`` would still advance the RNG and shift the
+        initial noise of every later sample / forecast step.
+
+        Works for both trajectory mode (``x_cur`` is ``(1, H, D)``) and ensemble mode
+        (``x_cur`` is ``(N, H, D)`` — each member gets independent churn noise).
+        """
+        if self.s_churn <= 0.0:
+            return x_cur, t_cur
+        s_max = min(self.s_max, sigma_max_eff)
+        sigma = t_cur.item()
+        if not (self.s_min <= sigma <= s_max):
+            return x_cur, t_cur
+        gamma = min(self.s_churn / num_steps, math.sqrt(2.0) - 1.0)
+        sigma_hat = min((1.0 + gamma) * sigma, s_max)
+        if sigma_hat <= sigma:
+            # gamma == 0, or the s_max cap clamps t_hat back to t_cur — nothing to inject.
+            return x_cur, t_cur
+        t_hat = torch.full_like(t_cur, sigma_hat)
+        x_hat = x_cur + math.sqrt(sigma_hat**2 - sigma**2) * self.s_noise * torch.randn_like(x_cur)
+        return x_hat, t_hat
+
     def _run_ode(
         self,
         c: torch.Tensor | None,
@@ -748,12 +799,18 @@ class DiffusionForecastEngine(torch.nn.Module):
         sigma_max_eff = min(self.sigma_max, sigma_max_train)
         sigma_min_eff = max(self.sigma_min, sigma_min_from_dist, self.sigma_data * 0.01)
         if log_diagnostics:
+            _churn = (
+                f", stochastic churn: s_churn={self.s_churn}, s_min={self.s_min}, "
+                f"s_max={self.s_max}, s_noise={self.s_noise}"
+                if self.s_churn > 0
+                else " (deterministic Heun sampler)"
+            )
             logger.info(
                 f"Inference sigma schedule ({self.noise_distribution}): "
                 f"sigma_max_eff={sigma_max_eff:.4f} (config={self.sigma_max}, train_max={sigma_max_train:.4f}), "
                 f"sigma_min_eff={sigma_min_eff:.4f} "
                 f"(config={self.sigma_min}, dist q={sigma_min_quantile:.3f}/{sigma_min_from_dist:.4f}), "
-                f"sigma_data={self.sigma_data}, rho={self.rho}, num_steps={num_steps}"
+                f"sigma_data={self.sigma_data}, rho={self.rho}, num_steps={num_steps}{_churn}"
             )
 
         # Particle guidance couples the members, so it needs more than one of them.
@@ -788,6 +845,7 @@ class DiffusionForecastEngine(torch.nn.Module):
         # --- Per-step tracking for diagnostics ---
         track = {
             "sigma": [],
+            "sigma_hat": [],  # post-churn sigma; == "sigma" for the deterministic sampler
             "x_std": [],
             "denoised_std": [],
             "l2_to_target": [],
@@ -815,12 +873,11 @@ class DiffusionForecastEngine(torch.nn.Module):
 
             x_cur = x_next
 
-            # Increase noise temporarily. (Stochastic sampling; not used for now)
-            # gamma = min(S_churn / num_steps, np.sqrt(2) - 1) if S_min <= t_cur <= S_max else 0
-            # t_hat = self.net.round_sigma(t_cur + gamma * t_cur)
-            # x_hat = x_cur + (t_hat**2 - t_cur**2).sqrt() * s_noise * torch.randn_like(x_cur)
-            x_hat = x_cur
-            t_hat = t_cur
+            # Increase noise temporarily (EDM Algorithm 2 churn). No-op — x_hat is x_cur,
+            # t_hat is t_cur, RNG untouched — when fe_diffusion_s_churn == 0 (the default),
+            # so the deterministic Heun sampler below is unchanged. sigma_max_eff caps the
+            # churn so it never reaches into the untrained high-sigma tail.
+            x_hat, t_hat = self._stochastic_churn(x_cur, t_cur, num_steps, sigma_max_eff)
 
             # Euler step.
             denoised = self.denoise(x=x_hat, c=c, sigma=t_hat, fstep=fstep, coords=coords)
@@ -847,6 +904,7 @@ class DiffusionForecastEngine(torch.nn.Module):
             with torch.no_grad():
                 s = t_cur.item()
                 track["sigma"].append(s)
+                track["sigma_hat"].append(t_hat.item())
                 track["c_skip"].append(self.sigma_data**2 / (s**2 + self.sigma_data**2))
                 track["x_std"].append(x_next.std().item())
                 track["denoised_std"].append(denoised.std().item())
@@ -862,7 +920,14 @@ class DiffusionForecastEngine(torch.nn.Module):
                     track["x"].append(self.cur_token.cpu())
 
             if return_trajectory:
-                intermediate_x.append(x_next)
+                # Move to CPU immediately so the GPU segment containing x_next
+                # is fully freed after the next step's allocations.  Keeping all
+                # num_steps tensors live on GPU causes non-releasable fragmentation
+                # (each step's denoised/d_cur holes land in segments that also hold
+                # earlier x_next entries, so those segments can never be returned to
+                # CUDA even after empty_cache()).  The decoder/writer accesses the
+                # trajectory sequentially, so a .to(device) there is sufficient.
+                intermediate_x.append(x_next.cpu())
 
         if log_diagnostics:
             self._plot_sampling_diagnostics(track, num_steps)
@@ -884,7 +949,17 @@ class DiffusionForecastEngine(torch.nn.Module):
         fig, axes = plt.subplots(n_plots, 1, figsize=(10, 3 * n_plots), sharex=True)
 
         # 1) Sigma schedule
-        axes[0].semilogy(steps, track["sigma"], "o-", markersize=3)
+        axes[0].semilogy(steps, track["sigma"], "o-", markersize=3, label="sigma (schedule)")
+        if track.get("sigma_hat") and track["sigma_hat"] != track["sigma"]:
+            # Stochastic sampler: show the per-step noise bump from churn.
+            axes[0].semilogy(
+                steps,
+                track["sigma_hat"],
+                "x--",
+                markersize=4,
+                color="tab:green",
+                label="sigma_hat (post-churn)",
+            )
         axes[0].set_ylabel("sigma (noise level)")
         axes[0].set_title(
             f"Sampling diagnostics  |  sigma_max_eff={track['sigma'][0]:.2f}, "

--- a/src/weathergen/model/diffusion.py
+++ b/src/weathergen/model/diffusion.py
@@ -226,12 +226,12 @@ class DiffusionForecastEngine(torch.nn.Module):
             f"(got '{self.cond_noise_norm_scope}')"
         )
         # How the perturbation is applied along the denoising trajectory:
+        #   "fixed" (default) one draw per forecast step, held constant through the whole
+        #           ODE -- the member keeps a persistent perturbed state to forecast from.
         #   "cads"  CADS (Sadat et al., ICLR 2024, arXiv:2310.17347): re-corrupted at every
         #           denoising step under the gamma(t) schedule below, so the conditioning is
         #           destroyed at high sigma and fully restored by the end of the ODE.
-        #   "fixed" one draw per forecast step, held constant through the whole ODE -- the
-        #           member keeps a persistent perturbed state to forecast from.
-        self.cond_noise_schedule = self.cf.get("diffusion_conditioning_noise_schedule", "cads")
+        self.cond_noise_schedule = self.cf.get("diffusion_conditioning_noise_schedule", "fixed")
         assert self.cond_noise_schedule in {"cads", "fixed"}, (
             f"diffusion_conditioning_noise_schedule must be 'cads' or 'fixed' "
             f"(got '{self.cond_noise_schedule}')"

--- a/src/weathergen/model/diffusion.py
+++ b/src/weathergen/model/diffusion.py
@@ -187,12 +187,10 @@ class DiffusionForecastEngine(torch.nn.Module):
         # Time constant tau, in forecast steps, of the exponential fade applied across the
         # rollout on top of the sigma schedule; 0 disables the fade.
         self.pg_fstep_decay = self.cf.get("diffusion_particle_guidance_fstep_decay", 0.0)
-        # First forecast step of the rollout. The fade is measured from here so that it
-        # starts at 1.0 on the first step actually generated, rather than part-way down
-        # the curve when forecast.offset > 0.
-        self.pg_fstep_offset = (
-            self.cf.get("training_config", {}).get("forecast", {}).get("offset", 0)
-        )
+        # First forecast step of the rollout. Fades are measured from here so that they
+        # start at 1.0 on the first step actually generated, rather than part-way down
+        # the curve when forecast.offset > 0. Shared with the conditioning noise fade.
+        self.fstep_offset = self._stage_forecast_offset()
         # Number of HEALPix cells whose particle systems are solved at once; 0 = all.
         # Purely a memory/speed trade-off, the result is identical either way.
         self.pg_cell_chunk = self.cf.get("diffusion_particle_guidance_cell_chunk", 4096)
@@ -209,6 +207,54 @@ class DiffusionForecastEngine(torch.nn.Module):
         _s_max = self.cf.get("fe_diffusion_s_max", None)
         self.s_max = math.inf if _s_max is None else float(_s_max)
         self.s_noise = float(self.cf.get("fe_diffusion_s_noise", 1.0))
+
+        # --- Conditioning noise (per-member perturbation of the latent conditioning) ---
+        # Inference only; see _perturb_conditioning(). 0.0 (the default) leaves the
+        # conditioning untouched and does not draw from the RNG at all.
+        self.cond_noise_std = float(self.cf.get("diffusion_conditioning_noise_std", 0.0))
+        # Time constant tau, in forecast steps, of an exponential fade exp(-fstep / tau) on
+        # the amplitude across the rollout; 0 keeps it constant.
+        self.cond_noise_fstep_decay = float(
+            self.cf.get("diffusion_conditioning_noise_fstep_decay", 0.0)
+        )
+        # Norm the amplitude is relative to: "token" (each HEALPix token's own RMS, so the
+        # perturbation follows the local token magnitude) or "member" (one RMS per member,
+        # i.e. a spatially uniform amplitude).
+        self.cond_noise_norm_scope = self.cf.get("diffusion_conditioning_noise_norm_scope", "token")
+        assert self.cond_noise_norm_scope in {"token", "member"}, (
+            f"diffusion_conditioning_noise_norm_scope must be 'token' or 'member' "
+            f"(got '{self.cond_noise_norm_scope}')"
+        )
+        # How the perturbation is applied along the denoising trajectory:
+        #   "cads"  CADS (Sadat et al., ICLR 2024, arXiv:2310.17347): re-corrupted at every
+        #           denoising step under the gamma(t) schedule below, so the conditioning is
+        #           destroyed at high sigma and fully restored by the end of the ODE.
+        #   "fixed" one draw per forecast step, held constant through the whole ODE -- the
+        #           member keeps a persistent perturbed state to forecast from.
+        self.cond_noise_schedule = self.cf.get("diffusion_conditioning_noise_schedule", "cads")
+        assert self.cond_noise_schedule in {"cads", "fixed"}, (
+            f"diffusion_conditioning_noise_schedule must be 'cads' or 'fixed' "
+            f"(got '{self.cond_noise_schedule}')"
+        )
+        # CADS gamma(t) thresholds on trajectory progress t (1 at the first denoising step,
+        # 0 at the last): no corruption for t <= tau1, full corruption for t >= tau2, linear
+        # in between. Paper defaults tau1=0.6, tau2=1.0.
+        self.cond_noise_tau1 = float(self.cf.get("diffusion_conditioning_noise_tau1", 0.6))
+        self.cond_noise_tau2 = float(self.cf.get("diffusion_conditioning_noise_tau2", 1.0))
+        assert 0.0 <= self.cond_noise_tau1 <= self.cond_noise_tau2 <= 1.0, (
+            f"diffusion_conditioning_noise_tau1/tau2 must satisfy 0 <= tau1 <= tau2 <= 1 "
+            f"(got tau1={self.cond_noise_tau1}, tau2={self.cond_noise_tau2})"
+        )
+        # CADS rescaling mix psi: fraction of the corrupted conditioning taken from the
+        # variant renormalised back to the clean mean/std. 1.0 (the paper's recommendation)
+        # rescales fully, 0.0 disables it.
+        self.cond_noise_rescale_psi = float(
+            self.cf.get("diffusion_conditioning_noise_rescale_psi", 1.0)
+        )
+        assert 0.0 <= self.cond_noise_rescale_psi <= 1.0, (
+            f"diffusion_conditioning_noise_rescale_psi must be in [0, 1] "
+            f"(got {self.cond_noise_rescale_psi})"
+        )
 
         self.cur_token = None  # TODO: re move after single sample experiments
         self._noised_tokens: torch.Tensor | None = None
@@ -511,6 +557,8 @@ class DiffusionForecastEngine(torch.nn.Module):
             # (N, H, D) on subsequent steps (stored by model.py after the previous ensemble step).
             # expand() is a no-op when the leading dim already matches N, so this handles both.
             c_batched = c.expand(num_ensemble_members, *c.shape[1:]) if c is not None else None
+            # Perturb after expanding, so each member gets its own draw.
+            c_batched = self._store_perturbed_conditioning(c_batched, fstep, meta_info)
             final_x, _ = self._run_ode(
                 c=c_batched,
                 fstep=fstep,
@@ -523,6 +571,7 @@ class DiffusionForecastEngine(torch.nn.Module):
             return final_x
 
         # Default trajectory mode: return all intermediate ODE states (existing behaviour).
+        c = self._store_perturbed_conditioning(c, fstep, meta_info)
         _, intermediate_x = self._run_ode(
             c=c,
             fstep=fstep,
@@ -533,16 +582,39 @@ class DiffusionForecastEngine(torch.nn.Module):
         )
         return intermediate_x
 
-    def _pg_fstep_fade(self, fstep: int) -> float:
-        """Across-rollout fade factor exp(-fstep / tau); 1.0 when the fade is disabled.
+    def _stage_forecast_offset(self) -> int:
+        """``forecast.offset`` of the stage this run is executing.
 
-        Measured from ``pg_fstep_offset`` (the rollout's first forecast step) and clamped
-        at zero below it, so the first generated step always receives the full strength
-        even when ``forecast.offset > 0``.
+        ``validation_config`` and ``test_config`` are overlays on ``training_config``
+        (see ``Trainer.__init__``), so at inference the offset is whichever of them
+        defines it, most specific first -- reading ``training_config`` alone would report
+        the training offset for a run whose ``test_config.forecast.offset`` differs.
         """
-        if not self.pg_fstep_decay:
+        stage_keys = (
+            ["test_config", "validation_config", "training_config"]
+            if self.cf.get("stage", None) == "inference"
+            else ["training_config"]
+        )
+        for key in stage_keys:
+            offset = self.cf.get(key, {}).get("forecast", {}).get("offset", None)
+            if offset is not None:
+                return offset
+        return 0
+
+    def _fstep_fade(self, fstep: int, tau: float) -> float:
+        """Across-rollout fade factor exp(-fstep / tau); 1.0 when ``tau`` is 0 (disabled).
+
+        Measured from ``fstep_offset`` (the rollout's first forecast step) and clamped at
+        zero below it, so the first generated step always receives the full strength even
+        when ``forecast.offset > 0``.
+        """
+        if not tau:
             return 1.0
-        return math.exp(-max(0, fstep - self.pg_fstep_offset) / self.pg_fstep_decay)
+        return math.exp(-max(0, fstep - self.fstep_offset) / tau)
+
+    def _pg_fstep_fade(self, fstep: int) -> float:
+        """Particle-guidance strength fade across the rollout; see :meth:`_fstep_fade`."""
+        return self._fstep_fade(fstep, self.pg_fstep_decay)
 
     @staticmethod
     def _pg_scale(drift: torch.Tensor, force: torch.Tensor, alpha: float) -> torch.Tensor:
@@ -730,6 +802,195 @@ class DiffusionForecastEngine(torch.nn.Module):
         x_hat = x_cur + math.sqrt(sigma_hat**2 - sigma**2) * self.s_noise * torch.randn_like(x_cur)
         return x_hat, t_hat
 
+    def _cads_gamma(self, step_idx: int, num_steps: int) -> float:
+        """CADS conditioning-annealing factor at denoising step ``step_idx``.
+
+        ``t`` is the progress along the sampling trajectory, 1.0 at the first step (pure
+        noise) down to 0.0 at the last, and (Sadat et al., arXiv:2310.17347, Eq. 3)::
+
+            gamma(t) = 1                        t <= tau1   (clean conditioning)
+                       (tau2 - t)/(tau2 - tau1) tau1 < t < tau2
+                       0                        t >= tau2   (conditioning destroyed)
+
+        Progress is measured in step index rather than in sigma: the Karras schedule drops
+        sigma by orders of magnitude over the first few steps, so tau thresholds expressed
+        in sigma would concentrate the whole ramp into them, while the paper's thresholds
+        were tuned against a time variable that is roughly linear in the step index.
+        """
+        t = 1.0 - step_idx / max(num_steps - 1, 1)
+        if t <= self.cond_noise_tau1:
+            return 1.0
+        if t >= self.cond_noise_tau2:
+            return 0.0
+        return (self.cond_noise_tau2 - t) / (self.cond_noise_tau2 - self.cond_noise_tau1)
+
+    def _cond_noise_amplitude(self, fstep: int) -> float:
+        """Noise scale ``s`` at forecast step ``fstep``, after the across-rollout fade."""
+        return self.cond_noise_std * self._fstep_fade(fstep, self.cond_noise_fstep_decay)
+
+    def _perturb_conditioning(
+        self, c: torch.Tensor | None, fstep: int, gamma: float | None = None
+    ) -> torch.Tensor | None:
+        """Perturb the latent conditioning tokens per ensemble member (inference only).
+
+        The ensemble's members are denoised from the *same* conditioning, so at the first
+        forecast step everything that separates them is the initial noise draw (plus
+        particle guidance, if enabled). Perturbing the conditioning instead treats the
+        analysis/previous state as uncertain: each member forecasts from its own slightly
+        different information, and the model's own dynamics grow that difference over the
+        rollout. It is complementary to particle guidance -- that one pushes members apart
+        *within* one denoising pass, this one hands them different information to begin
+        with.
+
+        Two ways of applying it along the denoising trajectory, selected by
+        ``diffusion_conditioning_noise_schedule``:
+
+        ``gamma is None`` -- "fixed": plain additive noise, drawn once per forecast step and
+        held constant through the whole ODE::
+
+            c_hat = c + s * scale * n
+
+        so the member carries a persistent perturbed state, the latent analogue of an
+        ensemble of initial conditions.
+
+        ``gamma is not None`` -- "cads" (Sadat et al., ICLR 2024, arXiv:2310.17347): the
+        variance-preserving mix of their Eq. 2, redrawn at every denoising step with
+        ``gamma`` from :meth:`_cads_gamma` rising from 0 to 1 along the trajectory::
+
+            c_hat = sqrt(gamma) * c + s * sqrt(1 - gamma) * scale * n
+
+        The conditioning is therefore destroyed at high sigma -- where the trajectory
+        decides which mode it falls into, and where diversity is won -- and fully restored
+        by the end of the ODE, where condition alignment is what matters. Because it is
+        clean again at the end, the member is left with an unbiased conditioning rather
+        than a persistent offset, which is the substantive difference from "fixed".
+
+        The amplitude is relative to the token norm rather than absolute, because latent
+        token magnitudes vary by orders of magnitude across cells and checkpoints, so a
+        fixed std would be a different perturbation for every run. With
+        ``diffusion_conditioning_noise_norm_scope``::
+
+            "token"  scale_h = rms(c[:, h, :])   per HEALPix token (default)
+            "member" scale   = rms(c[n])         one value per member
+
+        so ``diffusion_conditioning_noise_std = 0.01`` means "perturb each conditioning
+        token by ~1% of its own magnitude". (CADS assumes a standardised conditioning
+        vector and uses an absolute s; scaling by the token RMS is what makes their s
+        transferable to a latent state that is not unit-scale.)
+
+        With ``diffusion_conditioning_noise_rescale_psi`` > 0 the corrupted conditioning is
+        renormalised back to the clean per-member mean/std and mixed back in (their Eq. 4-5,
+        psi=1 recommended); the paper reports this prevents divergence at high noise scales
+        at a small cost in diversity. Note that it also means ``s`` sets the noise-to-signal
+        ratio inside the ramp rather than an absolute magnitude: at gamma=0 there is no
+        signal left to be relative to, and rescaling restores the clean scale whatever s
+        was.
+
+        The noise is drawn independently per member: on the first rollout step ``c`` is a
+        ``(1, H, D)`` tensor expanded to ``(N, H, D)``, and expanding before perturbing is
+        what makes the members differ; on later steps ``c`` is already per-member.
+
+        Both schedules additionally fade the amplitude across the rollout as
+        exp(-fstep / tau) (``diffusion_conditioning_noise_fstep_decay``), for the same
+        reason the particle guidance fade exists: the conditioning is identical across
+        members only at the first forecast step, which is where the perturbation buys
+        spread that is not already there. Later steps start from conditioning that has
+        diverged on its own, and re-injecting a fixed relative perturbation at every step
+        compounds -- k steps of (1 + eps) give (1 + eps)^k, so the injected spread would
+        otherwise depend on how far you rolled out. This axis is absent from CADS, which
+        generates one sample rather than a rollout.
+
+        Register and class tokens are left untouched, matching particle guidance: they
+        carry global state rather than a location's forecast, and perturbing them moves
+        every cell at once instead of adding local uncertainty.
+
+        Single-sample (trajectory) inference is perturbed as well. There is no within-batch
+        spread to create there, but independent runs then differ from one another, which is
+        how an ensemble is assembled from separate jobs rather than from one batched pass.
+
+        No-op -- returns ``c`` unchanged, RNG untouched -- when the feature is off, when the
+        conditioning is not the latent forecast state (the date/time modes condition on a
+        timestamp, which is not a thing to add Gaussian noise to), when the fade has decayed
+        the amplitude to zero, or when ``gamma == 1`` (the CADS schedule leaves most of the
+        trajectory uncorrupted, so this is the common case). Returning the *same object* is
+        what the callers use to detect that nothing happened.
+
+        Note that a perturbed conditioning is materialised: without noise the ensemble
+        conditioning is a stride-0 ``expand`` view costing nothing, so enabling this adds
+        one real ``(N, H, D)`` tensor while the perturbed copy is in use.
+        """
+        if c is None or self.conditioning != "forecast" or self.cond_noise_std <= 0.0:
+            return c
+        if gamma is not None and gamma >= 1.0:
+            return c
+
+        s_eff = self._cond_noise_amplitude(fstep)
+        if s_eff <= 0.0:
+            return c
+
+        n_special = self.cf.num_register_tokens + self.cf.num_class_tokens
+        spatial = c[:, n_special:, :].float()
+        if self.cond_noise_norm_scope == "token":
+            # (N, H, 1): every token gets noise proportional to its own magnitude.
+            scale = spatial.pow(2).mean(dim=-1, keepdim=True).sqrt()
+        else:
+            # (N, 1, 1): one amplitude per member, uniform over the map.
+            scale = spatial.pow(2).mean(dim=(1, 2), keepdim=True).sqrt()
+
+        noise = torch.randn_like(spatial) * scale * s_eff
+        if gamma is None:
+            noised = spatial + noise
+        else:
+            noised = math.sqrt(gamma) * spatial + math.sqrt(1.0 - gamma) * noise
+            if self.cond_noise_rescale_psi > 0.0:
+                # Renormalise to the clean per-member statistics (the analogue of CADS'
+                # per-sample rescaling) and mix back in with psi.
+                dims = (1, 2)
+                mean_c = spatial.mean(dim=dims, keepdim=True)
+                std_c = spatial.std(dim=dims, keepdim=True)
+                mean_n = noised.mean(dim=dims, keepdim=True)
+                std_n = noised.std(dim=dims, keepdim=True).clamp_min(1e-12)
+                rescaled = (noised - mean_n) / std_n * std_c + mean_c
+                psi = self.cond_noise_rescale_psi
+                noised = psi * rescaled + (1.0 - psi) * noised
+
+        perturbed = c.clone()  # materialises the expand() view; see docstring
+        perturbed[:, n_special:, :] = noised.to(c.dtype)
+        return perturbed
+
+    def _store_perturbed_conditioning(
+        self,
+        c: torch.Tensor | None,
+        fstep: int,
+        meta_info: dict[str, SampleMetaData] | None,
+    ) -> torch.Tensor | None:
+        """Apply the "fixed" conditioning perturbation once, before the ODE starts.
+
+        Only for ``diffusion_conditioning_noise_schedule="fixed"``; the CADS schedule
+        re-corrupts the conditioning inside :meth:`_run_ode` at every denoising step and
+        ends on the clean one, so there is nothing to apply (or to store) here.
+
+        The stored conditioning is kept in sync because with
+        ``fe_diffusion_predict_residual`` the caller (``model.py``) adds the tensor held in
+        ``meta_info`` back onto the network output: it has to be the state the denoiser was
+        actually conditioned on, or the residual would be taken relative to the clean state
+        and the perturbation would silently cancel. Nothing is written when the
+        perturbation is a no-op.
+        """
+        if self.cond_noise_schedule != "fixed":
+            return c
+        perturbed = self._perturb_conditioning(c, fstep)
+        if perturbed is not c and meta_info is not None:
+            meta_info["LATENT_CONDITIONING_TOKENS"] = perturbed
+            logger.info(
+                f"Conditioning noise (fixed): std={self.cond_noise_std}, "
+                f"scope={self.cond_noise_norm_scope}, tau={self.cond_noise_fstep_decay}, "
+                f"fstep={fstep}, fstep_fade="
+                f"{self._fstep_fade(fstep, self.cond_noise_fstep_decay):.4f}, "
+                f"s_eff={self._cond_noise_amplitude(fstep):.4g}, members={c.shape[0]}"
+            )
+        return perturbed
+
     def _run_ode(
         self,
         c: torch.Tensor | None,
@@ -821,6 +1082,25 @@ class DiffusionForecastEngine(torch.nn.Module):
                 "denoised, so it is inactive; it requires "
                 "fe_diffusion_num_ensemble_members > 1."
             )
+        # CADS re-corrupts the conditioning at every denoising step; the "fixed" schedule
+        # has already perturbed it once before the ODE (see _store_perturbed_conditioning).
+        cads_active = (
+            c is not None
+            and self.conditioning == "forecast"
+            and self.cond_noise_schedule == "cads"
+            and self._cond_noise_amplitude(fstep) > 0.0
+        )
+        if log_diagnostics and cads_active:
+            n_corrupted = sum(self._cads_gamma(i, num_steps) < 1.0 for i in range(num_steps))
+            logger.info(
+                f"Conditioning noise (CADS): s={self.cond_noise_std}, "
+                f"tau1={self.cond_noise_tau1}, tau2={self.cond_noise_tau2}, "
+                f"psi={self.cond_noise_rescale_psi}, scope={self.cond_noise_norm_scope}, "
+                f"rollout tau={self.cond_noise_fstep_decay}, fstep={fstep}, fstep_fade="
+                f"{self._fstep_fade(fstep, self.cond_noise_fstep_decay):.4f}, "
+                f"s_eff={self._cond_noise_amplitude(fstep):.4g}, "
+                f"corrupted steps={n_corrupted}/{num_steps}, members={batch_size}"
+            )
         if log_diagnostics and pg_active:
             # The sampling diagnostics plot is written to a fixed path and so only ever
             # shows the last forecast step; this line is how the across-rollout fade is
@@ -856,6 +1136,7 @@ class DiffusionForecastEngine(torch.nn.Module):
             "residual_std": [],
             "pg_alpha": [],
             "pg_spread": [],
+            "cads_gamma": [],
             "x": [x.cpu()],
         }
 
@@ -879,8 +1160,17 @@ class DiffusionForecastEngine(torch.nn.Module):
             # churn so it never reaches into the untrained high-sigma tail.
             x_hat, t_hat = self._stochastic_churn(x_cur, t_cur, num_steps, sigma_max_eff)
 
+            # CADS: one corrupted conditioning per denoising step, used by *both* stages of
+            # the Heun step -- re-drawing it between the Euler and the correction evaluation
+            # would have them measure two different vector fields, and the second-order
+            # correction assumes they are the same one.
+            c_step = c
+            if cads_active:
+                gamma = self._cads_gamma(i, num_steps)
+                c_step = self._perturb_conditioning(c, fstep, gamma=gamma)
+
             # Euler step.
-            denoised = self.denoise(x=x_hat, c=c, sigma=t_hat, fstep=fstep, coords=coords)
+            denoised = self.denoise(x=x_hat, c=c_step, sigma=t_hat, fstep=fstep, coords=coords)
             d_cur = (x_hat - denoised) / t_hat
             if pg_active:
                 pg_force, pg_alpha, pg_spread = self._particle_guidance_repulsion(
@@ -891,7 +1181,9 @@ class DiffusionForecastEngine(torch.nn.Module):
 
             # Apply 2nd order correction.
             if i < num_steps - 1:
-                denoised = self.denoise(x=x_next, c=c, sigma=t_next, fstep=fstep, coords=coords)
+                denoised = self.denoise(
+                    x=x_next, c=c_step, sigma=t_next, fstep=fstep, coords=coords
+                )
                 d_prime = (x_next - denoised) / t_next
                 if pg_active:
                     pg_force_p, pg_alpha_p, _ = self._particle_guidance_repulsion(
@@ -914,6 +1206,8 @@ class DiffusionForecastEngine(torch.nn.Module):
                 if pg_active:
                     track["pg_alpha"].append(pg_alpha)
                     track["pg_spread"].append(pg_spread)
+                if cads_active:
+                    track["cads_gamma"].append(gamma)
                 track["x"].append(x_next.cpu())
                 if self.cur_token is not None:
                     track["l2_to_target"].append((x_next - self.cur_token).norm().item())
@@ -944,7 +1238,8 @@ class DiffusionForecastEngine(torch.nn.Module):
         steps = list(range(len(track["sigma"])))
         has_target = len(track["l2_to_target"]) > 0
         has_pg = len(track.get("pg_spread", [])) > 0
-        n_plots = 8 if has_pg else 7
+        has_cads = len(track.get("cads_gamma", [])) > 0
+        n_plots = 7 + int(has_pg) + int(has_cads)
 
         fig, axes = plt.subplots(n_plots, 1, figsize=(10, 3 * n_plots), sharex=True)
 
@@ -1043,6 +1338,39 @@ class DiffusionForecastEngine(torch.nn.Module):
             )
             ax_alpha.set_ylabel("guidance strength")
             ax_alpha.legend(fontsize=8, loc="upper right")
+
+        if has_cads:
+            # 9) CADS conditioning annealing: how much of the conditioning the denoiser
+            # actually sees at each step, and the noise weight that replaces the rest.
+            ax_cads = axes[7 + int(has_pg)]
+            ax_cads.plot(
+                steps,
+                track["cads_gamma"],
+                "o-",
+                markersize=3,
+                color="tab:brown",
+                label="gamma(t) (conditioning kept)",
+            )
+            ax_cads.set_ylabel("gamma")
+            ax_cads.set_ylim(-0.05, 1.05)
+            ax_cads.set_title(
+                f"CADS conditioning annealing  |  s={self.cond_noise_std}, "
+                f"tau1={self.cond_noise_tau1}, tau2={self.cond_noise_tau2}, "
+                f"psi={self.cond_noise_rescale_psi}"
+            )
+            ax_cads.grid(True, alpha=0.3)
+            ax_cads.legend(fontsize=8, loc="upper left")
+            ax_noise = ax_cads.twinx()
+            ax_noise.plot(
+                steps,
+                [math.sqrt(1.0 - g) for g in track["cads_gamma"]],
+                "--",
+                lw=1,
+                color="tab:red",
+                label="sqrt(1 - gamma) (noise weight)",
+            )
+            ax_noise.set_ylabel("noise weight")
+            ax_noise.legend(fontsize=8, loc="upper right")
 
         axes[-1].set_xlabel("sampling step")
         fig.tight_layout()

--- a/src/weathergen/model/diffusion.py
+++ b/src/weathergen/model/diffusion.py
@@ -168,6 +168,30 @@ class DiffusionForecastEngine(torch.nn.Module):
         # When True, use EDM preconditioning (c_skip/c_out, EDM Eq. 7) in denoise().
         # When False (default), the network predicts x0 directly (c_skip=0, c_out=1).
         self.edm_preconditioning = self.cf.get("fe_diffusion_edm_preconditioning", False)
+
+        # --- Particle guidance (repulsion-only diverse ensemble sampling) ---
+        # When enabled *and* more than one ensemble member is sampled, the members are
+        # denoised jointly with a repulsive force between them; see
+        # _particle_guidance_repulsion. Disabled by default, in which case the sampler is
+        # exactly the plain EDM ODE and no extra work is done.
+        self.particle_guidance = self.cf.get("diffusion_particle_guidance", False)
+        # Repulsion magnitude as a fraction of the ODE drift at sigma_max (see _run_ode).
+        self.pg_strength = self.cf.get("diffusion_particle_guidance_strength", 0.1)
+        # Annealing exponent p in alpha(sigma) = strength * (sigma / sigma_max_eff) ** p.
+        # Repulsion is strongest at high sigma, where the trajectory still decides which
+        # mode it falls into, and is annealed to zero so members land on-manifold.
+        self.pg_sigma_power = self.cf.get("diffusion_particle_guidance_sigma_power", 1.0)
+        # Space in which pairwise member distances are measured: "x0" (denoiser output,
+        # recommended) or "xt" (the noisy state itself).
+        self.pg_kernel_space = self.cf.get("diffusion_particle_guidance_kernel_space", "x0")
+        # Number of HEALPix cells whose particle systems are solved at once; 0 = all.
+        # Purely a memory/speed trade-off, the result is identical either way.
+        self.pg_cell_chunk = self.cf.get("diffusion_particle_guidance_cell_chunk", 4096)
+        assert self.pg_kernel_space in {"x0", "xt"}, (
+            f"diffusion_particle_guidance_kernel_space must be 'x0' or 'xt' "
+            f"(got '{self.pg_kernel_space}')"
+        )
+
         self.cur_token = None  # TODO: re move after single sample experiments
         self._noised_tokens: torch.Tensor | None = None
         self._fixed_noise_level: float | None = None
@@ -491,6 +515,135 @@ class DiffusionForecastEngine(torch.nn.Module):
         )
         return intermediate_x
 
+    @staticmethod
+    def _pg_scale(drift: torch.Tensor, force: torch.Tensor, alpha: float) -> torch.Tensor:
+        """Scale factor putting the repulsion at ``alpha`` times the ODE drift magnitude.
+
+        The raw potential gradient has no natural scale: it depends on the kernel
+        bandwidth, the latent width and the member spread, so a bare strength constant
+        would need re-tuning for every configuration (and, with the median bandwidth,
+        would sit several orders of magnitude away from 1). Rescaling the whole force by
+        one scalar per step leaves the *direction* of the potential gradient untouched --
+        it only fixes the overall magnitude, which is exactly what the alpha(sigma)
+        schedule is for -- while making the strength knob dimensionless: 0.1 means the
+        repulsion perturbs each ODE step by ~10%.
+        """
+        return alpha * drift.norm() / force.norm().clamp_min(1e-12)
+
+    def _particle_guidance_repulsion(
+        self,
+        x: torch.Tensor,
+        denoised: torch.Tensor,
+        sigma: torch.Tensor,
+        sigma_max_eff: float,
+    ) -> "tuple[torch.Tensor, float, float]":
+        """Repulsive force between ensemble members, computed per HEALPix cell.
+
+        Implements the repulsion-only ("fixed potential") variant of particle guidance
+        (Corso et al., 2024). The N members are drawn from the joint distribution
+
+            p(x^1, ..., x^N)  ~  prod_i p_sigma(x^i) * exp(-alpha(sigma) * Phi(x^1..x^N))
+
+        instead of independently, with the similarity potential
+
+            Phi = sum_cells sum_{i<j} k(z^i, z^j),    k = RBF kernel
+
+        so each member picks up the extra drift -alpha * grad_{x^i} Phi, pushing it away
+        from the other members. Note what is *not* done here: each member keeps its own
+        score untouched. That is what separates this from SVGD, which additionally
+        replaces every particle's score by a kernel-weighted average over all particles
+        and locks the driving and repulsive terms at a fixed relative weight. Keeping the
+        score intact means the members stay (approximately) marginal samples of p_sigma
+        and the strength is a free schedule; with alpha -> 0 the plain EDM ODE is
+        recovered exactly.
+
+        The kernel acts *per HEALPix cell*: for each cell the N member latents form their
+        own independent N-particle system in R^D. One kernel over the whole flattened
+        (num_tokens * D) state would be useless at this dimensionality -- with N ~ 10
+        particles in ~10^6 dimensions an RBF either saturates (k -> 0 for every pair, no
+        repulsion) or goes flat under the median bandwidth (a uniform push away from the
+        centroid). The per-cell form also produces *local* spread, which is what an
+        ensemble forecast actually wants.
+
+        Register and class tokens are not spatial, so they receive zero force.
+
+        Note on kernel_space="x0": the kernel is evaluated on the denoiser output
+        x0_hat = D(x; sigma) while the force is applied to x, i.e. the Jacobian
+        dx0_hat/dx is approximated by the identity. Taking it exactly would mean
+        backpropagating through the denoiser at every ODE step. x0-space is preferred
+        over xt-space because at high sigma the pairwise distances between the x^i are
+        dominated by their independent noise draws rather than by any real difference in
+        the forecast they encode -- repulsion there would push apart along noise
+        directions, which the next denoiser call simply undoes.
+
+        Args:
+            x: Current noisy state, shape (N, T, D).
+            denoised: Denoiser output D(x; sigma) at this step, shape (N, T, D).
+            sigma: Current noise level (scalar tensor).
+            sigma_max_eff: Upper bound of the sampling schedule, used to normalise the
+                annealing factor.
+
+        Returns:
+            ``(force, alpha, spread)``. *force* has shape (N, T, D) and points away from
+            the other members (zero on the register/class tokens); it is unnormalised, the
+            caller sets its magnitude. *alpha* is the annealing factor at this sigma.
+            *spread* is the RMS pairwise member distance in kernel space -- the quantity
+            particle guidance exists to increase, and the main diagnostic for tuning.
+        """
+        n_members = x.shape[0]
+        n_special = self.cf.num_register_tokens + self.cf.num_class_tokens
+
+        alpha = self.pg_strength * (float(sigma.item()) / sigma_max_eff) ** self.pg_sigma_power
+
+        # Kernel coordinates (N, H, D) with the non-spatial tokens dropped, transposed to
+        # (H, N, D) so that each HEALPix cell is one independent particle system.
+        z_src = denoised if self.pg_kernel_space == "x0" else x
+        z_all = z_src[:, n_special:, :].detach().transpose(0, 1)
+        n_cells = z_all.shape[0]
+
+        out = torch.zeros_like(x, dtype=torch.float32)
+        out_spatial = out[:, n_special:, :]  # view: writes below land in `out`
+        off_diag = ~torch.eye(n_members, dtype=torch.bool, device=x.device)
+
+        d2_sum = torch.zeros((), device=x.device, dtype=torch.float64)
+        d2_count = 0
+
+        # The cells are independent, so chunking over them is exact -- unlike chunking over
+        # members, which would silently drop the couplings this whole method is about. It
+        # is worth doing: an fp32 copy of every cell at once is N * H * D * 4 bytes (~0.8 GB
+        # for 8 members at healpix level 5 and d2048), and the force doubles that.
+        chunk = self.pg_cell_chunk or n_cells
+        for start in range(0, n_cells, chunk):
+            z = z_all[start : start + chunk].float()
+
+            # Pairwise squared distances per cell, (chunk, N, N). Expanded form rather than
+            # cdist, whose accurate mode would materialise a (chunk, N, N, D) tensor.
+            z_sq = z.pow(2).sum(dim=-1)
+            d2 = (
+                z_sq.unsqueeze(2) + z_sq.unsqueeze(1) - 2.0 * torch.bmm(z, z.transpose(1, 2))
+            ).clamp_min(0.0)
+
+            # Median heuristic on the off-diagonal entries: h = median(||zi - zj||^2) / log N,
+            # which makes sum_j k_ij ~ 1 and keeps the repulsion from either saturating or
+            # vanishing. Recomputed at every step and for every cell, because the member
+            # spread changes by orders of magnitude along the trajectory and across cells --
+            # any fixed bandwidth would be wrong almost everywhere.
+            med = d2[:, off_diag].median(dim=1).values  # (chunk,)
+            h = (med / math.log(n_members)).clamp_min(1e-12).view(-1, 1, 1)
+
+            k = torch.exp(-d2 / h)  # (chunk, N, N)
+
+            # -grad_{z_i} Phi = (2/h) * sum_j k_ij (z_i - z_j), pointing away from the other
+            # members. The i == j term vanishes, so leaving the diagonal of k in is harmless.
+            force = (2.0 / h) * (k.sum(dim=-1, keepdim=True) * z - torch.bmm(k, z))
+            out_spatial[:, start : start + chunk, :] = force.transpose(0, 1)
+
+            d2_sum += d2[:, off_diag].sum().double()
+            d2_count += d2.shape[0] * n_members * (n_members - 1)
+
+        spread = math.sqrt(d2_sum.item() / d2_count)
+        return out.to(x.dtype), alpha, spread
+
     def _run_ode(
         self,
         c: torch.Tensor | None,
@@ -568,6 +721,21 @@ class DiffusionForecastEngine(torch.nn.Module):
                 f"sigma_data={self.sigma_data}, rho={self.rho}, num_steps={num_steps}"
             )
 
+        # Particle guidance couples the members, so it needs more than one of them.
+        pg_active = self.particle_guidance and batch_size > 1
+        if log_diagnostics and self.particle_guidance and batch_size == 1:
+            logger.warning(
+                "diffusion_particle_guidance is enabled but only one sample is being "
+                "denoised, so it is inactive; it requires "
+                "fe_diffusion_num_ensemble_members > 1."
+            )
+        if log_diagnostics and pg_active:
+            logger.info(
+                f"Particle guidance active: strength={self.pg_strength}, "
+                f"sigma_power={self.pg_sigma_power}, kernel_space={self.pg_kernel_space}, "
+                f"members={batch_size}"
+            )
+
         # --- Time step discretization (EDM Eq. 5) with training-aligned bounds ---
         step_indices = torch.arange(num_steps, dtype=torch.float64, device="cuda")
         t_steps = (
@@ -589,6 +757,8 @@ class DiffusionForecastEngine(torch.nn.Module):
             "d_cur_norm": [],
             "d_cur_step_norm": [],
             "residual_std": [],
+            "pg_alpha": [],
+            "pg_spread": [],
             "x": [x.cpu()],
         }
 
@@ -616,12 +786,22 @@ class DiffusionForecastEngine(torch.nn.Module):
             # Euler step.
             denoised = self.denoise(x=x_hat, c=c, sigma=t_hat, fstep=fstep, coords=coords)
             d_cur = (x_hat - denoised) / t_hat
+            if pg_active:
+                pg_force, pg_alpha, pg_spread = self._particle_guidance_repulsion(
+                    x_hat, denoised, t_hat, sigma_max_eff
+                )
+                d_cur = d_cur - self._pg_scale(d_cur, pg_force, pg_alpha) * pg_force
             x_next = x_hat + (t_next - t_hat) * d_cur
 
             # Apply 2nd order correction.
             if i < num_steps - 1:
                 denoised = self.denoise(x=x_next, c=c, sigma=t_next, fstep=fstep, coords=coords)
                 d_prime = (x_next - denoised) / t_next
+                if pg_active:
+                    pg_force_p, pg_alpha_p, _ = self._particle_guidance_repulsion(
+                        x_next, denoised, t_next, sigma_max_eff
+                    )
+                    d_prime = d_prime - self._pg_scale(d_prime, pg_force_p, pg_alpha_p) * pg_force_p
                 x_next = x_hat + (t_next - t_hat) * (0.5 * d_cur + 0.5 * d_prime)
 
             # --- Record diagnostics ---
@@ -634,6 +814,9 @@ class DiffusionForecastEngine(torch.nn.Module):
                 track["d_cur_norm"].append(d_cur.norm().item())
                 track["d_cur_step_norm"].append(((t_next - t_hat) * d_cur).norm().item())
                 track["residual_std"].append((x_hat - denoised).std().item())
+                if pg_active:
+                    track["pg_alpha"].append(pg_alpha)
+                    track["pg_spread"].append(pg_spread)
                 track["x"].append(x_next.cpu())
                 if self.cur_token is not None:
                     track["l2_to_target"].append((x_next - self.cur_token).norm().item())
@@ -656,7 +839,8 @@ class DiffusionForecastEngine(torch.nn.Module):
 
         steps = list(range(len(track["sigma"])))
         has_target = len(track["l2_to_target"]) > 0
-        n_plots = 7
+        has_pg = len(track.get("pg_spread", [])) > 0
+        n_plots = 8 if has_pg else 7
 
         fig, axes = plt.subplots(n_plots, 1, figsize=(10, 3 * n_plots), sharex=True)
 
@@ -723,6 +907,28 @@ class DiffusionForecastEngine(torch.nn.Module):
         axes[6].set_ylabel("std (log scale)")
         axes[6].set_title("Std of x_next over denoising steps")
         axes[6].grid(True, alpha=0.3)
+
+        if has_pg:
+            # 8) Particle guidance: member spread (what it is trying to increase) against
+            # the annealing factor (how hard it is pushing).
+            axes[7].plot(
+                steps,
+                track["pg_spread"],
+                "o-",
+                markersize=3,
+                color="tab:green",
+                label="RMS pairwise member distance",
+            )
+            axes[7].set_ylabel("member spread")
+            axes[7].grid(True, alpha=0.3)
+            axes[7].set_title("Particle guidance")
+            axes[7].legend(fontsize=8, loc="upper left")
+            ax_alpha = axes[7].twinx()
+            ax_alpha.plot(
+                steps, track["pg_alpha"], "--", lw=1, color="tab:purple", label="alpha(sigma)"
+            )
+            ax_alpha.set_ylabel("guidance strength")
+            ax_alpha.legend(fontsize=8, loc="upper right")
 
         axes[-1].set_xlabel("sampling step")
         fig.tight_layout()

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -807,6 +807,11 @@ class Model(torch.nn.Module):
         Returns:
             A list containing all prediction results
         """
+        # Mirrors the branch taken inside _get_initial_conditions: with no latent carried over
+        # the source window is encoded, otherwise this is a continuation chunk resuming from
+        # the previous chunk's latent state.
+        from_encoder = len(getattr(samples_or_output, "latent", [])) == 0
+
         source_samples, tokens, posteriors, intermediates = self._get_initial_conditions(
             samples_or_output, model_params
         )
@@ -820,25 +825,32 @@ class Model(torch.nn.Module):
             self.cf.get("fe_diffusion_model", False)
             and self.cf.get("fe_diffusion_model_conditioning", None) == "forecast"
         ):
-            # tokens[:,0] = t (most recent), tokens[:,1] = t-1, ..., tokens[:,-1] = t-(T-1) (oldest)
-            if self.cf.stage == "inference":
-                print("Using most recent steps as conditioning tokens for inference.")
-                # conditioning_tokens = tokens[:, :-1].sum(axis=1)
-                conditioning_tokens = tokens[:, 1:].sum(axis=1)
-            else:
-                # Conditioning: all older context steps [t-1, ..., t-(T-1)];
-                # denoising target: t (newest)
-                conditioning_tokens = tokens[:, 1:].sum(axis=1)
-                conditioning_tokens = conditioning_tokens + torch.randn_like(
+            # A continuation chunk carries a single rolled-forward step, so there are no older
+            # context steps left to derive conditioning from — tokens[:, 1:] would be empty and
+            # sum to zero. meta_info already holds the state the previous chunk rolled to, so
+            # leave it untouched and only unwrap the step dimension.
+            if from_encoder:
+                # tokens[:,0] = t (most recent), tokens[:,1] = t-1, ..., tokens[:,-1] = t-(T-1)
+                if self.cf.stage == "inference":
+                    print("Using most recent steps as conditioning tokens for inference.")
+                    # conditioning_tokens = tokens[:, :-1].sum(axis=1)
+                    conditioning_tokens = tokens[:, 1:].sum(axis=1)
+                else:
+                    # Conditioning: all older context steps [t-1, ..., t-(T-1)];
+                    # denoising target: t (newest)
+                    conditioning_tokens = tokens[:, 1:].sum(axis=1)
+                    conditioning_tokens = conditioning_tokens + torch.randn_like(
+                        conditioning_tokens
+                    ) * self.cf.get("fe_impute_latent_diffusion_noise_std", 0.0)
+                    if np.random.rand() < self.cf.get(
+                        "fe_diffusion_classifier_free_guidance_prob", 0.0
+                    ):  # occasionally dropout conditioning for classifier free guidance
+                        conditioning_tokens = torch.zeros_like(conditioning_tokens)
+                # X_t (tokens[:, 0], most recent) is the diffusion denoising target;
+                # older steps are conditioning.
+                source_samples.samples[0].meta_info["LATENT_CONDITIONING_TOKENS"] = (
                     conditioning_tokens
-                ) * self.cf.get("fe_impute_latent_diffusion_noise_std", 0.0)
-                if np.random.rand() < self.cf.get(
-                    "fe_diffusion_classifier_free_guidance_prob", 0.0
-                ):  # occasionally dropout conditioning for classifier free guidance
-                    conditioning_tokens = torch.zeros_like(conditioning_tokens)
-            # X_t (tokens[:, 0], most recent) is the diffusion denoising target;
-            # older steps are conditioning.
-            source_samples.samples[0].meta_info["LATENT_CONDITIONING_TOKENS"] = conditioning_tokens
+                )
             # self.forecast_engine._pending_target_tokens = diffusion_target_tokens
             tokens = tokens[:, 0]
         else:
@@ -928,25 +940,43 @@ class Model(torch.nn.Module):
                     predict_residual = self.cf.get("fe_diffusion_predict_residual", False)
                     # Apply residual correction; broadcasts cond (1, H, D) over all N members.
                     member_final_tokens = cond + tokens if predict_residual else tokens
-                    # Decode all members (or the single rollout state) in one forward pass.
-                    # Use a single-slot ModelOutput for this temporary container.
-                    # forecast_offset != step ensures base=step so chunk_idx(step)==0.
-                    tmp_output = ModelOutput([step], step + 1, source_samples)
-                    tmp_output = self.predict_decoders(
-                        model_params,
-                        step,
-                        member_final_tokens,
-                        source_samples,
-                        tmp_output,
-                        out_step=0,
-                    )
-                    # pred_tuple has N entries (one per member / "batch" item).
+                    # Decode the members in groups of decode_members_per_pass. The decoder runs
+                    # over (members * n_target_points) query tokens, so decoding all members at
+                    # once makes its peak activation scale with the ensemble size — the dominant
+                    # allocation for large target sets (a full O(1e6)-point stream). Grouping
+                    # keeps that peak bounded while the results are concatenated to the same
+                    # (N, n_points, channels) layout as a single pass.
+                    n_members = member_final_tokens.shape[0]
+                    group = self.cf.get("decode_members_per_pass", 0) or n_members
+                    member_preds: dict[str, list[torch.Tensor]] = {}
+                    for m_start in range(0, n_members, group):
+                        # Use a single-slot ModelOutput for this temporary container.
+                        # forecast_offset != step ensures base=step so chunk_idx(step)==0.
+                        tmp_output = ModelOutput([step], step + 1, source_samples)
+                        tmp_output = self.predict_decoders(
+                            model_params,
+                            step,
+                            member_final_tokens[m_start : m_start + group],
+                            source_samples,
+                            tmp_output,
+                            out_step=0,
+                        )
+                        # pred_tuple has one entry per member in this group.
+                        for sname, pred_tuple in tmp_output.physical[0].items():
+                            member_preds.setdefault(sname, []).extend(pred_tuple)
                     # Concatenate along dim 0: (N, n_points, channels),
                     # wrap in 1-tuple (batch_size=1).
-                    for sname, pred_tuple in tmp_output.physical[0].items():
+                    for sname, preds_list in member_preds.items():
                         output.add_physical_prediction(
-                            step, sname, (torch.cat(list(pred_tuple), dim=0),)
+                            output.chunk_idx(step), sname, (torch.cat(preds_list, dim=0),)
                         )
+                    # Carry the rolled-forward state so a following forecast chunk resumes from
+                    # here instead of re-encoding the source window and restarting the forecast.
+                    output.add_latent_prediction(
+                        output.chunk_idx(step),
+                        "latent_state",
+                        self.tokens_to_latent_state(None, member_final_tokens),
+                    )
                     # Store per-member conditioning for the next rollout step.
                     # conditioning_tokens holds (N, H, D) during ensemble rollout; inference_forward
                     # calls expand(N, ...) which is a no-op when the dim already matches.
@@ -1194,16 +1224,42 @@ class Model(torch.nn.Module):
                         tcs_lens,
                     ).unsqueeze(0)  # add ensemble dim: shape is then [1, preds_per_coord, channels]
                 else:
-                    tc_tokens = self.target_token_engines[stream_name](
-                        latent=tokens_nbors,
-                        output=tc_tokens,
-                        latent_lens=tokens_nbors_lens,
-                        output_lens=tcs_lens,
-                        coordinates=t_coords,
-                    )
+                    # The decoder runs one varlen group per (member, healpix cell): group g
+                    # holds tcls[g] target points attending to the 9 latent tokens at
+                    # tokens_nbors[9g : 9g+9]. Every block modulates with a per-point
+                    # AdaLayerNorm, so a full-resolution stream (O(1e6) target points) makes a
+                    # single block hold several multi-GiB fp32 temporaries at once — the
+                    # dominant allocation of the whole forward pass. Groups are independent
+                    # under varlen attention, so decoding them in slices bounds that peak
+                    # without changing the result.
+                    n_groups = tcls.shape[0]
+                    nbors_per_group = tokens_nbors.shape[0] // n_groups
+                    group_size = self.cf.get("decode_cells_per_pass", 0) or n_groups
+                    # start offset of each group's target points; last entry is the total
+                    point_offsets = torch.cumsum(tcs_lens, 0).tolist()
+                    preds = []
+                    for g_start in range(0, n_groups, group_size):
+                        g_end = min(g_start + group_size, n_groups)
+                        p_start, p_end = point_offsets[g_start], point_offsets[g_end]
+                        # groups in this slice may all be empty; flash-attn needs >0 queries
+                        if p_end == p_start:
+                            continue
+                        zero = torch.zeros(1, dtype=tcls.dtype, device=tcls.device)
+                        group_lens = torch.cat([zero, tcls[g_start:g_end]])
+                        tc_tokens_group = self.target_token_engines[stream_name](
+                            latent=tokens_nbors[
+                                g_start * nbors_per_group : g_end * nbors_per_group
+                            ],
+                            output=tc_tokens[p_start:p_end],
+                            latent_lens=tokens_nbors_lens[: g_end - g_start + 1],
+                            output_lens=group_lens,
+                            coordinates=t_coords[p_start:p_end],
+                        )
 
-                    # final prediction head to map back to physical space
-                    pred = self.pred_heads[stream_name](tc_tokens)
+                        # final prediction head to map back to physical space
+                        preds.append(self.pred_heads[stream_name](tc_tokens_group))
+                    # points are on dim 1: (ens_size, n_points, channels)
+                    pred = torch.cat(preds, dim=1)
 
             # recover batch dimension (ragged, so as list)
             pred = torch.split(pred, t_coords_lens, dim=1)

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -191,6 +191,33 @@ class ModelParams(torch.nn.Module):
         self.reset_parameters(cf)
         return self
 
+    def offload_encoder_params(self) -> None:
+        """Move encoder-only ModelParams tensors back to CPU after the encoder has run.
+
+        ``pe_global`` (shape: num_healpix_cells × ae_local_num_queries × ae_global_dim_embed)
+        is used exclusively by the encoder to build the global query tokens.  It is not
+        touched by the forecast engine or physical decoder, so it can be offloaded for the
+        entire multi-step rollout — saving ~1–2 GiB of HBM per GPU depending on config.
+
+        ``pe_embed`` (shape: max_tokens_local × ae_local_dim_embed) is similarly encoder-only
+        and offloaded here, though its contribution is negligible (~65 KiB).
+        """
+        if self.pe_global is not None:
+            self.pe_global.data = self.pe_global.data.cpu()
+        if self.pe_embed is not None:
+            self.pe_embed.data = self.pe_embed.data.cpu()
+
+    def load_encoder_params_to_device(self, device) -> None:
+        """Reload encoder-only ModelParams tensors onto *device* before the encoder forward.
+
+        Counterpart to offload_encoder_params().  Called immediately before chunk 0's
+        model forward so that the encoder finds ``pe_global`` on the correct device.
+        """
+        if self.pe_global is not None:
+            self.pe_global.data = self.pe_global.data.to(device, non_blocking=True)
+        if self.pe_embed is not None:
+            self.pe_embed.data = self.pe_embed.data.to(device, non_blocking=True)
+
     def reset_parameters(self, cf: Config) -> "ModelParams":
         """Creates positional embedding for each grid point for each stream used after stream
         embedding, positional embedding for all stream assimilated cell-level local embedding,
@@ -936,6 +963,11 @@ class Model(torch.nn.Module):
                         "fe_diffusion_predict_residual", False
                     )
                     for i, toks in enumerate(tokens):
+                        # tokens may be CPU tensors (offloaded by _run_ode to avoid
+                        # accumulating num_steps × ~1 GiB of non-releasable GPU memory).
+                        # Reload each step individually just before use.
+                        if not toks.is_cuda:
+                            toks = toks.to(cond.device, non_blocking=True)
                         toks_abs = cond + toks if predict_residual else toks
                         output = self.predict_decoders(
                             model_params, step, toks_abs, source_samples, output, out_step=i
@@ -946,7 +978,11 @@ class Model(torch.nn.Module):
                     # Feed the final denoised state back as conditioning for the next step.
                     # Pass tokens[-1] forward so inference diagnostics have a reference point;
                     # inference_forward always starts from pure noise regardless.
-                    final_abs = cond + tokens[-1] if predict_residual else tokens[-1]
+                    # tokens[-1] is CPU-offloaded; reload to GPU before storing as conditioning.
+                    _final = tokens[-1]
+                    if not _final.is_cuda:
+                        _final = _final.to(cond.device, non_blocking=True)
+                    final_abs = cond + _final if predict_residual else _final
                     source_samples.samples[0].meta_info["LATENT_CONDITIONING_TOKENS"] = final_abs
                     # NOTE: This is precautionary, might need to be handled differently.
                     # It should not be the same as conditioning tokens.
@@ -961,7 +997,10 @@ class Model(torch.nn.Module):
                 ):
                     if isinstance(tokens, list):
                         # diffusion_rollout=True: discard intermediate steps, keep the final state.
+                        # _run_ode offloads trajectory steps to CPU; reload the final one.
                         tokens = tokens[-1]  # (1, healpix_cells, embed_dim)
+                        if not tokens.is_cuda:
+                            tokens = tokens.cuda()
                     cond = source_samples.samples[0].meta_info["LATENT_CONDITIONING_TOKENS"]
                     predict_residual = self.cf.get("fe_diffusion_predict_residual", False)
                     # Apply residual correction; broadcasts cond (1, H, D) over all N members.
@@ -1227,20 +1266,27 @@ class Model(torch.nn.Module):
 
             # embed token coords
             tc_embed = self.embed_target_coords[stream_name]
-            tc_tokens = checkpoint(tc_embed, t_coords, use_reentrant=False)
+
+            # For the Linear decoder we need tc_tokens upfront; for the TTE decoder we
+            # embed per-group inside the loop to avoid materialising the full
+            # (n_target_points × D_embed) tensor (e.g. 3.25 M × D ≈ 734 MiB for ERA5).
+            if self.cf.decoder_type == "Linear":
+                tc_tokens = checkpoint(tc_embed, t_coords, use_reentrant=False)
+            else:
+                tc_tokens = None  # embedded on-demand per group below
 
             # skip when coordinate embeddings yields nan (i.e. the coord embedding network diverged)
-            if torch.isnan(tc_tokens).any():
+            if tc_tokens is not None and torch.isnan(tc_tokens).any():
                 logger.warning(
                     (
                         f"Skipping prediction for {stream_name} because",
                         f" of {torch.isnan(tc_tokens).sum()} NaN in tc_tokens.",
                     )
                 )
-                pred = torch.tensor([], device=tc_tokens.device)
+                pred = torch.tensor([], device=t_coords.device)
 
             # skip empty lengths
-            elif tc_tokens.shape[0] == 0:
+            elif tc_tokens is not None and tc_tokens.shape[0] == 0:
                 pred = torch.tensor([], device=tc_tokens.device)
 
             else:
@@ -1282,15 +1328,25 @@ class Model(torch.nn.Module):
                             continue
                         zero = torch.zeros(1, dtype=tcls.dtype, device=tcls.device)
                         group_lens = torch.cat([zero, tcls[g_start:g_end]])
+                        # Embed only this group's coordinates (cell-independent MLP →
+                        # chunked result is identical to full-batch embedding).
+                        # This avoids materialising the full (n_points × D_embed) tensor
+                        # for large streams such as ERA5.
+                        tc_tokens_group_input = (
+                            tc_tokens[p_start:p_end]  # Linear path: already embedded
+                            if tc_tokens is not None
+                            else checkpoint(tc_embed, t_coords[p_start:p_end], use_reentrant=False)
+                        )
                         tc_tokens_group = self.target_token_engines[stream_name](
                             latent=tokens_nbors[
                                 g_start * nbors_per_group : g_end * nbors_per_group
                             ],
-                            output=tc_tokens[p_start:p_end],
+                            output=tc_tokens_group_input,
                             latent_lens=tokens_nbors_lens[: g_end - g_start + 1],
                             output_lens=group_lens,
                             coordinates=t_coords[p_start:p_end],
                         )
+                        del tc_tokens_group_input
 
                         # final prediction head to map back to physical space
                         preds.append(self.pred_heads[stream_name](tc_tokens_group))

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -992,9 +992,19 @@ class Model(torch.nn.Module):
                             member_preds.setdefault(sname, []).extend(pred_tuple)
                     # Concatenate along dim 0: (N, n_points, channels),
                     # wrap in 1-tuple (batch_size=1).
+                    # Optionally offload the decoded physical predictions to CPU. During a
+                    # rollout the per-step, per-member full-map predictions would otherwise
+                    # accumulate on the GPU across all forecast steps (they are only consumed
+                    # later by write_output/loss, both of which tolerate CPU tensors), so
+                    # offloading keeps peak GPU memory independent of num_steps / ensemble
+                    # size. The rolled-forward latent conditioning stays on the GPU below.
+                    offload_preds = self.cf.get("offload_predictions_to_cpu", True)
                     for sname, preds_list in member_preds.items():
+                        member_pred = torch.cat(preds_list, dim=0)
+                        if offload_preds:
+                            member_pred = member_pred.to("cpu", non_blocking=True)
                         output.add_physical_prediction(
-                            output.chunk_idx(step), sname, (torch.cat(preds_list, dim=0),)
+                            output.chunk_idx(step), sname, (member_pred,)
                         )
                     # Carry the rolled-forward state so a following forecast chunk resumes from
                     # here instead of re-encoding the source window and restarting the forecast.

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -831,11 +831,37 @@ class Model(torch.nn.Module):
             # leave it untouched and only unwrap the step dimension.
             if from_encoder:
                 # tokens[:,0] = t (most recent), tokens[:,1] = t-1, ..., tokens[:,-1] = t-(T-1)
-                if self.cf.stage == "inference":
+                if self.cf.stage == "inference" and tokens.shape[1] == 1 and forecast_offset == 1:
+                    # Single-input-step inference path: test_config.model_input.forecasting.
+                    # num_steps_input=1 paired with test_config.forecast.offset=1, so the
+                    # diffusion model's single forecast step lines up with a deterministic
+                    # offset=1 model's +1-step lead time. There is no older step to sum over —
+                    # the sole loaded step IS the conditioning.
+                    print(
+                        "Using the sole loaded step as conditioning token for inference "
+                        "(offset=1, num_steps_input=1)."
+                    )
+                    conditioning_tokens = tokens[:, 0]
+                elif self.cf.stage == "inference":
+                    assert tokens.shape[1] > 1, (
+                        "Diffusion inference with fe_diffusion_model_conditioning='forecast' got "
+                        f"only one loaded input step (tokens.shape[1]=1) but forecast.offset="
+                        f"{forecast_offset} != 1. The single-input-step inference path is only "
+                        "defined for offset=1, num_steps_input=1 (used to align the diffusion "
+                        "model's first forecast step with a deterministic offset=1 model's lead "
+                        "time). Check test_config.forecast.offset and "
+                        "test_config.model_input.forecasting.num_steps_input."
+                    )
                     print("Using most recent steps as conditioning tokens for inference.")
                     # conditioning_tokens = tokens[:, :-1].sum(axis=1)
                     conditioning_tokens = tokens[:, 1:].sum(axis=1)
                 else:
+                    assert tokens.shape[1] > 1, (
+                        "Diffusion training with fe_diffusion_model_conditioning='forecast' "
+                        "requires at least 2 loaded input steps (one denoising target + one "
+                        f"conditioning step); got tokens.shape[1]={tokens.shape[1]}. Check "
+                        "training_config.model_input.forecasting.num_steps_input."
+                    )
                     # Conditioning: all older context steps [t-1, ..., t-(T-1)];
                     # denoising target: t (newest)
                     conditioning_tokens = tokens[:, 1:].sum(axis=1)

--- a/src/weathergen/model/model_interface.py
+++ b/src/weathergen/model/model_interface.py
@@ -318,6 +318,12 @@ def load_model(cf, model, device, run_id: str, with_ddp: bool, with_fsdp: bool, 
             # Get all modules for quick lookup and initialize the new ones
             all_modules = dict(model.named_modules())
             for path in root_new_modules:
+                if path not in all_modules:
+                    # FSDP v2 state_dict() can emit duplicate parameter paths for shared modules
+                    # (e.g. MLP.lnorm == MLP.layers[0]). named_modules() deduplicates and only
+                    # retains the canonical path (layers.0), so the alias (lnorm) is absent.
+                    # The module will be initialised via its canonical path, so skip here.
+                    continue
                 if is_root():
                     logger.info(f"Initializing new module not found in checkpoint: {path}")
                 module_to_init = all_modules[path]

--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -19,6 +19,10 @@ import time
 import traceback
 from pathlib import Path
 
+# Verify NCCL env vars are visible before any NCCL/CUDA init
+for _var in ("NCCL_CUMEM_ENABLE", "NCCL_MAX_NCHANNELS", "NCCL_P2P_DISABLE"):
+    print(f"[env-check] {_var}={os.environ.get(_var, 'NOT SET')}", flush=True)
+
 import weathergen.common.config as config
 import weathergen.utils.cli as cli
 from weathergen.common.logger import init_loggers

--- a/src/weathergen/train/loss_modules/loss_module_latent_diffusion.py
+++ b/src/weathergen/train/loss_modules/loss_module_latent_diffusion.py
@@ -136,8 +136,14 @@ class LossLatentDiffusion(LossModuleBase):
             target_tokens_all = [tokens[:, num_extra_tokens:] for tokens in target_tokens_all]
 
         # In ensemble mode predict_latent is not called, so latent predictions are absent.
-        # Return a zero loss rather than crashing.
-        if not pred_tokens_all:
+        # In diffusion-rollout mode the model instead stores a per-step `latent_state` to
+        # carry the rolled-forward state forward (for continuation / physical decoding), not
+        # a per-fstep denoising prediction — so pred and target fstep counts do not
+        # correspond and the latent diffusion loss is not meaningful. In all of these
+        # inference-only cases, return a zero loss rather than crashing.
+        is_ensemble = self.cf.get("fe_diffusion_num_ensemble_members", 1) > 1
+        is_rollout = self.cf.get("diffusion_rollout", False)
+        if not pred_tokens_all or is_ensemble or is_rollout:
             nan = torch.tensor(torch.nan).to(self.device)
             return LossValues(
                 loss=torch.zeros(1, device=self.device),

--- a/src/weathergen/train/loss_modules/loss_module_physical.py
+++ b/src/weathergen/train/loss_modules/loss_module_physical.py
@@ -265,6 +265,12 @@ class LossPhysical(LossModuleBase):
                     assert len(target_idx) == 1
                     target_idx = target_idx[0]
 
+                    # Predictions may be offloaded to CPU (e.g. diffusion rollout inference,
+                    # offload_predictions_to_cpu) to bound peak GPU memory. Move this single
+                    # prediction back to the compute device for the loss; a no-op when it is
+                    # already there.
+                    pred = pred.to(self.device, non_blocking=True)
+
                     # current target data
                     target = targets_batch[target_idx]
                     target_times = targets_times_batch[target_idx]

--- a/src/weathergen/train/loss_modules/loss_module_physical.py
+++ b/src/weathergen/train/loss_modules/loss_module_physical.py
@@ -224,8 +224,11 @@ class LossPhysical(LossModuleBase):
 
             # TODO: make nicer
             output_step_loss_weights = self._get_output_step_weights(len(targets.output_idxs))
-            if len(targets.physical) - len(targets.output_idxs) > 0:
-                output_step_loss_weights.insert(0, None)
+            # leading placeholder fsteps (forecast.offset > 0) carry no target and no
+            # prediction; give each of them a None weight so the weight list stays aligned
+            # with the fstep index used below
+            num_leading_pad = len(targets.physical) - len(targets.output_idxs)
+            output_step_loss_weights = [None] * max(0, num_leading_pad) + output_step_loss_weights
 
             # loss_stream: loss for given stream
             loss_stream = torch.tensor(0.0, device=self.device, requires_grad=True)

--- a/src/weathergen/train/target_and_aux_diffusion.py
+++ b/src/weathergen/train/target_and_aux_diffusion.py
@@ -12,6 +12,9 @@ from weathergen.train.target_and_aux_module_base import (
 
 
 class DiffusionLatentTargetEncoder(TargetAndAuxModuleBase):
+    # compute() encodes the target samples to build the latent diffusion target
+    encodes_target_samples = True
+
     def __init__(self, cf, encoder, is_model_sharded=True):
         # Todo: make sure this is a frozen clone or forward without gradients in compute()
         self.cf = cf

--- a/src/weathergen/train/target_and_aux_module_base.py
+++ b/src/weathergen/train/target_and_aux_module_base.py
@@ -65,6 +65,11 @@ class TargetAuxOutput:
 
 
 class TargetAndAuxModuleBase:
+    # True for calculators that run an encoder over the target samples in compute(), which
+    # needs the target samples' *source* view on the device. Chunked inference otherwise
+    # leaves that view on the host to save memory, so it consults this flag before deciding.
+    encodes_target_samples: bool = False
+
     def __init__(self, cf, model, **kwargs):
         pass
 

--- a/src/weathergen/train/target_and_aux_ssl_teacher.py
+++ b/src/weathergen/train/target_and_aux_ssl_teacher.py
@@ -38,6 +38,9 @@ class EncoderTeacher(TargetAndAuxModuleBase):
     Subclasses must implement forward_teacher().
     """
 
+    # forward_teacher() encodes the target samples to build the SSL targets
+    encodes_target_samples = True
+
     def __init__(self, teacher_model, training_cfg, **kwargs):
         self.teacher_model = teacher_model
 

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -276,24 +276,28 @@ class Trainer(TrainerBase):
         mini_epoch,
         bidx,
         targets_and_auxs,
-        is_diffusion: bool = False,
+        is_diffusion_trajectory: bool = False,
     ) -> ModelOutput:
         """Run the rollout in chunks and assemble the predictions for the whole batch."""
         forecast_cfg = mode_cfg.get("forecast", {})
 
         output_idxs = batch.get_output_idxs()
-        # Diffusion consumes the output's fstep dimension for the ODE denoising trajectory,
-        # which neither the reassembly below nor a per-chunk write can handle. Roll out in a
-        # single chunk and let validate() write the output as it did before chunking.
+        # Trajectory-mode diffusion (diffusion_rollout=False) consumes the output's fstep
+        # dimension for the ODE denoising trajectory, which neither the reassembly below nor a
+        # per-chunk write can handle. Roll out in a single chunk and let validate() write the
+        # output as it did before chunking. A diffusion *rollout* keeps the ordinary fstep
+        # layout and carries its state across chunks, so it chunks like any other forecast.
         chunk_size = (
-            len(output_idxs) if is_diffusion else forecast_cfg.get("chunk_size", len(output_idxs))
+            len(output_idxs)
+            if is_diffusion_trajectory
+            else forecast_cfg.get("chunk_size", len(output_idxs))
         )
         chunks = self._get_forecast_step_chunks(output_idxs, chunk_size)
 
         num_samples_write = mode_cfg.get("output", {}).get("num_samples", 0) * batch_size
         # This assumes that you only have a physical loss, else this breaks
         compute_full_loss = mode_cfg.get("compute_full_validation_loss", True)
-        should_write_output = not is_diffusion and bidx < num_samples_write
+        should_write_output = not is_diffusion_trajectory and bidx < num_samples_write
         if should_write_output:
             denormalize_data_fct = (
                 (lambda x0, x1: x1)
@@ -318,8 +322,11 @@ class Trainer(TrainerBase):
         forecast_chunk = batch.get_source_samples()
        
         if not compute_full_loss:
-            target_aux_chunk = copy.deepcopy(targets_and_auxs[physical_loss_names[0]])
-        
+            # bound here, not inside the write branch: the trailing trim below needs it on
+            # every batch, including the ones past output.num_samples that write nothing
+            target_aux = targets_and_auxs[physical_loss_names[0]]
+            target_aux_chunk = copy.deepcopy(target_aux)
+
         for chunk_idx, chunk in enumerate(chunks):
             if not compute_full_loss:
                 batch.to_device_for_output_chunk(self.device, chunk)
@@ -339,8 +346,9 @@ class Trainer(TrainerBase):
 
             if should_write_output:
                 if not compute_full_loss:
-                    target_aux = targets_and_auxs[physical_loss_names[0]]
-                    target_aux_chunk.physical = [None for _ in range(chunk[0])] + [target_aux.physical[step] for step in chunk]
+                    target_aux_chunk.physical = [None for _ in range(chunk[0])] + [
+                        target_aux.physical[step] for step in chunk
+                    ]
                     target_aux_chunk.output_idxs = chunk
                     target_output = { physical_loss_names[0]: target_aux_chunk }
                 else:
@@ -370,12 +378,16 @@ class Trainer(TrainerBase):
             if not compute_full_loss:
                 batch.clear_output_chunk_coordinates(chunk)
 
-        if is_diffusion:
+        if is_diffusion_trajectory:
             # single chunk; its fstep dimension is the trajectory, not forecast steps
             return forecast_chunk, targets_and_auxs
 
         # Data for validation purposes => accumulates in memory!?
-        preds = ModelOutput(chunk, output_idxs[0], batch.get_source_samples())
+        # compute_full_loss keeps every chunk's predictions, so preds spans all output steps;
+        # otherwise only the last chunk survives the loop and preds spans just that chunk.
+        # (These coincide when there is a single chunk, which is why chunk alone used to do.)
+        covered_steps = output_idxs if compute_full_loss else chunk
+        preds = ModelOutput(covered_steps, output_idxs[0], batch.get_source_samples())
         assert len(physical) == len(preds.physical), (
             f"Chunks cover {len(physical)} forecast steps, expected {len(preds.physical)}."
         )
@@ -813,6 +825,11 @@ class Trainer(TrainerBase):
         self.model.eval()
 
         is_diffusion = cf.get("fe_diffusion_model", False)
+        # Only trajectory-mode diffusion (diffusion_rollout=False) hands back a ModelOutput
+        # whose fstep dimension is the ODE trajectory rather than the forecast steps. That
+        # layout is what forces a single chunk and a deferred, whole-batch write below; a
+        # diffusion rollout is an ordinary forecast as far as chunking and IO are concerned.
+        is_diffusion_trajectory = is_diffusion and not cf.get("diffusion_rollout", False)
         noise_levels = list(mode_cfg.get("validation_noise_levels", [0.0]))
         if not is_diffusion:
             noise_levels = [0.0]
@@ -849,13 +866,22 @@ class Trainer(TrainerBase):
                 ) as pbar:
                     for bidx, batch in enumerate(dataset_val_iter):
                         compute_full_loss = mode_cfg.get("compute_full_validation_loss", True)
-                        if compute_full_loss or is_diffusion:
+                        if compute_full_loss or is_diffusion_trajectory:
                             batch.to_device(self.device)
                         else:
                             output_idxs = batch.get_output_idxs()
                             chunk_size = mode_cfg.forecast.get("chunk_size", len(output_idxs))
                             chunks = self._get_forecast_step_chunks(output_idxs, chunk_size)
-                            batch.to_device_for_chunked_inference(self.device, chunks[-1])
+                            # calculators that encode the target window (diffusion latent
+                            # target, SSL teachers) read the target samples' source view
+                            needs_target_source = any(
+                                getattr(c, "encodes_target_samples", False)
+                                for c in self.target_and_aux_calculators_val.values()
+                            )
+                            batch.to_device_for_chunked_inference(
+                                self.device, chunks[-1], include_target_source=needs_target_source
+                            )
+                            print(">>>>>>> chunk_size: " + str(chunk_size))
 
                         # evaluate model
                         with torch.autocast(
@@ -883,24 +909,30 @@ class Trainer(TrainerBase):
                                 mini_epoch,
                                 bidx,
                                 targets_and_auxs,
-                                is_diffusion,
+                                is_diffusion_trajectory,
                             )
-                            # Diffusion inference inflates the model output's fstep
-                            # dimension to one entry per ODE step (the denoising
-                            # trajectory). The physical target is identical for every
-                            # such step, so replicate target/aux entries to keep the
+                            # Both diffusion modes produce more preds fsteps than target
+                            # entries: trajectory mode inflates the fstep dimension to one
+                            # entry per ODE step, and a rollout gets a single encoder latent
+                            # target for all T forecast steps. The target is identical for
+                            # every such step, so replicate target/aux entries to keep the
                             # downstream loss calculator and validation IO aligned.
                             if is_diffusion:
                                 _expand_targets_to_match_preds(preds, targets_and_auxs)
 
-                            # Write output for diffusion — _process_validation_chunks
-                            # skips writing when is_diffusion=True because chunked IO
-                            # is incompatible with the ODE trajectory fstep layout.
-                            # Do it here instead, mirroring the non-diffusion path.
+                            # Write output for trajectory-mode diffusion —
+                            # _process_validation_chunks skips writing there because chunked
+                            # IO is incompatible with the ODE trajectory fstep layout. Do it
+                            # here instead, mirroring the non-diffusion path. A diffusion
+                            # rollout has already been written chunk by chunk.
                             num_samples_write = (
                                 mode_cfg.get("output", {}).get("num_samples", 0) * batch_size
                             )
-                            if is_diffusion and _noise_idx == 0 and bidx < num_samples_write:
+                            if (
+                                is_diffusion_trajectory
+                                and _noise_idx == 0
+                                and bidx < num_samples_write
+                            ):
                                 denormalize_data_fct = (
                                     (lambda x0, x1: x1)
                                     if mode_cfg.get("output", {}).get("normalized_samples", False)

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -310,14 +310,15 @@ class Trainer(TrainerBase):
             name for name, loss_cfg in mode_cfg.losses.items()
             if loss_cfg.type == "LossPhysical"
         ]
-        assert len(physical_loss_names) == 1, (
+        assert len(physical_loss_names) == 1 or chunk_size == len(output_idxs), (
             "Chunked non-full validation requires one LossPhysical term."
         )
 
         physical, latent = [], []
         forecast_chunk = batch.get_source_samples()
-        
-        target_aux_chunk = copy.deepcopy(targets_and_auxs[physical_loss_names[0]])
+       
+        if not compute_full_loss:
+            target_aux_chunk = copy.deepcopy(targets_and_auxs[physical_loss_names[0]])
         
         for chunk_idx, chunk in enumerate(chunks):
             if not compute_full_loss:
@@ -337,10 +338,13 @@ class Trainer(TrainerBase):
                 )
 
             if should_write_output:
-                target_aux = targets_and_auxs[physical_loss_names[0]]
-                target_aux_chunk.physical = [None for _ in range(chunk[0])] + [target_aux.physical[step] for step in chunk]
-                target_aux_chunk.output_idxs = chunk
-                # this modifies targets_and_auxs in place
+                if not compute_full_loss:
+                    target_aux = targets_and_auxs[physical_loss_names[0]]
+                    target_aux_chunk.physical = [None for _ in range(chunk[0])] + [target_aux.physical[step] for step in chunk]
+                    target_aux_chunk.output_idxs = chunk
+                    target_output = { physical_loss_names[0]: target_aux_chunk }
+                else:
+                    target_output = targets_and_auxs
                 write_output(
                     self.cf,
                     mode_cfg,
@@ -350,7 +354,7 @@ class Trainer(TrainerBase):
                     denormalize_data_fct,
                     batch,
                     forecast_chunk,
-                    { physical_loss_names[0]: target_aux_chunk },
+                    target_output
                 )
 
             if compute_full_loss:

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -318,8 +318,11 @@ class Trainer(TrainerBase):
         forecast_chunk = batch.get_source_samples()
        
         if not compute_full_loss:
-            target_aux_chunk = copy.deepcopy(targets_and_auxs[physical_loss_names[0]])
-        
+            # shallow copy is sufficient: .physical and .output_idxs are reassigned before
+            # any use, and the shared per-step target dicts are only read downstream
+            target_aux = targets_and_auxs[physical_loss_names[0]]
+            target_aux_chunk = copy.copy(target_aux)
+
         for chunk_idx, chunk in enumerate(chunks):
             if not compute_full_loss:
                 batch.to_device_for_output_chunk(self.device, chunk)
@@ -339,7 +342,6 @@ class Trainer(TrainerBase):
 
             if should_write_output:
                 if not compute_full_loss:
-                    target_aux = targets_and_auxs[physical_loss_names[0]]
                     target_aux_chunk.physical = [None for _ in range(chunk[0])] + [target_aux.physical[step] for step in chunk]
                     target_aux_chunk.output_idxs = chunk
                     target_output = { physical_loss_names[0]: target_aux_chunk }
@@ -427,6 +429,10 @@ class Trainer(TrainerBase):
             self.dataset, **loader_params, sampler=None
         )
 
+        # Inference runs under torch.no_grad with no gradient synchronization, so the
+        # DDP/FSDP wrappers are not needed; skipping them avoids allocating DDP gradient
+        # buckets (~one model-size buffer per rank). The process group set up by torchrun
+        # is still used for per-rank data sharding.
         self.model, self.model_params = init_model_and_shard(
             cf,
             self.dataset,
@@ -434,8 +440,8 @@ class Trainer(TrainerBase):
             mini_epoch_contd,
             self.test_cfg.training_mode,
             devices[0],
-            cf.with_ddp,
-            cf.with_fsdp,
+            with_ddp=False,
+            with_fsdp=cf.with_fsdp,
         )
 
         # get target_aux calculators for different loss terms

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -446,6 +446,12 @@ class Trainer(TrainerBase):
         if is_root():
             config.save(self.cf, mini_epoch=0)
 
+        if self.test_cfg.get("skip_target_values", False):
+            logger.warning(
+                "skip_target_values is active: target values are neither read nor written "
+                "(the output zarr has no target datasets) and no validation losses are computed."
+            )
+
         logger.info(f"Starting inference with id={self.cf.general.run_id}.")
 
         # inference validation set
@@ -456,6 +462,16 @@ class Trainer(TrainerBase):
         # general initalization
         self.init(cf, devices)
         cf = self.cf
+
+        # skip_target_values is inference-only: without target values there is nothing
+        # to train against and validation losses would be meaningless
+        if self.training_cfg.get("skip_target_values", False) or self.validation_cfg.get(
+            "skip_target_values", False
+        ):
+            raise ValueError(
+                "skip_target_values is only allowed in inference (test_config), "
+                "not in training_config or validation_config."
+            )
 
         device_type = torch.accelerator.current_accelerator()
         self.device = torch.device(f"{device_type}:{cf.local_rank}")
@@ -918,11 +934,14 @@ class Trainer(TrainerBase):
                                     targets_and_auxs,
                                 )
 
-                        _ = self.loss_calculator_val.compute_loss(
-                            preds=preds,
-                            targets_and_aux=targets_and_auxs,
-                            metadata=extract_batch_metadata(batch),
-                        )
+                        # skip_target_values: target values are not read (zero width),
+                        # so no loss can be computed
+                        if not mode_cfg.get("skip_target_values", False):
+                            _ = self.loss_calculator_val.compute_loss(
+                                preds=preds,
+                                targets_and_aux=targets_and_auxs,
+                                metadata=extract_batch_metadata(batch),
+                            )
                         pbar.update(batch_size * self.cf.world_size)
 
                         if (bidx * batch_size) > mode_cfg.samples_per_mini_epoch:

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -268,6 +268,62 @@ class Trainer(TrainerBase):
             for start in range(0, len(output_idxs), chunk_size)
         ]
 
+    def _offload_encoder_weights(self) -> None:
+        """Move encoder parameter storage to CPU after the encoder has run.
+
+        FSDP2 uses lazy all-gather: it only fetches parameters for modules that are
+        actually called during a forward pass.  Continuation chunks (chunk_idx > 0)
+        never call the encoder — they resume from the cached latent state — so FSDP2
+        will never try to all-gather the encoder shards while they are on CPU.
+
+        **FSDP2 DTensor parameters are intentionally skipped.**  Some encoder parameters
+        (e.g. stream embedders in embed_engine) live in the *root* FSDP group rather than
+        in individually-sharded sub-modules.  Moving their _local_tensor to CPU outside
+        FSDP's knowledge causes FSDP's root pre-forward to trigger a spurious 1.95 GiB
+        all-gather on the next chunk.  Safe offloading of DTensor params would require
+        CPUOffload configured at shard time; we limit this method to the non-FSDP path.
+        """
+        try:
+            from torch.distributed.tensor import DTensor
+
+            base_model = getattr(self.model, "module", self.model)
+            encoder = getattr(base_model, "encoder", None)
+            if encoder is None:
+                return
+            for param in encoder.parameters():
+                # DTensor = FSDP-managed shard — do NOT move; see docstring.
+                if isinstance(param, DTensor):
+                    continue
+                if param.is_cuda:
+                    param.data = param.data.cpu()
+            torch.cuda.empty_cache()
+        except Exception:
+            pass  # best-effort; do not crash inference
+
+    def _reload_encoder_weights(self) -> None:
+        """Reload encoder parameter storage onto the inference device.
+
+        Counterpart to ``_offload_encoder_weights()``.  Called just before chunk 0's
+        model forward so that the encoder can run a fresh all-gather from its local
+        (now GPU-resident) shards.  DTensor parameters are skipped for the same reason
+        as in _offload_encoder_weights.
+        """
+        try:
+            from torch.distributed.tensor import DTensor
+
+            base_model = getattr(self.model, "module", self.model)
+            encoder = getattr(base_model, "encoder", None)
+            if encoder is None:
+                return
+            device = self.device
+            for param in encoder.parameters():
+                if isinstance(param, DTensor):
+                    continue  # FSDP-managed; do not touch
+                if not param.is_cuda:
+                    param.data = param.data.to(device, non_blocking=True)
+        except Exception:
+            pass  # best-effort
+
     def _process_validation_chunks(
         self,
         batch,
@@ -322,14 +378,41 @@ class Trainer(TrainerBase):
         forecast_chunk = batch.get_source_samples()
        
         if not compute_full_loss:
-            # bound here, not inside the write branch: the trailing trim below needs it on
-            # every batch, including the ones past output.num_samples that write nothing
+            # shallow copy is sufficient: .physical and .output_idxs are reassigned before
+            # any use, and the shared per-step target dicts are only read downstream
             target_aux = targets_and_auxs[physical_loss_names[0]]
-            target_aux_chunk = copy.deepcopy(target_aux)
+            target_aux_chunk = copy.copy(target_aux)
 
         for chunk_idx, chunk in enumerate(chunks):
+            # Return PyTorch's reserved-but-unallocated HBM cache to CUDA at the start
+            # of every chunk.  This is critical for chunk 0: the previous batch's latent
+            # conditioning tensor (~1 GiB) was freed by CPython ref-counting when 'batch'
+            # was reassigned at the top of the outer loop, but it sits in PyTorch's
+            # reserved cache until empty_cache() is called.  Without this, loading the new
+            # batch's source tokens (~444 MiB) fails even though the total freed+free
+            # exceeds the request.
+            torch.cuda.empty_cache()
+
             if not compute_full_loss:
                 batch.to_device_for_output_chunk(self.device, chunk)
+
+            # Load source tokens to GPU just before the encoder runs (chunk 0 only).
+            # They were intentionally left on CPU by to_device_for_chunked_inference
+            # (include_source_tokens=False) to keep peak GPU HBM free during the
+            # DataLoader prefetch and pre-forward target computation.
+            if chunk_idx == 0 and not compute_full_loss:
+                # Also reload encoder-only ModelParams embeddings (pe_global ~1-2 GiB,
+                # pe_embed ~65 KiB) that were offloaded after the previous batch.
+                if is_root():
+                    print(
+                        f"[memory] before encoder params + source tokens "
+                        f"rank={self.cf.rank} device={self.device}\n"
+                        + torch.cuda.memory_summary(device=self.device, abbreviated=True),
+                        flush=True,
+                    )
+                self.model_params.load_encoder_params_to_device(self.device)
+                self._reload_encoder_weights()  # bring encoder shards back to GPU
+                batch.load_source_tokens_to_device(self.device)
 
             if self.ema_model is None:
                 forecast_chunk = self.model(
@@ -343,6 +426,25 @@ class Trainer(TrainerBase):
                     forecast_chunk,
                     chunk,
                 )
+
+            # After the encoder has run on the first chunk, observation source tokens
+            # are no longer needed on GPU (continuation chunks only use the latent
+            # state and decoder coordinates).  Offloading them immediately keeps GPU
+            # memory constant regardless of the number of forecast steps.
+            if chunk_idx == 0 and not compute_full_loss:
+                batch.offload_source_tokens()
+                # Drop the now-CPU source tensors entirely (source_tokens_cells /
+                # source_tokens_lens / source_idxs_embed / source_raw).  target_coords
+                # and meta_info (LATENT_CONDITIONING_TOKENS) are preserved.
+                batch.drop_source_observations()
+                # Offload encoder-only ModelParams (pe_global ~1-2 GiB) — not needed
+                # by the forecast engine or decoder during the rollout.
+                self.model_params.offload_encoder_params()
+                # Offload encoder weight shards (~244 MiB FSDP-sharded / ~975 MiB full).
+                # FSDP2's lazy all-gather means it will not touch them on continuation
+                # chunks; they are reloaded by _reload_encoder_weights before the next
+                # sample's encoder forward.
+                self._offload_encoder_weights()
 
             if should_write_output:
                 if not compute_full_loss:
@@ -370,7 +472,9 @@ class Trainer(TrainerBase):
                 latent += forecast_chunk.latent
             elif chunk_idx == len(chunks) - 1:
                 physical = forecast_chunk.physical
-                latent = forecast_chunk.latent
+                # Latent states are only needed for loss computation; skip accumulation
+                # when losses are not computed (skip_target_values or chunked mode).
+                latent = [] if mode_cfg.get("skip_target_values", False) else forecast_chunk.latent
             else:
                 forecast_chunk.physical.clear()
                 forecast_chunk.latent = [forecast_chunk.latent[-1]]
@@ -450,6 +554,13 @@ class Trainer(TrainerBase):
             cf.with_fsdp,
         )
 
+        # Pre-emptively offload encoder-only ModelParams (pe_global ~1-2 GiB) to CPU.
+        # They will be reloaded just-in-time before each sample's encoder forward and
+        # offloaded again immediately after, keeping them off GPU during decoding and
+        # between samples.
+        self.model_params.offload_encoder_params()
+        torch.cuda.empty_cache()
+
         # get target_aux calculators for different loss terms
         self.target_and_aux_calculators_val = self.get_target_aux_calculators(self.test_cfg)
 
@@ -457,6 +568,12 @@ class Trainer(TrainerBase):
 
         if is_root():
             config.save(self.cf, mini_epoch=0)
+
+        if self.test_cfg.get("skip_target_values", False):
+            logger.warning(
+                "skip_target_values is active: target values are neither read nor written "
+                "(the output zarr has no target datasets) and no validation losses are computed."
+            )
 
         logger.info(f"Starting inference with id={self.cf.general.run_id}.")
 
@@ -468,6 +585,16 @@ class Trainer(TrainerBase):
         # general initalization
         self.init(cf, devices)
         cf = self.cf
+
+        # skip_target_values is inference-only: without target values there is nothing
+        # to train against and validation losses would be meaningless
+        if self.training_cfg.get("skip_target_values", False) or self.validation_cfg.get(
+            "skip_target_values", False
+        ):
+            raise ValueError(
+                "skip_target_values is only allowed in inference (test_config), "
+                "not in training_config or validation_config."
+            )
 
         device_type = torch.accelerator.current_accelerator()
         self.device = torch.device(f"{device_type}:{cf.local_rank}")
@@ -880,7 +1007,8 @@ class Trainer(TrainerBase):
                                 for c in self.target_and_aux_calculators_val.values()
                             )
                             batch.to_device_for_chunked_inference(
-                                self.device, chunks[-1], include_target_source=needs_target_source
+                                self.device, chunks[-1], include_target_source=needs_target_source,
+                                include_source_tokens=False,
                             )
                             print(">>>>>>> chunk_size: " + str(chunk_size))
 
@@ -896,6 +1024,12 @@ class Trainer(TrainerBase):
                                 target_aux,
                             ) in self.target_and_aux_calculators_val.items():
                                 target_idxs = get_target_idxs_from_cfg(mode_cfg, loss_name)
+                                # DiffusionLatentTargetEncoder calls the encoder on
+                                # target samples, which needs pe_embed / pe_global on
+                                # device.  Reload them if they were offloaded and the
+                                # calculator encodes target samples.
+                                if getattr(target_aux, "encodes_target_samples", False):
+                                    self.model_params.load_encoder_params_to_device(self.device)
                                 targets_and_auxs[loss_name] = target_aux.compute(
                                     self.cf.general.istep,
                                     batch.get_target_samples(target_idxs),
@@ -951,11 +1085,14 @@ class Trainer(TrainerBase):
                                     targets_and_auxs,
                                 )
 
-                        _ = self.loss_calculator_val.compute_loss(
-                            preds=preds,
-                            targets_and_aux=targets_and_auxs,
-                            metadata=extract_batch_metadata(batch),
-                        )
+                        # skip_target_values: target values are not read (zero width),
+                        # so no loss can be computed
+                        if not mode_cfg.get("skip_target_values", False):
+                            _ = self.loss_calculator_val.compute_loss(
+                                preds=preds,
+                                targets_and_aux=targets_and_auxs,
+                                metadata=extract_batch_metadata(batch),
+                            )
                         pbar.update(batch_size * self.cf.world_size)
 
                         if (bidx * batch_size) > mode_cfg.samples_per_mini_epoch:

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -870,7 +870,8 @@ class Trainer(TrainerBase):
                             batch.to_device(self.device)
                         else:
                             output_idxs = batch.get_output_idxs()
-                            chunk_size = mode_cfg.forecast.get("chunk_size", len(output_idxs))
+                            forecast_cfg = mode_cfg.get("forecast", {})
+                            chunk_size = forecast_cfg.get("chunk_size", len(output_idxs))
                             chunks = self._get_forecast_step_chunks(output_idxs, chunk_size)
                             # calculators that encode the target window (diffusion latent
                             # target, SSL teachers) read the target samples' source view

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -397,7 +397,16 @@ class Trainer(TrainerBase):
 
         if not compute_full_loss:
             # this modifies targets_and_auxs in place
-            target_aux_chunk.physical = [target_aux.physical[step] for step in chunk]
+            # The first chunk's ModelOutput keeps leading placeholder slots [0..forecast_offset)
+            # so that a slot index equals the global forecast step (see ModelOutput.__init__).
+            # Pad the trimmed targets the same way — with forecast.offset > 0 preds would
+            # otherwise be longer than the targets and the loss calculator's strict zip raises.
+            # Later chunks start at their own step, so the padding is empty for them.
+            num_leading_pad = chunk[0] - preds.forecast_steps[0]
+            target_aux_chunk.physical = [{} for _ in range(num_leading_pad)] + [
+                target_aux.physical[step] for step in chunk
+            ]
+            target_aux_chunk.output_idxs = chunk
             targets_and_auxs[physical_loss_names[0]] = target_aux_chunk
 
         return preds, targets_and_auxs

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -268,6 +268,62 @@ class Trainer(TrainerBase):
             for start in range(0, len(output_idxs), chunk_size)
         ]
 
+    def _offload_encoder_weights(self) -> None:
+        """Move encoder parameter storage to CPU after the encoder has run.
+
+        FSDP2 uses lazy all-gather: it only fetches parameters for modules that are
+        actually called during a forward pass.  Continuation chunks (chunk_idx > 0)
+        never call the encoder — they resume from the cached latent state — so FSDP2
+        will never try to all-gather the encoder shards while they are on CPU.
+
+        **FSDP2 DTensor parameters are intentionally skipped.**  Some encoder parameters
+        (e.g. stream embedders in embed_engine) live in the *root* FSDP group rather than
+        in individually-sharded sub-modules.  Moving their _local_tensor to CPU outside
+        FSDP's knowledge causes FSDP's root pre-forward to trigger a spurious 1.95 GiB
+        all-gather on the next chunk.  Safe offloading of DTensor params would require
+        CPUOffload configured at shard time; we limit this method to the non-FSDP path.
+        """
+        try:
+            from torch.distributed.tensor import DTensor
+
+            base_model = getattr(self.model, "module", self.model)
+            encoder = getattr(base_model, "encoder", None)
+            if encoder is None:
+                return
+            for param in encoder.parameters():
+                # DTensor = FSDP-managed shard — do NOT move; see docstring.
+                if isinstance(param, DTensor):
+                    continue
+                if param.is_cuda:
+                    param.data = param.data.cpu()
+            torch.cuda.empty_cache()
+        except Exception:
+            pass  # best-effort; do not crash inference
+
+    def _reload_encoder_weights(self) -> None:
+        """Reload encoder parameter storage onto the inference device.
+
+        Counterpart to ``_offload_encoder_weights()``.  Called just before chunk 0's
+        model forward so that the encoder can run a fresh all-gather from its local
+        (now GPU-resident) shards.  DTensor parameters are skipped for the same reason
+        as in _offload_encoder_weights.
+        """
+        try:
+            from torch.distributed.tensor import DTensor
+
+            base_model = getattr(self.model, "module", self.model)
+            encoder = getattr(base_model, "encoder", None)
+            if encoder is None:
+                return
+            device = self.device
+            for param in encoder.parameters():
+                if isinstance(param, DTensor):
+                    continue  # FSDP-managed; do not touch
+                if not param.is_cuda:
+                    param.data = param.data.to(device, non_blocking=True)
+        except Exception:
+            pass  # best-effort
+
     def _process_validation_chunks(
         self,
         batch,
@@ -322,14 +378,41 @@ class Trainer(TrainerBase):
         forecast_chunk = batch.get_source_samples()
        
         if not compute_full_loss:
-            # bound here, not inside the write branch: the trailing trim below needs it on
-            # every batch, including the ones past output.num_samples that write nothing
+            # shallow copy is sufficient: .physical and .output_idxs are reassigned before
+            # any use, and the shared per-step target dicts are only read downstream
             target_aux = targets_and_auxs[physical_loss_names[0]]
-            target_aux_chunk = copy.deepcopy(target_aux)
+            target_aux_chunk = copy.copy(target_aux)
 
         for chunk_idx, chunk in enumerate(chunks):
+            # Return PyTorch's reserved-but-unallocated HBM cache to CUDA at the start
+            # of every chunk.  This is critical for chunk 0: the previous batch's latent
+            # conditioning tensor (~1 GiB) was freed by CPython ref-counting when 'batch'
+            # was reassigned at the top of the outer loop, but it sits in PyTorch's
+            # reserved cache until empty_cache() is called.  Without this, loading the new
+            # batch's source tokens (~444 MiB) fails even though the total freed+free
+            # exceeds the request.
+            torch.cuda.empty_cache()
+
             if not compute_full_loss:
                 batch.to_device_for_output_chunk(self.device, chunk)
+
+            # Load source tokens to GPU just before the encoder runs (chunk 0 only).
+            # They were intentionally left on CPU by to_device_for_chunked_inference
+            # (include_source_tokens=False) to keep peak GPU HBM free during the
+            # DataLoader prefetch and pre-forward target computation.
+            if chunk_idx == 0 and not compute_full_loss:
+                # Also reload encoder-only ModelParams embeddings (pe_global ~1-2 GiB,
+                # pe_embed ~65 KiB) that were offloaded after the previous batch.
+                if is_root():
+                    print(
+                        f"[memory] before encoder params + source tokens "
+                        f"rank={self.cf.rank} device={self.device}\n"
+                        + torch.cuda.memory_summary(device=self.device, abbreviated=True),
+                        flush=True,
+                    )
+                self.model_params.load_encoder_params_to_device(self.device)
+                self._reload_encoder_weights()  # bring encoder shards back to GPU
+                batch.load_source_tokens_to_device(self.device)
 
             if self.ema_model is None:
                 forecast_chunk = self.model(
@@ -343,6 +426,25 @@ class Trainer(TrainerBase):
                     forecast_chunk,
                     chunk,
                 )
+
+            # After the encoder has run on the first chunk, observation source tokens
+            # are no longer needed on GPU (continuation chunks only use the latent
+            # state and decoder coordinates).  Offloading them immediately keeps GPU
+            # memory constant regardless of the number of forecast steps.
+            if chunk_idx == 0 and not compute_full_loss:
+                batch.offload_source_tokens()
+                # Drop the now-CPU source tensors entirely (source_tokens_cells /
+                # source_tokens_lens / source_idxs_embed / source_raw).  target_coords
+                # and meta_info (LATENT_CONDITIONING_TOKENS) are preserved.
+                batch.drop_source_observations()
+                # Offload encoder-only ModelParams (pe_global ~1-2 GiB) — not needed
+                # by the forecast engine or decoder during the rollout.
+                self.model_params.offload_encoder_params()
+                # Offload encoder weight shards (~244 MiB FSDP-sharded / ~975 MiB full).
+                # FSDP2's lazy all-gather means it will not touch them on continuation
+                # chunks; they are reloaded by _reload_encoder_weights before the next
+                # sample's encoder forward.
+                self._offload_encoder_weights()
 
             if should_write_output:
                 if not compute_full_loss:
@@ -370,7 +472,9 @@ class Trainer(TrainerBase):
                 latent += forecast_chunk.latent
             elif chunk_idx == len(chunks) - 1:
                 physical = forecast_chunk.physical
-                latent = forecast_chunk.latent
+                # Latent states are only needed for loss computation; skip accumulation
+                # when losses are not computed (skip_target_values or chunked mode).
+                latent = [] if mode_cfg.get("skip_target_values", False) else forecast_chunk.latent
             else:
                 forecast_chunk.physical.clear()
                 forecast_chunk.latent = [forecast_chunk.latent[-1]]
@@ -459,6 +563,13 @@ class Trainer(TrainerBase):
             cf.with_fsdp,
         )
 
+        # Pre-emptively offload encoder-only ModelParams (pe_global ~1-2 GiB) to CPU.
+        # They will be reloaded just-in-time before each sample's encoder forward and
+        # offloaded again immediately after, keeping them off GPU during decoding and
+        # between samples.
+        self.model_params.offload_encoder_params()
+        torch.cuda.empty_cache()
+
         # get target_aux calculators for different loss terms
         self.target_and_aux_calculators_val = self.get_target_aux_calculators(self.test_cfg)
 
@@ -466,6 +577,12 @@ class Trainer(TrainerBase):
 
         if is_root():
             config.save(self.cf, mini_epoch=0)
+
+        if self.test_cfg.get("skip_target_values", False):
+            logger.warning(
+                "skip_target_values is active: target values are neither read nor written "
+                "(the output zarr has no target datasets) and no validation losses are computed."
+            )
 
         logger.info(f"Starting inference with id={self.cf.general.run_id}.")
 
@@ -477,6 +594,16 @@ class Trainer(TrainerBase):
         # general initalization
         self.init(cf, devices)
         cf = self.cf
+
+        # skip_target_values is inference-only: without target values there is nothing
+        # to train against and validation losses would be meaningless
+        if self.training_cfg.get("skip_target_values", False) or self.validation_cfg.get(
+            "skip_target_values", False
+        ):
+            raise ValueError(
+                "skip_target_values is only allowed in inference (test_config), "
+                "not in training_config or validation_config."
+            )
 
         device_type = torch.accelerator.current_accelerator()
         self.device = torch.device(f"{device_type}:{cf.local_rank}")
@@ -889,7 +1016,8 @@ class Trainer(TrainerBase):
                                 for c in self.target_and_aux_calculators_val.values()
                             )
                             batch.to_device_for_chunked_inference(
-                                self.device, chunks[-1], include_target_source=needs_target_source
+                                self.device, chunks[-1], include_target_source=needs_target_source,
+                                include_source_tokens=False,
                             )
                             print(">>>>>>> chunk_size: " + str(chunk_size))
 
@@ -905,6 +1033,12 @@ class Trainer(TrainerBase):
                                 target_aux,
                             ) in self.target_and_aux_calculators_val.items():
                                 target_idxs = get_target_idxs_from_cfg(mode_cfg, loss_name)
+                                # DiffusionLatentTargetEncoder calls the encoder on
+                                # target samples, which needs pe_embed / pe_global on
+                                # device.  Reload them if they were offloaded and the
+                                # calculator encodes target samples.
+                                if getattr(target_aux, "encodes_target_samples", False):
+                                    self.model_params.load_encoder_params_to_device(self.device)
                                 targets_and_auxs[loss_name] = target_aux.compute(
                                     self.cf.general.istep,
                                     batch.get_target_samples(target_idxs),
@@ -960,11 +1094,14 @@ class Trainer(TrainerBase):
                                     targets_and_auxs,
                                 )
 
-                        _ = self.loss_calculator_val.compute_loss(
-                            preds=preds,
-                            targets_and_aux=targets_and_auxs,
-                            metadata=extract_batch_metadata(batch),
-                        )
+                        # skip_target_values: target values are not read (zero width),
+                        # so no loss can be computed
+                        if not mode_cfg.get("skip_target_values", False):
+                            _ = self.loss_calculator_val.compute_loss(
+                                preds=preds,
+                                targets_and_aux=targets_and_auxs,
+                                metadata=extract_batch_metadata(batch),
+                            )
                         pbar.update(batch_size * self.cf.world_size)
 
                         if (bidx * batch_size) > mode_cfg.samples_per_mini_epoch:

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -79,9 +79,12 @@ def write_output(
     # original first index to cover every entry in model_output / target_aux_out.
     # A diffusion rollout keeps the ordinary fstep layout: there the extra entries are the
     # chunk's leading padding slots, which timestep_idxs has already dropped, so leave it be.
+    # The same holds whenever the chunk starts at a non-zero forecast offset (e.g.
+    # forecast.offset=1): the surplus entries are that chunk's padding, not trajectory steps,
+    # and synthesizing indices would run the emitted steps past the end of the forecast.
     is_trajectory = cf.get("fe_diffusion_model", False) and not cf.get("diffusion_rollout", False)
     n_pred_steps = len(model_output.physical)
-    if is_trajectory and n_pred_steps > len(timestep_idxs):
+    if is_trajectory and chunk_forecast_offset == 0 and n_pred_steps > len(timestep_idxs):
         timestep_idxs = list(range(forecast_offset, forecast_offset + n_pred_steps))
 
     targets_lens = []

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -73,12 +73,15 @@ def write_output(
 
     n_samples = len(batch.get_source_samples().get_samples())
 
-    # Diffusion inference inflates the model output's fstep dimension to one entry per
+    # Trajectory-mode diffusion inflates the model output's fstep dimension to one entry per
     # ODE denoising step (the trajectory). The batch only has the original physical
     # forecast indices, so synthesize a contiguous run of indices starting at the
     # original first index to cover every entry in model_output / target_aux_out.
+    # A diffusion rollout keeps the ordinary fstep layout: there the extra entries are the
+    # chunk's leading padding slots, which timestep_idxs has already dropped, so leave it be.
+    is_trajectory = cf.get("fe_diffusion_model", False) and not cf.get("diffusion_rollout", False)
     n_pred_steps = len(model_output.physical)
-    if cf.get("fe_diffusion_model", False) and n_pred_steps > len(timestep_idxs):
+    if is_trajectory and n_pred_steps > len(timestep_idxs):
         timestep_idxs = list(range(forecast_offset, forecast_offset + n_pred_steps))
 
     targets_lens = []
@@ -213,7 +216,9 @@ def write_output(
     source_windows = (twh.window(idx) for idx in sample_idxs)
     source_intervals = [TimeRange(window.start, window.end) for window in source_windows]
 
-    latents_all = get_latent_output(batch, model_output) if write_latents else None
+    latents_all = (
+        get_latent_output(batch, model_output, timestep_idxs) if write_latents else None
+    )
 
     data = io.OutputBatchData(
         sources,
@@ -240,15 +245,20 @@ def write_output(
             zio.write_zarr(subset)
 
 
-def get_latent_output(batch, model_output):
+def get_latent_output(batch, model_output, timestep_idxs=None):
     """
     Interface for getting latent states
+
+    timestep_idxs are the global forecast steps this model_output actually covers; they must
+    match the ones write_output emits, since a chunk's latents are indexed chunk-locally and
+    only span that chunk.
     """
 
     # collect latent outputs per forecast step and per sample
     fp32 = torch.float32
 
-    timestep_idxs = [0] if len(batch.get_output_idxs()) == 0 else batch.get_output_idxs()
+    if timestep_idxs is None:
+        timestep_idxs = [0] if len(batch.get_output_idxs()) == 0 else batch.get_output_idxs()
 
     sample_idxs = [
         list(sample.streams_data.values())[0].sample_idx
@@ -258,7 +268,7 @@ def get_latent_output(batch, model_output):
     latents_all: list[list[dict]] = []
     for t_idx in timestep_idxs:
         latents_all.append([])
-        latent_pred = model_output.get_latent_prediction(t_idx)
+        latent_pred = model_output.get_latent_prediction(model_output.chunk_idx(t_idx))
         n_samples = len(sample_idxs)
         for i_sample in range(n_samples):
             per_sample: dict = {}

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -60,6 +60,10 @@ def write_output(
     fp32 = torch.float32
     preds_all, targets_all, targets_coords_all, targets_times_all = [], [], [], []
 
+    # skip_target_values: targets have zero width (values were never read) and no
+    # target datasets are written; the target arrays below only provide row counts
+    write_targets = not val_cfg.get("skip_target_values", False)
+
     # _get_output_length clamps to at least one output step, so this always holds
     assert len(batch.get_output_idxs()) > 0, "Batch carries no output steps."
     forecast_offset = batch.get_output_idxs()[0]
@@ -132,9 +136,10 @@ def write_output(
 
                 # handle forcing streams or if sample is empty
                 if preds is None:
-                    # preds are empty so create copy of target and add ensemble dimension
+                    # preds are empty so create empty preds with ensemble dimension
+                    # (explicit width: targets have zero width under skip_target_values)
                     assert targets[0].shape[0] == 0, "Empty preds but non-empty targets."
-                    preds = [target.clone().unsqueeze(0) for target in targets]
+                    preds = [target.new_zeros((1, 0, n_channels)) for target in targets]
 
                 for i_batch, (pred, target) in enumerate(zip(preds, targets, strict=True)):
                     target_data = target_aux_out.physical[t_idx][sname]
@@ -150,7 +155,12 @@ def write_output(
 
                     # denormalize data if requested and map to storage format
                     preds_s += [dn_data(sname, pred.to(fp32)).detach().cpu().numpy()]
-                    targets_s += [dn_data(sname, target.to(fp32)).detach().cpu().numpy()]
+                    if write_targets:
+                        targets_s += [dn_data(sname, target.to(fp32)).detach().cpu().numpy()]
+                    else:
+                        # zero-width targets cannot be denormalized (channel-count
+                        # mismatch); only their row counts are used, for targets_lens
+                        targets_s += [target.detach().cpu().numpy()]
 
                     # extract original target coords and times from target data
                     t_coords_s += [t_coords.cpu().numpy()]
@@ -239,6 +249,7 @@ def write_output(
         sample_start=sample_start,
         forecast_offset=forecast_offset,
         forecast_steps=timestep_idxs,
+        write_targets=write_targets,
     )
 
     store_path = config.get_path_results(cf, mini_epoch)

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -60,6 +60,10 @@ def write_output(
     fp32 = torch.float32
     preds_all, targets_all, targets_coords_all, targets_times_all = [], [], [], []
 
+    # skip_target_values: targets have zero width (values were never read) and no
+    # target datasets are written; the target arrays below only provide row counts
+    write_targets = not val_cfg.get("skip_target_values", False)
+
     # _get_output_length clamps to at least one output step, so this always holds
     assert len(batch.get_output_idxs()) > 0, "Batch carries no output steps."
     forecast_offset = batch.get_output_idxs()[0]
@@ -126,9 +130,10 @@ def write_output(
 
                 # handle forcing streams or if sample is empty
                 if preds is None:
-                    # preds are empty so create copy of target and add ensemble dimension
+                    # preds are empty so create empty preds with ensemble dimension
+                    # (explicit width: targets have zero width under skip_target_values)
                     assert targets[0].shape[0] == 0, "Empty preds but non-empty targets."
-                    preds = [target.clone().unsqueeze(0) for target in targets]
+                    preds = [target.new_zeros((1, 0, n_channels)) for target in targets]
 
                 for i_batch, (pred, target) in enumerate(zip(preds, targets, strict=True)):
                     target_data = target_aux_out.physical[t_idx][sname]
@@ -144,7 +149,12 @@ def write_output(
 
                     # denormalize data if requested and map to storage format
                     preds_s += [dn_data(sname, pred.to(fp32)).detach().cpu().numpy()]
-                    targets_s += [dn_data(sname, target.to(fp32)).detach().cpu().numpy()]
+                    if write_targets:
+                        targets_s += [dn_data(sname, target.to(fp32)).detach().cpu().numpy()]
+                    else:
+                        # zero-width targets cannot be denormalized (channel-count
+                        # mismatch); only their row counts are used, for targets_lens
+                        targets_s += [target.detach().cpu().numpy()]
 
                     # extract original target coords and times from target data
                     t_coords_s += [t_coords.cpu().numpy()]
@@ -231,6 +241,7 @@ def write_output(
         sample_start=sample_start,
         forecast_offset=forecast_offset,
         forecast_steps=timestep_idxs,
+        write_targets=write_targets,
     )
 
     store_path = config.get_path_results(cf, mini_epoch)


### PR DESCRIPTION
## Description

We cannot run long inference rollouts with multiple members due to OOM issues.

These fixes allow that.

You can run inference with the following command for 1 member and 40 forecast steps (should work at least for 4 members):
```
uv run --offline inference --from-run-id ni41n7gy --options \
  test_config.samples_per_mini_epoch=1 test_config.output.num_samples=1 \
  data_loading.num_workers=0 training_config.forecast.num_steps=40 \
  validation_config.validation_noise_levels=[] diffusion_rollout=True \
  fe_diffusion_num_ensemble_members=1 \
  decode_members_per_pass=1 decode_cells_per_pass=1536 \
  test_config.forecast.chunk_size=4 test_config.compute_full_validation_loss=False \
  training_config.losses='{"physical": {"type": "LossPhysical", "weight": 0.0, "loss_fcts": {"mse": {}}, "target_and_aux_calc": "Physical"}}' \
  load_decoder_chkpt.run_id=mapw62ot load_decoder_chkpt.mini_epoch=-1 \
  test_config.start_date=2023-10-11T00:00 test_config.end_date=2023-11-11T00:00 test_config.shuffle=False \
  test_config.losses='{"physical": {"type": "LossPhysical", "weight": 0.0, "loss_fcts": {"mse": {}}, "target_and_aux_calc": "Physical"}}'
```


## Issue Number

No issue

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel

#### FastEvaluation
 - [ ] I have updated the public documentation if necessary

