### PR TITLE
offset at inference hot-fix

### DIFF
--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -821,11 +821,37 @@ class Model(torch.nn.Module):
             and self.cf.get("fe_diffusion_model_conditioning", None) == "forecast"
         ):
             # tokens[:,0] = t (most recent), tokens[:,1] = t-1, ..., tokens[:,-1] = t-(T-1) (oldest)
-            if self.cf.stage == "inference":
+            if self.cf.stage == "inference" and tokens.shape[1] == 1 and forecast_offset == 1:
+                # Single-input-step inference path: test_config.model_input.forecasting.
+                # num_steps_input=1 paired with test_config.forecast.offset=1, so the
+                # diffusion model's single forecast step lines up with a deterministic
+                # offset=1 model's +1-step lead time. There is no older step to sum over —
+                # the sole loaded step IS the conditioning.
+                print(
+                    "Using the sole loaded step as conditioning token for inference "
+                    "(offset=1, num_steps_input=1)."
+                )
+                conditioning_tokens = tokens[:, 0]
+            elif self.cf.stage == "inference":
+                assert tokens.shape[1] > 1, (
+                    "Diffusion inference with fe_diffusion_model_conditioning='forecast' got "
+                    f"only one loaded input step (tokens.shape[1]=1) but forecast.offset="
+                    f"{forecast_offset} != 1. The single-input-step inference path is only "
+                    "defined for offset=1, num_steps_input=1 (used to align the diffusion "
+                    "model's first forecast step with a deterministic offset=1 model's lead "
+                    "time). Check test_config.forecast.offset and "
+                    "test_config.model_input.forecasting.num_steps_input."
+                )
                 print("Using most recent steps as conditioning tokens for inference.")
                 # conditioning_tokens = tokens[:, :-1].sum(axis=1)
                 conditioning_tokens = tokens[:, 1:].sum(axis=1)
             else:
+                assert tokens.shape[1] > 1, (
+                    "Diffusion training with fe_diffusion_model_conditioning='forecast' "
+                    "requires at least 2 loaded input steps (one denoising target + one "
+                    f"conditioning step); got tokens.shape[1]={tokens.shape[1]}. Check "
+                    "training_config.model_input.forecasting.num_steps_input."
+                )
                 # Conditioning: all older context steps [t-1, ..., t-(T-1)];
                 # denoising target: t (newest)
                 conditioning_tokens = tokens[:, 1:].sum(axis=1)

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -78,7 +78,11 @@ def write_output(
     # forecast indices, so synthesize a contiguous run of indices starting at the
     # original first index to cover every entry in model_output / target_aux_out.
     n_pred_steps = len(model_output.physical)
-    if cf.get("fe_diffusion_model", False) and n_pred_steps > len(timestep_idxs):
+    if (
+        cf.get("fe_diffusion_model", False)
+        and chunk_forecast_offset == 0
+        and n_pred_steps > len(timestep_idxs)
+    ):
         timestep_idxs = list(range(forecast_offset, forecast_offset + n_pred_steps))
 
     targets_lens = []


### PR DESCRIPTION
## Description


Setting forecast as below (num_steps_input=1, offset=1, policy="fixed") now enables correctly aligned inference samples. That is, the forecast roll-out now starts at t, not at t-6. This change only applies at inference, training still needs num_steps_input=2, offset=0.

```
test_config:
  model_input:
    forecasting:
      num_steps_input: 1
  forecast:
    offset: 1
    policy: "fixed"
```
and 


This is a hot-fix, but should not impact existing data flow. 
<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [x] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel

#### FastEvaluation
 - [ ] I have updated the public documentation if necessary

