### PR TITLE
Inference Pipeline Optimization - normalize target channels

### DIFF
--- a/src/weathergen/datasets/data_reader_base.py
+++ b/src/weathergen/datasets/data_reader_base.py
@@ -556,9 +556,44 @@ class DataReaderBase(metaclass=ABCMeta):
             raise ValueError(
                 f"incorrect number of {name} channels: expected {len(idx)}, got {data.shape[-1]}"
             )
+        # Equivalent to (data[..., i] - mean[ch]) / stdev[ch] per channel.
+        # Dict stats are Python floats (weak scalars → same dtype as data). Array stats keep
+        # their dtype so float32 data minus float64 mean still promotes, matching the loop.
+        if isinstance(mean, dict):
+            mean_vec = np.array([mean[ch] for ch in idx], dtype=data.dtype)
+            std_vec = np.array([stdev[ch] for ch in idx], dtype=data.dtype)
+        else:
+            idx_arr = np.asarray(idx, dtype=np.intp)
+            mean_vec = np.asarray(mean)[idx_arr]
+            std_vec = np.asarray(stdev)[idx_arr]
+
+        if mean_vec.dtype == data.dtype and std_vec.dtype == data.dtype:
+            data -= mean_vec
+            data /= std_vec
+            return data
+
+        # Mixed dtypes (typically float32 data, float64 anemoi/obs stats): promote the same
+        # way the original channel loop did. Row-chunked ufuncs avoid a full-size float64
+        # temporary; few-channel or non-contiguous last axes stay on the scalar loop.
+        n_ch = data.shape[-1]
+        last_contiguous = data.strides[-1] == data.dtype.itemsize
+        if n_ch >= 8 and last_contiguous:
+            n_rows = int(np.prod(data.shape[:-1], dtype=np.intp))
+            flat = data.reshape(n_rows, n_ch)
+            if np.shares_memory(flat, data):
+                chunk = 8192
+                tmp_dtype = np.result_type(data.dtype, mean_vec.dtype, std_vec.dtype)
+                tmp = np.empty((min(chunk, n_rows), n_ch), dtype=tmp_dtype)
+                for start in range(0, n_rows, chunk):
+                    end = min(start + chunk, n_rows)
+                    sl = flat[start:end]
+                    view = tmp[: end - start]
+                    np.subtract(sl, mean_vec, out=view)
+                    np.divide(view, std_vec, out=view)
+                    np.copyto(sl, view)
+                return data
         for i, ch in enumerate(idx):
             data[..., i] = (data[..., i] - mean[ch]) / stdev[ch]
-
         return data
 
     @staticmethod

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,136 @@
+# (C) Copyright 2025 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Equivalence of vectorized DataReaderBase._normalize vs the original channel loop."""
+
+import numpy as np
+import pytest
+
+from weathergen.datasets.data_reader_base import DataReaderBase
+
+
+def _normalize_original(data, idx, mean, stdev, name):
+    """Pre-rewrite per-channel loop."""
+    if data.shape[-1] != len(idx):
+        raise ValueError(
+            f"incorrect number of {name} channels: expected {len(idx)}, got {data.shape[-1]}"
+        )
+    for i, ch in enumerate(idx):
+        data[..., i] = (data[..., i] - mean[ch]) / stdev[ch]
+    return data
+
+
+def _run_both(data, idx, mean, stdev):
+    original = _normalize_original(data.copy(), idx, mean, stdev, "target")
+    vectorized = DataReaderBase._normalize(data.copy(), idx, mean, stdev, "target")
+    return original, vectorized
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_normalize_matches_original_array_stats(dtype):
+    rng = np.random.default_rng(0)
+    n_full, n_sel = 20, 7
+    idx = [1, 3, 4, 8, 9, 15, 19]
+    mean = rng.normal(size=n_full)
+    stdev = rng.uniform(0.1, 2.0, size=n_full)
+    data = rng.normal(size=(128, n_sel)).astype(dtype)
+    original, vectorized = _run_both(data, idx, mean, stdev)
+    np.testing.assert_array_equal(vectorized, original)
+    assert vectorized.dtype == data.dtype
+
+
+def test_normalize_matches_original_dict_stats():
+    rng = np.random.default_rng(1)
+    idx = [2, 5, 11]
+    mean = {ch: float(rng.normal()) for ch in idx}
+    stdev = {ch: float(rng.uniform(0.2, 3.0)) for ch in idx}
+    data = rng.normal(size=(32, 16, 3)).astype(np.float32)
+    original, vectorized = _run_both(data, idx, mean, stdev)
+    np.testing.assert_array_equal(vectorized, original)
+
+
+def test_normalize_matches_original_numpy_idx():
+    rng = np.random.default_rng(2)
+    idx = np.array([0, 2, 4], dtype=np.int64)
+    mean = rng.normal(size=6)
+    stdev = rng.uniform(0.5, 1.5, size=6)
+    data = rng.normal(size=(64, 3)).astype(np.float32)
+    original, vectorized = _run_both(data, idx, mean, stdev)
+    np.testing.assert_array_equal(vectorized, original)
+
+
+def test_normalize_matches_original_float32_stats():
+    rng = np.random.default_rng(4)
+    idx = [0, 1, 2]
+    mean = rng.normal(size=3).astype(np.float32)
+    stdev = rng.uniform(0.2, 2.0, size=3).astype(np.float32)
+    data = rng.normal(size=(64, 3)).astype(np.float32)
+    original, vectorized = _run_both(data, idx, mean, stdev)
+    np.testing.assert_array_equal(vectorized, original)
+
+
+def test_normalize_is_inplace():
+    rng = np.random.default_rng(3)
+    idx = [0, 1]
+    mean = np.array([0.0, 1.0])
+    stdev = np.array([1.0, 2.0])
+    data = rng.normal(size=(8, 2)).astype(np.float32)
+    out = DataReaderBase._normalize(data, idx, mean, stdev, "target")
+    assert out is data
+
+
+def test_normalize_empty_rows():
+    idx = [1, 4]
+    mean = np.arange(6, dtype=np.float64)
+    stdev = np.ones(6)
+    data = np.zeros((0, 2), dtype=np.float32)
+    original, vectorized = _run_both(data, idx, mean, stdev)
+    np.testing.assert_array_equal(vectorized, original)
+    assert vectorized.shape == (0, 2)
+
+
+def test_normalize_rejects_wrong_channel_count():
+    data = np.zeros((4, 3), dtype=np.float32)
+    with pytest.raises(ValueError, match="incorrect number of target channels"):
+        DataReaderBase._normalize(data, [0, 1], np.zeros(5), np.ones(5), "target")
+
+
+def test_normalize_matches_original_across_row_chunks():
+    rng = np.random.default_rng(5)
+    n_sel = 12
+    idx = list(range(n_sel))
+    mean = rng.normal(size=n_sel)
+    stdev = rng.uniform(0.2, 2.0, size=n_sel)
+    data = rng.normal(size=(9000, n_sel)).astype(np.float32)
+    original, vectorized = _run_both(data, idx, mean, stdev)
+    np.testing.assert_array_equal(vectorized, original)
+    out = DataReaderBase._normalize(data, idx, mean, stdev, "target")
+    assert out is data
+
+
+def test_normalize_matches_original_3d_array_stats():
+    rng = np.random.default_rng(6)
+    idx = [0, 2, 3, 5, 6, 7, 8, 9]
+    mean = rng.normal(size=10)
+    stdev = rng.uniform(0.3, 1.5, size=10)
+    data = rng.normal(size=(4, 2048, len(idx))).astype(np.float32)
+    original, vectorized = _run_both(data, idx, mean, stdev)
+    np.testing.assert_array_equal(vectorized, original)
+
+
+def test_normalize_matches_original_strided_rows():
+    rng = np.random.default_rng(8)
+    idx = list(range(12))
+    mean = rng.normal(size=12)
+    stdev = rng.uniform(0.2, 2.0, size=12)
+    data = rng.normal(size=(2000, 12)).astype(np.float32)[::2]
+    original, vectorized = _run_both(data, idx, mean, stdev)
+    np.testing.assert_array_equal(vectorized, original)
+    out = DataReaderBase._normalize(data, idx, mean, stdev, "target")
+    assert out is data


### PR DESCRIPTION
## Description

# Vectorize `DataReaderBase._normalize` (faster channel normalization)

- **Base:** `develop-ssl-diffusion-v1`
- **Head:** `javad/develop-ssl-diffusion-v1-optimize-normalize_target_channels` (`9eae3bca`)

## Summary

`DataReaderBase._normalize` (used by `normalize_target_channels` and `normalize_source_channels`) used a Python loop over channels:

```python

for i, ch in enumerate(idx):

    data[..., i] = (data[..., i] - mean[ch]) / stdev[ch]

```

That is slow on large last-axis arrays (obs/anemoi windows). This replaces the loop with a vectorized pass while keeping bit-identical results vs the original loop.

- **Same-dtype stats:** in-place `data -= mean_vec; data /= std_vec` (no extra buffer).
- **Mixed dtypes** (typical: float32 data, float64 anemoi/obs stats): same promotion as the scalar loop. For ≥8 contiguous channels, row-chunked ufuncs avoid one full-size float64 temporary. Few channels or a non-contiguous last axis keep the original loop.
- **Dict stats:** Python floats are built as `dtype=data.dtype` (weak scalars), matching the loop.
- **In-place:** still returns the same array object.
- **Tests:** `tests/test_normalize.py` freezes the original loop and checks `np.testing.assert_array_equal` for float32/float64, dict vs array stats, numpy idx, empty rows, 3D arrays, strided rows, and the row-chunk path (~9000 rows). Also checks in-place behavior and the channel-count error.

## Inference timing

**Environment:** Jupiter, 1 node, mini-epoch 8 from `cw6a4szu`

The following command was used for both branches. `test_config.output.num_samples=0` is required to avoid OOM.

```bash
../WeatherGenerator-private/hpc/launch-slurm.py --stage inference --from-run-id cw6a4szu \
  --mini-epoch 8 --nodes 1 --time 15:00 \
  --options test_config.output.num_samples=0 test_config.forecast.num_steps=8 \
    test_config.samples_per_mini_epoch=4 test_config.validation_noise_levels=[] \
    data_loading.num_workers=1 data_loading.num_workers_validation=1 \
    test_config.compute_full_validation_loss=False
```

| `develop-ssl-diffusion-v1` | `u6xdzoq8` 60.50, `xhohdobd` 58.61, `mjijni1u` 58.84 | **59.15** |

| this branch | `swtou46r` 55.77, `x5sjd662` 54.16, `xied0lp7` 54.45 | **54.79** |

About **7% faster** (~4.4 s/it).

**Note:** These timings only show up if the job tree is running `javad/optimize-hpy_splits`. `launch-slurm.py --from-run-id cw6a4szu` copies Python from that training run, not from your checkout, so launching from the optimized branch alone does not change `_normalize` unless those files are overlaid (or otherwise copied) into the new job directory.



<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number
#2778 
<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel

#### FastEvaluation
 - [ ] I have updated the public documentation if necessary

