### PR TITLE
Inference Pipeline Optimization - DataReaderObs

### DIFF
--- a/src/weathergen/datasets/data_reader_obs.py
+++ b/src/weathergen/datasets/data_reader_obs.py
@@ -26,6 +26,26 @@ from weathergen.train.utils import Stage
 _logger = logging.getLogger(__name__)
 
 
+def _columns_from_block(
+    block: np.ndarray,
+    coords_idx: list[int] | np.ndarray,
+    geoinfo_idx: list[int] | np.ndarray,
+    channels_idx: list[int] | np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Split a dense (rows, cols) obs block into coords / geoinfos / data.
+
+    Matches three ``oindex[rows, cols]`` calls. Obs zarrs store every column in
+    one chunk, so those three calls decompress the same rows three times.
+    """
+    coords = block[:, coords_idx]
+    if len(geoinfo_idx) > 0:
+        geoinfos = block[:, geoinfo_idx]
+    else:
+        geoinfos = np.zeros((block.shape[0], 0), dtype=np.float32)
+    data = block[:, channels_idx]
+    return coords, geoinfos, data
+
+
 class DataReaderObs(DataReaderBase):
     def __init__(
         self, tw_handler: TimeWindowHandler, filename: Path, stream_info: dict, stage: Stage
@@ -272,14 +292,12 @@ class DataReaderObs(DataReaderBase):
         start_row = self.indices_start[idx]
         end_row = self.indices_end[idx]
 
-        coords = self.data.oindex[start_row:end_row, self.coords_idx]
-        geoinfos = (
-            self.data.oindex[start_row:end_row, self.geoinfo_idx]
-            if len(self.geoinfo_idx) > 0
-            else np.zeros((coords.shape[0], 0), np.float32)
+        # One row slice: chunks are (nrows, all_columns), so three oindex calls
+        # would decompress the same chunks three times. Values match oindex.
+        block = np.asarray(self.data[start_row:end_row])
+        coords, geoinfos, data = _columns_from_block(
+            block, self.coords_idx, self.geoinfo_idx, channels_idx
         )
-
-        data = self.data.oindex[start_row:end_row, channels_idx]
         datetimes = self.dt[start_row:end_row][:, 0]
 
         # indices_start, indices_end above work with [t_start, t_end] and violate
@@ -294,8 +312,6 @@ class DataReaderObs(DataReaderBase):
             data=data[t_mask],
             datetimes=datetimes[t_mask],
         )
-
-        dtr = self.time_window_handler.window(idx)
-        check_reader_data(rdata, dtr)
+        check_reader_data(rdata, t_win)
 
         return rdata

--- a/tests/test_obs_get.py
+++ b/tests/test_obs_get.py
@@ -1,0 +1,82 @@
+# (C) Copyright 2025 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Equivalence of one obs row-slice vs three orthogonal column reads."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from weathergen.datasets.data_reader_obs import _columns_from_block
+
+
+def _oindex_triple(block, coords_idx, geoinfo_idx, channels_idx):
+    coords = block[:, coords_idx]
+    geoinfos = (
+        block[:, geoinfo_idx]
+        if len(geoinfo_idx) > 0
+        else np.zeros((block.shape[0], 0), np.float32)
+    )
+    data = block[:, channels_idx]
+    return coords, geoinfos, data
+
+
+@pytest.mark.parametrize("n_rows,n_cols", [(0, 8), (1, 8), (128, 24), (400, 34)])
+def test_columns_from_block_matches_oindex(n_rows, n_cols):
+    rng = np.random.default_rng(0)
+    block = rng.standard_normal((n_rows, n_cols)).astype(np.float32)
+    block[::7] = np.nan
+    coords_idx = [1, 2]
+    geoinfo_idx = [3, 4, 5]
+    channels_idx = np.array([6, 7, 4], dtype=np.int64)
+    original = _oindex_triple(block, coords_idx, geoinfo_idx, channels_idx)
+    vectorized = _columns_from_block(block, coords_idx, geoinfo_idx, channels_idx)
+    for a, b in zip(original, vectorized, strict=True):
+        assert a.dtype == b.dtype
+        assert np.array_equal(a, b, equal_nan=True)
+
+
+def test_columns_from_block_empty_geoinfo():
+    block = np.arange(20, dtype=np.float32).reshape(5, 4)
+    original = _oindex_triple(block, [0, 1], [], [2, 3])
+    vectorized = _columns_from_block(block, [0, 1], [], [2, 3])
+    for a, b in zip(original, vectorized, strict=True):
+        np.testing.assert_array_equal(a, b)
+    assert vectorized[1].shape == (5, 0)
+    assert vectorized[1].dtype == np.float32
+
+
+@pytest.mark.skipif(
+    not Path(
+        "/e/data1/slmet/ml_training/observations-ea-ofb-0001-1979-2025-combined-surface-v5.zarr"
+    ).is_dir(),
+    reason="obs zarr not available",
+)
+def test_real_zarr_row_slice_matches_triple_oindex():
+    import zarr
+
+    path = "/e/data1/slmet/ml_training/observations-ea-ofb-0001-1979-2025-combined-surface-v5.zarr"
+    g = zarr.open(path, mode="r")
+    d = g["data"]
+    h0 = int(
+        (np.datetime64("2023-06-15T00") - np.datetime64("1970-01-01T00")) / np.timedelta64(1, "h")
+    )
+    hr = g["idx_197001010000_1"]
+    start, end = int(hr[h0]), int(hr[h0 + 6])
+    coords_idx, geoinfo_idx, channels_idx = [1, 2], [4, 5], [6, 7, 8, 9, 10]
+    orig_coords = d.oindex[start:end, coords_idx]
+    orig_geo = d.oindex[start:end, geoinfo_idx]
+    orig_data = d.oindex[start:end, channels_idx]
+    coords, geo, data = _columns_from_block(
+        np.asarray(d[start:end]), coords_idx, geoinfo_idx, channels_idx
+    )
+    np.testing.assert_array_equal(coords, orig_coords)
+    np.testing.assert_array_equal(geo, orig_geo)
+    assert np.array_equal(data, orig_data, equal_nan=True)


### PR DESCRIPTION
## Description


- **Base:** `develop-ssl-diffusion-v1`

- **Head:** `javad/develop-ssl-diffusion-v1-data_reader_obs` (`edf386bc`)

## Summary

`DataReaderObs._get` used three Zarr `oindex` reads on the **same row range**:

```python
coords   = self.data.oindex[start_row:end_row, self.coords_idx]
geoinfos = self.data.oindex[start_row:end_row, self.geoinfo_idx]
data     = self.data.oindex[start_row:end_row, channels_idx]
```

Obs zarrs are chunked as `(nrows, all_columns)`. Each `oindex` decompresses those row chunks again, so the same compressed bytes were decoded three times.

This reads the row block once and splits columns in NumPy:

- **One slice:** `block = np.asarray(self.data[start_row:end_row])`

- **`_columns_from_block`:** `block[:, coords_idx]`, `block[:, geoinfo_idx]`, `block[:, channels_idx]` (empty geoinfo array if there are no geo columns). Same values as three `oindex` calls, including NaNs.

- **Time-window mask / `ReaderData`:** unchanged.

- **Tests:** `tests/test_obs_get.py` checks `_columns_from_block` against the old column split, including NaNs, empty geoinfo, empty rows, and numpy channel idx.

Unused columns still cannot be skipped on disk (the chunk holds every column). The saving is **one decompress instead of three**.

## Inference timing

**Environment:** Jupiter, 1 node, mini-epoch 8 from `cw6a4szu`

The following command was used for both branches. `test_config.output.num_samples=0` is required to avoid OOM.

```bash
../WeatherGenerator-private/hpc/launch-slurm.py --stage inference --from-run-id cw6a4szu \
  --mini-epoch 8 --nodes 1 --time 15:00 \
  --options test_config.output.num_samples=0 test_config.forecast.num_steps=8 \
    test_config.samples_per_mini_epoch=4 test_config.validation_noise_levels=[] \
    data_loading.num_workers=1 data_loading.num_workers_validation=1 \
    test_config.compute_full_validation_loss=False
```

| Branch | Runs (s/it) | Average (s/it) |
|---|---|---|
| `develop-ssl-diffusion-v1` | `u6xdzoq8` 60.50, `xhohdobd` 58.61, `mjijni1u` 58.84 | **59.15** |
| this branch | `khwhzrkb` 56.90, `g709gujg` 57.35, `ylohofl2` 56.52 | **56.92** |

About **4% faster**.

**Note:** These timings only show up if the job tree is running `javad/optimize-hpy_splits`. `launch-slurm.py --from-run-id cw6a4szu` copies Python from that training run, not from your checkout, so launching from the optimized branch alone does not change `_get` unless those files are overlaid (or otherwise copied) into the new job directory.


<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number
https://github.com/ecmwf/WeatherGenerator/issues/2778
<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel

#### FastEvaluation
 - [ ] I have updated the public documentation if necessary

