### PR TITLE
Sgrasse/develop/2786 remove time step

### DIFF
--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -104,11 +104,6 @@ def _sanitize_delta_time_keys(sub_conf):
         if key in sub_conf:
             sub_conf = _patch_time(key, sub_conf, _TIMEDELTA_TYPE_NAME)
 
-    if sub_conf.get("forecast") is not None:
-        key = "time_step"
-        if key in sub_conf.forecast:
-            sub_conf.forecast = _patch_time(key, sub_conf.forecast, _TIMEDELTA_TYPE_NAME)
-
 
 def _sanitize_time_keys(conf: Config) -> Config:
     """
@@ -366,7 +361,6 @@ def _check_time_interpolation(config: Config) -> Config:
 
     time_keys = ["start_date", "end_date"]
     delta_keys = ["time_window_step", "time_window_len"]
-    forecast_step_dt = "time_step"
 
     config = config.copy()
     subconfs = [
@@ -379,8 +373,6 @@ def _check_time_interpolation(config: Config) -> Config:
         if subconf is not None:
             for key in (*time_keys, *delta_keys):
                 _convert_interpolation(subconf, key)
-            if "forecast" in subconf:
-                _convert_interpolation(subconf.forecast, forecast_step_dt)
 
     return config
 

--- a/src/weathergen/datasets/data_reader_base.py
+++ b/src/weathergen/datasets/data_reader_base.py
@@ -47,6 +47,9 @@ class TimeIndexRange:
     start: TIndex
     end: TIndex
 
+    def __len__(self) -> int:
+        return int(self.end - self.start)
+
 
 @dataclass
 class DTRange:
@@ -94,8 +97,13 @@ class TimeWindowHandler:
         self.t_window_len: NPTDel64 = t_window_len_hours
         self.t_window_step: NPTDel64 = t_window_step_hours
 
+        idx_start: TIndex = np.int64(0)
+        idx_end = np.int64((self.t_end - self.t_start) // self.t_window_step)
+        self.index_range = TimeIndexRange(idx_start, idx_end)
+
         assert self.t_start < self.t_end, "end datetime has to be in the past of start datetime"
         assert self.t_start > _DT_ZERO, "start datetime has to be >= 1850-01-01T00:00."
+        assert idx_start <= idx_end, f"time window idxs invalid: {idx_start} <= {idx_end}"
 
     def __str__(self) -> str:
         # Helper to ensure readable timedelta formatting
@@ -104,26 +112,6 @@ class TimeWindowHandler:
         return (
             f"TimeWindowHandler: start={self.t_start}, end={self.t_end}, len={l_str}, step={s_str}"
         )
-
-    def get_index_range(self) -> TimeIndexRange:
-        """
-        Temporal window corresponding to index
-
-        Parameters
-        ----------
-        idx :
-            index of temporal window
-
-        Returns
-        -------
-            start and end of temporal window
-        """
-
-        idx_start: TIndex = np.int64(0)
-        idx_end = np.int64((self.t_end - self.t_start) // self.t_window_step)
-        assert idx_start <= idx_end, f"time window idxs invalid: {idx_start} <= {idx_end}"
-
-        return TimeIndexRange(idx_start, idx_end)
 
     def window(self, idx: TIndex) -> DTRange:
         """
@@ -143,6 +131,14 @@ class TimeWindowHandler:
         t_end_win = t_start_win + self.t_window_len
 
         return DTRange(t_start_win, t_end_win)
+
+    def max_index(self, n_steps) -> int:
+        """Last viable index to make a n_steps long forecast (including offset)."""
+        return self.index_range.end - (
+            # time that windows for n_steps cover
+            (self.t_window_step * n_steps + self.t_window_len)
+            // self.t_window_step  # as number of indexes
+        )
 
 
 @dataclass

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -119,25 +119,20 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         self.batch_size = get_batch_size_from_config(mode_cfg)
         self.shuffle = mode_cfg.shuffle
 
-        self.len_timedelta = mode_cfg.time_window_len
-        self.step_timedelta = mode_cfg.time_window_step
-        tw = TimeWindowHandler(
-            self.mode_cfg.start_date,
-            self.mode_cfg.end_date,
-            self.len_timedelta,
-            self.step_timedelta,
-        )
-
         # needed as offset for permutations
         source_cfgs = self.mode_cfg.get("model_input")
         self.max_input_steps = np.array(
             [sc.get("num_steps_input", 1) for _, sc in source_cfgs.items()]
         ).max()
 
-        self.time_window_handler = tw
+        self.time_window_handler = TimeWindowHandler(
+            self.mode_cfg.start_date,
+            self.mode_cfg.end_date,
+            self.mode_cfg.time_window_len,
+            self.mode_cfg.time_window_step,
+        )
         if is_root():
             logger.info(self.time_window_handler)
-        self.index_range = tw.get_index_range()
 
         # check samples per mini epoch
         self.samples_per_mini_epoch = mode_cfg.samples_per_mini_epoch
@@ -155,14 +150,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
         """Check if samples_per_mini_epoch is suitable
         Repeated both to initialise the MultiStreamDataSampler and for each mini epoch"""
 
-        max_index = self.index_range.end - (
-            (  # max time units needed to make a forecast
-                self.step_timedelta * (fsm + self.output_offset)  # translation due to forecasting
-                + self.len_timedelta  # length of forecasting window
-            )
-            // self.step_timedelta  # as number of indexs
-        )
-
+        max_index = self.time_window_handler.max_index(fsm + self.output_offset)
         available_samples = max_index * self.batch_size  # as number of samples
 
         assert available_samples > 0, (
@@ -210,8 +198,7 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
     def _calc_baseperms(self, fsm: int) -> np.typing.NDArray:
         """This calculates the base permutation array and
         depends on fsm so must be repeated for __init__ and reset"""
-        perms_len = int(self.index_range.end - self.index_range.start)
-        perms_len -= (fsm + self.output_offset)
+        perms_len = len(self.time_window_handler.index_range) - (fsm + self.output_offset)
         return np.arange(self.max_input_steps, perms_len)
 
     def _init_stream_datasets(self, cf) -> dict[StreamName, _Stream]:

--- a/src/weathergen/datasets/multi_stream_data_sampler.py
+++ b/src/weathergen/datasets/multi_stream_data_sampler.py
@@ -43,7 +43,6 @@ logger = logging.getLogger(__name__)
 
 FORECAST_DEFAULTS = {
     "offset": 0,
-    "time_step": np.timedelta64(0, "ms"),
     "policy": None,
     "num_steps": np.array([0], dtype=np.int32),
 }
@@ -112,7 +111,6 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
 
         forecast_cfg = FORECAST_DEFAULTS | OmegaConf.to_object(mode_cfg.get("forecast", {}))
         self.output_offset = forecast_cfg["offset"]
-        self.time_step = forecast_cfg["time_step"]
         self.forecast_policy = forecast_cfg["policy"]
         steps = np.array(forecast_cfg["num_steps"], dtype=np.int32).reshape(-1)
         self.list_num_forecast_steps = np.array(steps, dtype=np.int32)
@@ -159,7 +157,7 @@ class MultiStreamDataSampler(torch.utils.data.IterableDataset):
 
         max_index = self.index_range.end - (
             (  # max time units needed to make a forecast
-                self.time_step * (fsm + self.output_offset)  # translation due to forecasting
+                self.step_timedelta * (fsm + self.output_offset)  # translation due to forecasting
                 + self.len_timedelta  # length of forecasting window
             )
             // self.step_timedelta  # as number of indexs
@@ -213,8 +211,7 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
         """This calculates the base permutation array and
         depends on fsm so must be repeated for __init__ and reset"""
         perms_len = int(self.index_range.end - self.index_range.start)
-        perms_len -= (fsm + self.output_offset) * (self.time_step // self.step_timedelta)
-
+        perms_len -= (fsm + self.output_offset)
         return np.arange(self.max_input_steps, perms_len)
 
     def _init_stream_datasets(self, cf) -> dict[StreamName, _Stream]:
@@ -457,7 +454,7 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
         # collect for all forecast steps
         num_output_steps = self._get_output_length(num_forecast_steps)
         for step, timestep_idx in enumerate(range(self.output_offset, num_output_steps)):
-            step_forecast_dt = idx + (self.time_step * timestep_idx) // self.step_timedelta
+            step_forecast_dt = idx + timestep_idx
             time_win_target = self.time_window_handler.window(step_forecast_dt)
 
             # collect all targets for current stream
@@ -590,7 +587,7 @@ Set repeat_data_in_mini_epoch to True if this is undesired."
         output_data = []
         num_output_steps = self._get_output_length(num_forecast_steps)
         for timestep_idx in range(self.output_offset, num_output_steps):
-            step_forecast_dt = base_idx + (self.time_step * timestep_idx) // self.step_timedelta
+            step_forecast_dt = base_idx + timestep_idx
 
             rdata = collect_datasources(stream_ds, step_forecast_dt, "target", self.rng)
 


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->
Removes `forecast.time_step` from mode config and make TimeWindowHandler solely responsible for computations involving `time_window_step` and `time_window_len`. (if the latter is not desired only the last commit can be dropped)

## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->
closes #2786 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel

#### FastEvaluation
 - [x] I have updated the public documentation if necessary

