### PR TITLE
Allow time-varying fields to be a static forcing in DataReaderAnemoiRT

### DIFF
--- a/packages/readers_extra/src/weathergen/readers_extra/data_reader_anemoi_rt.py
+++ b/packages/readers_extra/src/weathergen/readers_extra/data_reader_anemoi_rt.py
@@ -129,17 +129,15 @@ class DataReaderAnemoiRT(DataReaderTimestep):
             if k not in self.geoinfo_channels:
                 continue
 
-            if v.is_constant_in_time:
-                self.geoinfo_channels_static += [k]
-                self.geoinfo_idx_static += [ds.variables.index(k)]
-                self.geoinfo_idx_static_lin += [idx]
-            else:
-                assert k in _anemoi_dynamic_forcings(), (
-                    f"Dynamic forcing {k} not implemented in DataReaderAnemoiRT"
-                )
+            if k in _anemoi_dynamic_forcings():
                 self.geoinfo_channels_dynamic += [k]
                 self.geoinfo_idx_dynamic += [ds.variables.index(k)]
                 self.geoinfo_idx_dynamic_lin += [idx]
+            else:
+                # treat time-varying variables as static
+                self.geoinfo_channels_static += [k]
+                self.geoinfo_idx_static += [ds.variables.index(k)]
+                self.geoinfo_idx_static_lin += [idx]
             idx += 1
 
         # set geoinfo normalization statistics


### PR DESCRIPTION
## Description

Allow time-varying fields to be a static forcing in DataReaderAnemoiRT. This is useful for fields like land-sea-mask (lsm), which is technically time-varying in an anemoi-dataset, but can be treated as static

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel

#### FastEvaluation
 - [ ] I have updated the public documentation if necessary

