### PR TITLE
Inference Pipeline Optimization - vectorize hpy_splits

### DIFF
--- a/src/weathergen/datasets/tokenizer_utils.py
+++ b/src/weathergen/datasets/tokenizer_utils.py
@@ -121,26 +121,23 @@ def hpy_cell_splits(coords: torch.tensor, hl: int):
     """Compute healpix cell id for each coordinate on given level hl
 
     Returns
-      hpy_idxs_ord_split : list of per cell indices into thetas,phis,posr3
-      thetas : thetas in rad
-      phis : phis in rad
+      idxs_ord : indices into thetas,phis,posr3, grouped by ascending healpix cell and
+        ordered by theta within each cell
+      counts : number of points in each of the 12 * 4**hl cells, so that
+        np.split(idxs_ord, np.cumsum(counts)) recovers the per cell indices
     """
     thetas, phis = theta_phi_to_standard_coords(coords)
     # healpix cells for all points
     hpy_idxs = ang2pix(2**hl, thetas, phis, nest=True)
 
-    # extract information to split according to cells by first sorting and then finding split idxs
-    hpy_idxs_ord = np.argsort(hpy_idxs, **numpy_argsort_args)
-    splits = np.flatnonzero(np.diff(hpy_idxs[hpy_idxs_ord]))
+    # One lexicographic sort yields the cell grouping and the by-theta order within every cell
+    # at once. Sorting stably by cell and then stably by theta per cell gives the same
+    # permutation, since lexsort is stable and applies the last key as the primary one.
+    thetas_np = thetas.numpy() if isinstance(thetas, torch.Tensor) else np.asarray(thetas)
+    idxs_ord = np.lexsort((thetas_np, hpy_idxs))
+    counts = np.bincount(hpy_idxs, minlength=12 * 4**hl)
 
-    # extract per cell data
-    hpy_idxs_ord_temp = np.split(hpy_idxs_ord, splits + 1)
-    hpy_idxs_ord_split = [np.array([], dtype=np.int64) for _ in range(12 * 4**hl)]
-    # TODO: split smarter (with a augmented splits list?) so that this loop is not needed
-    for b, x in zip(np.unique(np.unique(hpy_idxs[hpy_idxs_ord])), hpy_idxs_ord_temp, strict=True):
-        hpy_idxs_ord_split[b] = x
-
-    return (hpy_idxs_ord_split, thetas, phis)
+    return idxs_ord, counts
 
 
 def hpy_splits(
@@ -156,37 +153,52 @@ def hpy_splits(
         (so that data[idxs_ord].split( idxs_ord_lens) provides per cell data)
     """
 
-    # list of data points per healpix cell
-    (hpy_idxs_ord_split, thetas, phis) = hpy_cell_splits(coords, hl)
-
-    # if token_size is exceeed split based on latitude
+    # data points per healpix cell, already ordered by theta within each cell
+    # (if token_size is exceeded the cell is split based on latitude)
     # TODO: split by hierarchically traversing healpix scheme
-    thetas_sorted = [torch.argsort(thetas[idxs], stable=True) for idxs in hpy_idxs_ord_split]
-    # remainder for padding to token size
-    if pad_tokens:
-        rem = [
-            token_size - (len(idxs) % token_size if len(idxs) % token_size != 0 else token_size)
-            for idxs in hpy_idxs_ord_split
-        ]
-    else:
-        rem = np.zeros(len(hpy_idxs_ord_split), dtype=np.int32)
+    idxs_ord_flat, counts = hpy_cell_splits(coords, hl)
 
-    # helper variables to split according to cells
+    num_cells = len(counts)
+    if len(idxs_ord_flat) == 0:
+        empty = [[] for _ in range(num_cells)]
+        return empty, [[] for _ in range(num_cells)]
+
     # pad to token size *and* offset by +1 to account for the index 0 that is added for the padding
     offset = (1 if pad_tokens else 0) + offset_step
-    int32 = torch.int32
+
+    tokens_per_cell = -(-counts // token_size)
+    # padding the tail of a cell to a whole number of tokens leaves gaps between cells, which
+    # stay zero and so index the padding row that the caller prepends to the data
+    slots_per_cell = tokens_per_cell * token_size if pad_tokens else counts
+
+    # Scatter the sorted indices into one flat buffer instead of concatenating and splitting
+    # each cell separately: the destination of every point is its cell's slot offset plus its
+    # rank within the cell.
+    point_starts = np.cumsum(counts) - counts
+    slot_starts = np.cumsum(slots_per_cell) - slots_per_cell
+    dest = (
+        np.arange(len(idxs_ord_flat))
+        - np.repeat(point_starts, counts)
+        + np.repeat(slot_starts, counts)
+    )
+    flat = np.zeros(int(slots_per_cell.sum()), dtype=np.int64)
+    flat[dest] = idxs_ord_flat + offset
+
+    # One split covers every token of every cell; the tokens of a cell are then a contiguous run
+    if pad_tokens:
+        tokens = torch.split(torch.from_numpy(flat), token_size)
+    else:
+        token_lens = np.full(int(tokens_per_cell.sum()), token_size, dtype=np.int64)
+        filled = counts > 0
+        token_starts_filled = (np.cumsum(tokens_per_cell) - tokens_per_cell)[filled]
+        last = token_starts_filled + tokens_per_cell[filled] - 1
+        token_lens[last] = counts[filled] - (tokens_per_cell[filled] - 1) * token_size
+        tokens = torch.split(torch.from_numpy(flat), token_lens.tolist())
+
+    token_starts = (np.cumsum(tokens_per_cell) - tokens_per_cell).tolist()
     idxs_ord = [
-        list(
-            torch.split(
-                torch.cat(
-                    (torch.from_numpy(np.take(idxs, ts) + offset), torch.zeros(r, dtype=int32))
-                ),
-                token_size,
-            )
-        )
-        if len(idxs) > 0
-        else []
-        for idxs, ts, r in zip(hpy_idxs_ord_split, thetas_sorted, rem, strict=True)
+        list(tokens[start : start + num]) if num > 0 else []
+        for start, num in zip(token_starts, tokens_per_cell.tolist(), strict=True)
     ]
 
     # extract length and flatten nested list

--- a/tests/test_hpy_splits.py
+++ b/tests/test_hpy_splits.py
@@ -1,0 +1,172 @@
+"""Equivalence of vectorized hpy_cell_splits / hpy_splits vs the original loop.
+
+The original implementations are frozen here. TokenizerMasking always converts
+coords to torch before tokenize_space, so the cases use torch coordinates.
+"""
+
+import numpy as np
+import pytest
+import torch
+from astropy_healpix.healpy import ang2pix
+
+from weathergen.datasets.tokenizer_utils import (
+    hpy_cell_splits,
+    hpy_splits,
+    numpy_argsort_args,
+    theta_phi_to_standard_coords,
+)
+
+
+def _hpy_cell_splits_original(coords: torch.Tensor, hl: int):
+    """Pre-rewrite hpy_cell_splits: per-cell index lists, unsorted by latitude."""
+    thetas, phis = theta_phi_to_standard_coords(coords)
+    hpy_idxs = ang2pix(2**hl, thetas, phis, nest=True)
+
+    hpy_idxs_ord = np.argsort(hpy_idxs, **numpy_argsort_args)
+    splits = np.flatnonzero(np.diff(hpy_idxs[hpy_idxs_ord]))
+
+    hpy_idxs_ord_temp = np.split(hpy_idxs_ord, splits + 1)
+    hpy_idxs_ord_split = [np.array([], dtype=np.int64) for _ in range(12 * 4**hl)]
+    for b, x in zip(np.unique(np.unique(hpy_idxs[hpy_idxs_ord])), hpy_idxs_ord_temp, strict=True):
+        hpy_idxs_ord_split[b] = x
+
+    return (hpy_idxs_ord_split, thetas, phis)
+
+
+def _hpy_splits_original(
+    coords: torch.Tensor, hl: int, token_size: int, pad_tokens: bool, offset_step: int = 0
+):
+    """Pre-rewrite hpy_splits: per-cell torch.argsort / cat / split."""
+    (hpy_idxs_ord_split, thetas, phis) = _hpy_cell_splits_original(coords, hl)
+
+    thetas_sorted = [torch.argsort(thetas[idxs], stable=True) for idxs in hpy_idxs_ord_split]
+    if pad_tokens:
+        rem = [
+            token_size - (len(idxs) % token_size if len(idxs) % token_size != 0 else token_size)
+            for idxs in hpy_idxs_ord_split
+        ]
+    else:
+        rem = np.zeros(len(hpy_idxs_ord_split), dtype=np.int32)
+
+    offset = (1 if pad_tokens else 0) + offset_step
+    int32 = torch.int32
+    idxs_ord = [
+        list(
+            torch.split(
+                torch.cat(
+                    (torch.from_numpy(np.take(idxs, ts) + offset), torch.zeros(r, dtype=int32))
+                ),
+                token_size,
+            )
+        )
+        if len(idxs) > 0
+        else []
+        for idxs, ts, r in zip(hpy_idxs_ord_split, thetas_sorted, rem, strict=True)
+    ]
+
+    idxs_ord_lens = [[len(a) for a in aa] for aa in idxs_ord]
+    return idxs_ord, idxs_ord_lens
+
+
+def _split_by_counts(idxs_ord, counts):
+    """Recover the original per-cell index lists from the vectorized return value."""
+    cells = []
+    start = 0
+    for count in counts:
+        cells.append(idxs_ord[start : start + int(count)])
+        start += int(count)
+    return cells
+
+
+def _coords(n: int, seed: int) -> torch.Tensor:
+    rng = np.random.default_rng(seed)
+    lat = rng.uniform(-89.0, 89.0, n).astype(np.float32)
+    lon = rng.uniform(-180.0, 180.0, n).astype(np.float32)
+    return torch.tensor(np.stack([lat, lon], axis=1))
+
+
+def _assert_hpy_splits_equal(old_idxs, old_lens, new_idxs, new_lens):
+    assert old_lens == new_lens
+    assert len(old_idxs) == len(new_idxs)
+    for cell_i, (old_cell, new_cell) in enumerate(zip(old_idxs, new_idxs, strict=True)):
+        assert len(old_cell) == len(new_cell), f"cell {cell_i}: token count"
+        for tok_i, (old_tok, new_tok) in enumerate(zip(old_cell, new_cell, strict=True)):
+            assert old_tok.shape == new_tok.shape, f"cell {cell_i} token {tok_i}: shape"
+            assert torch.equal(old_tok, new_tok), f"cell {cell_i} token {tok_i}: values"
+
+
+# ---------------------------------------------------------------------------
+# Cases: production always passes torch coords. Empty streams never reach these
+# functions (TokenizerMasking skips them).
+# ---------------------------------------------------------------------------
+
+HPY_CASES = [
+    pytest.param(_coords(1, 0), 3, 4, True, 0, id="one_point"),
+    pytest.param(_coords(8000, 1), 3, 4, True, 0, id="dense_padded"),
+    pytest.param(_coords(8000, 1), 3, 4, False, 0, id="dense_unpadded"),
+    pytest.param(_coords(8000, 1), 3, 4, True, 17, id="dense_offset"),
+    pytest.param(
+        torch.tensor(
+            np.stack(
+                [np.full(16, 45.0, np.float32), np.linspace(10.0, 10.01, 16, dtype=np.float32)],
+                axis=1,
+            )
+        ),
+        3,
+        4,
+        True,
+        0,
+        id="exact_multiple_of_token_size",
+    ),
+    pytest.param(
+        torch.tensor(
+            np.stack(
+                [
+                    np.array([45.0] * 8 + [10.0] * 3, np.float32),
+                    np.array([20.0] * 8 + [40.0] * 3, np.float32),
+                ],
+                axis=1,
+            )
+        ),
+        3,
+        3,
+        True,
+        0,
+        id="tied_coordinates",
+    ),
+    pytest.param(_coords(7, 2), 3, 4, True, 0, id="remainder_token"),
+    pytest.param(_coords(2000, 3), 5, 4, True, 0, id="healpix_level_5"),
+]
+
+
+@pytest.mark.parametrize("coords, hl, token_size, pad_tokens, offset_step", HPY_CASES)
+def test_hpy_splits_matches_original(coords, hl, token_size, pad_tokens, offset_step):
+    old_idxs, old_lens = _hpy_splits_original(coords, hl, token_size, pad_tokens, offset_step)
+    new_idxs, new_lens = hpy_splits(coords, hl, token_size, pad_tokens, offset_step)
+    _assert_hpy_splits_equal(old_idxs, old_lens, new_idxs, new_lens)
+
+
+@pytest.mark.parametrize("coords, hl, token_size, pad_tokens, offset_step", HPY_CASES)
+def test_hpy_cell_splits_matches_original(coords, hl, token_size, pad_tokens, offset_step):
+    """Same points per cell; within a cell the new order is the original latitude sort."""
+    del token_size, pad_tokens, offset_step
+    old_cells, thetas, _phis = _hpy_cell_splits_original(coords, hl)
+    new_idxs, new_counts = hpy_cell_splits(coords, hl)
+
+    assert len(old_cells) == len(new_counts)
+    assert int(new_counts.sum()) == coords.shape[0]
+    new_cells = _split_by_counts(new_idxs, new_counts)
+
+    for cell_i, (old_cell, new_cell) in enumerate(zip(old_cells, new_cells, strict=True)):
+        assert old_cell.shape[0] == new_cell.shape[0], f"cell {cell_i}: occupancy"
+        np.testing.assert_array_equal(
+            np.sort(old_cell), np.sort(new_cell), err_msg=f"cell {cell_i}: member indices"
+        )
+        if old_cell.shape[0] == 0:
+            continue
+        theta_order = torch.argsort(thetas[old_cell], stable=True).numpy()
+        np.testing.assert_array_equal(
+            np.take(old_cell, theta_order),
+            new_cell,
+            err_msg=f"cell {cell_i}: latitude order",
+        )


### PR DESCRIPTION
## Description
# Inference Pipeline Optimization

Tokenizer CPU time was dominated by `hpy_splits`: a Python loop over every HEALPix cell (`12 * 4**hl`) with a tiny `torch.argsort` / `cat` / `split` per cell. This replaces that with a vectorized NumPy path while preserving the same token index lists.

- **`hpy_cell_splits`**: Uses one `np.lexsort((theta, cell_id))` to group points by cell and sort them by latitude within each cell. Occupancy is computed using `np.bincount(..., minlength=12 * 4**hl)`. It returns packed `(idxs_ord, counts)` instead of a Python list of per-cell arrays.
- **`hpy_splits`**: Scatters the packed indices into one padded buffer, splits once into tokens, and then slices the tokens back per cell. The same padding (`index 0`) and `offset_step` behavior are preserved.
- **`tokenize_space` / `tokenize_spacetime`**: Unchanged; they continue to consume the same nested token lists.
- **Tests**: `tests/test_hpy_splits.py` freezes the original implementations and checks `torch.equal` on tokens for padded and unpadded cases, `offset_step`, tied coordinates, remainder tokens, and `hl=5`.

`hpy_cell_splits` is only used by `hpy_splits` in this tree.

## Inference Timing

**Environment:** Jupiter, 1 node, mini-epoch 8 from `cw6a4szu`

The following command was used for both branches. `test_config.output.num_samples=0` is required to avoid OOM.

```bash
../WeatherGenerator-private/hpc/launch-slurm.py --stage inference --from-run-id cw6a4szu \
  --mini-epoch 8 --nodes 1 --time 15:00 \
  --options test_config.output.num_samples=0 test_config.forecast.num_steps=8 \
  test_config.samples_per_mini_epoch=4 test_config.validation_noise_levels=[] \
  data_loading.num_workers=1 data_loading.num_workers_validation=1 \
  test_config.compute_full_validation_loss=False
```


| Run | RUN_ID | Slurm | s/it | loss | valid? |
| --- | --- | --- | --- | --- | --- |
| 1 | `n7sqya5y` | `1517694` | 32.39 | 3.2944E-02 | yes |
| 2 | `zl4t0n1w` | `1517696` | 32.38 | 3.2943E-02 | yes |
| 3 | `cio16jn2` | `1517699` | 32.58 | 3.2942E-02 | yes |
| **Mean (valid)** | — | — | **32.45** | cluster | **yes** |

Vs **develop-ssl-diffusion-v1** control mean **59.15 s/it**: **1.82×**.

**Note:** These timings only show up if the job tree is running `javad/optimize-hpy_splits` branch on private repo. `launch-slurm.py --from-run-id cw6a4szu` copies Python from that training run, not from your checkout, so launching from the optimized branch alone does not change the tokenizer unless those files are overlaid (or otherwise copied) into the new job directory.

## Issue Number
#2778 
<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel

#### FastEvaluation
 - [ ] I have updated the public documentation if necessary

