### PR TITLE
HEALPix Curriculum

### DIFF
--- a/config/config_curriculum.yml
+++ b/config/config_curriculum.yml
@@ -1,8 +1,8 @@
 healpix_curriculum:
-  3: 100
-  4: 100
-  5: 100
-  6: 100
+  3: 250
+  4: 250
+  5: 250
+  6: 250
 
 curriculum_streams:
   3: "./config/streams/era5_1deg/"

--- a/config/config_curriculum.yml
+++ b/config/config_curriculum.yml
@@ -9,5 +9,3 @@ curriculum_streams:
   4: "./config/streams/era5_1deg/"
   5: "./config/streams/era5_1deg/"
   6: "./config/streams/era5_1deg/"
-
-streams_directory: "${curriculum_streams.${healpix_level}}"

--- a/config/config_curriculum.yml
+++ b/config/config_curriculum.yml
@@ -1,8 +1,8 @@
 healpix_curriculum:
-  3: 250
-  4: 250
-  5: 250
-  6: 250
+  3: 100
+  4: 100
+  5: 100
+  6: 100
 
 curriculum_streams:
   3: "./config/streams/era5_1deg/"

--- a/config/config_curriculum.yml
+++ b/config/config_curriculum.yml
@@ -1,13 +1,13 @@
 healpix_curriculum:
-  3: 1000
-  4: 1000
-  5: 1500
-  6: 3000
+  3: 250
+  4: 250
+  5: 250
+  6: 250
 
 curriculum_streams:
-  3: "./config/streams/era5_8deg/"
-  4: "./config/streams/era5_4deg/"
-  5: "./config/streams/era5_2deg/"
+  3: "./config/streams/era5_1deg/"
+  4: "./config/streams/era5_1deg/"
+  5: "./config/streams/era5_1deg/"
   6: "./config/streams/era5_1deg/"
 
 streams_directory: "${curriculum_streams.${healpix_level}}"

--- a/config/config_curriculum.yml
+++ b/config/config_curriculum.yml
@@ -1,0 +1,13 @@
+healpix_curriculum:
+  3: 1000
+  4: 1000
+  5: 1500
+  6: 3000
+
+curriculum_streams:
+  3: "./config/streams/era5_8deg/"
+  4: "./config/streams/era5_4deg/"
+  5: "./config/streams/era5_2deg/"
+  6: "./config/streams/era5_1deg/"
+
+streams_directory: "${curriculum_streams.${healpix_level}}"

--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -480,7 +480,12 @@ def load_merge_configs(
 def _load_streams_in_config(config: Config) -> Config:
     """If the config contains a streams_directory, loads the streams and returns the config with
     the streams set."""
-    streams_directory = config.get("streams_directory", None)
+    import omegaconf
+    try:
+        streams_directory = config.get("streams_directory", None)
+    except (omegaconf.errors.InterpolationKeyError, omegaconf.errors.InterpolationResolutionError):
+        streams_directory = None
+        
     config = config.copy()
     if streams_directory is not None:
         streams_directory = Path(streams_directory)

--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -24,6 +24,7 @@ import yaml.constructor
 import yaml.scanner
 from omegaconf import DictConfig, ListConfig, OmegaConf
 from omegaconf.omegaconf import open_dict
+from omegaconf.errors import InterpolationKeyError, InterpolationResolutionError
 
 from weathergen.common.io import StoreType
 from weathergen.common.paths import _REPO_ROOT, get_wg_private_path
@@ -456,7 +457,7 @@ def load_merge_configs(
     with open_dict(base_config):
         base_config.from_run_id = from_run_id
         # streams from an overwrite's streams_directory replace inherited streams
-        if any(o.get("streams_directory") is not None for o in overwrite_configs):
+        if any("streams_directory" in o for o in overwrite_configs):
             base_config.streams = None
     # use OmegaConf.unsafe_merge if too slow
     c = OmegaConf.merge(base_config, private_config, *overwrite_configs)
@@ -480,10 +481,9 @@ def load_merge_configs(
 def _load_streams_in_config(config: Config) -> Config:
     """If the config contains a streams_directory, loads the streams and returns the config with
     the streams set."""
-    import omegaconf
     try:
         streams_directory = config.get("streams_directory", None)
-    except (omegaconf.errors.InterpolationKeyError, omegaconf.errors.InterpolationResolutionError):
+    except (InterpolationKeyError, InterpolationResolutionError):
         streams_directory = None
         
     config = config.copy()

--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -474,6 +474,10 @@ def load_merge_configs(
             if istep < cumulative:
                 break
         c.healpix_level = current_hl
+        
+        if c.get("curriculum_streams"):
+            # Support both integer and string keys in the yaml
+            c.streams_directory = c.curriculum_streams.get(current_hl) or c.curriculum_streams.get(str(current_hl))
 
     return c
 

--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -23,8 +23,8 @@ import yaml
 import yaml.constructor
 import yaml.scanner
 from omegaconf import DictConfig, ListConfig, OmegaConf
-from omegaconf.omegaconf import open_dict
 from omegaconf.errors import InterpolationKeyError, InterpolationResolutionError
+from omegaconf.omegaconf import open_dict
 
 from weathergen.common.io import StoreType
 from weathergen.common.paths import _REPO_ROOT, get_wg_private_path
@@ -475,10 +475,12 @@ def load_merge_configs(
             if istep < cumulative:
                 break
         c.healpix_level = current_hl
-        
+
         if c.get("curriculum_streams"):
             # Support both integer and string keys in the yaml
-            c.streams_directory = c.curriculum_streams.get(current_hl) or c.curriculum_streams.get(str(current_hl))
+            c.streams_directory = c.curriculum_streams.get(current_hl) or c.curriculum_streams.get(
+                str(current_hl)
+            )
 
     return c
 
@@ -490,7 +492,7 @@ def _load_streams_in_config(config: Config) -> Config:
         streams_directory = config.get("streams_directory", None)
     except (InterpolationKeyError, InterpolationResolutionError):
         streams_directory = None
-        
+
     config = config.copy()
     if streams_directory is not None:
         streams_directory = Path(streams_directory)

--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -463,6 +463,17 @@ def load_merge_configs(
     assert isinstance(c, Config)
     c = _sanitize_time_keys(c)
 
+    if c.get("healpix_curriculum"):
+        istep = c.get("general", {}).get("istep", 0)
+        cumulative = 0
+        current_hl = None
+        for hl, steps in c.healpix_curriculum.items():
+            cumulative += steps
+            current_hl = int(hl)
+            if istep < cumulative:
+                break
+        c.healpix_level = current_hl
+
     return c
 
 

--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -140,25 +140,25 @@ def _strip_interpolation(conf: Config) -> Config:
     """Recursively convert interpolated timedelta/datetime objects to strings."""
     stripped = {}
     if OmegaConf.is_dict(conf):
-        for key in list(conf.keys()):
-            key = str(key)
-            if OmegaConf.is_missing(conf, key):
+        for orig_key in list(conf.keys()):
+            str_key = str(orig_key)
+            if OmegaConf.is_missing(conf, orig_key):
                 val = "???"
-            elif OmegaConf.is_config(conf[key]):
-                val = _strip_interpolation(conf[key])
-            elif key.startswith("_"):
+            elif OmegaConf.is_config(conf[orig_key]):
+                val = _strip_interpolation(conf[orig_key])
+            elif str_key.startswith("_"):
                 continue  # Skip hidden/backup keys
-            elif OmegaConf.is_interpolation(conf, key):
-                raw_key = f"_{key}"
+            elif OmegaConf.is_interpolation(conf, orig_key):
+                raw_key = f"_{str_key}"
                 assert raw_key in conf, (
-                    f"Backup key: {raw_key} expected for interpolated key: {key}"
+                    f"Backup key: {raw_key} expected for interpolated key: {orig_key}"
                 )
                 # Retrieve the value from the backup key (resolves interpolation)
                 val = conf[raw_key]
             else:
-                val = conf[key]
+                val = conf[orig_key]
 
-            stripped[key] = val
+            stripped[str_key] = val
     elif OmegaConf.is_list(conf):
         stripped = [
             _strip_interpolation(item) if OmegaConf.is_config(item) else item for item in conf

--- a/packages/common/src/weathergen/common/config.py
+++ b/packages/common/src/weathergen/common/config.py
@@ -468,9 +468,10 @@ def load_merge_configs(
         istep = c.get("general", {}).get("istep", 0)
         cumulative = 0
         current_hl = None
-        for hl, steps in c.healpix_curriculum.items():
-            cumulative += steps
-            current_hl = int(hl)
+        unique_curr = {int(hl): steps for hl, steps in c.healpix_curriculum.items()}
+        for hl in sorted(unique_curr.keys()):
+            cumulative += unique_curr[hl]
+            current_hl = hl
             if istep < cumulative:
                 break
         c.healpix_level = current_hl

--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -170,7 +170,7 @@ def run_continue(args):
             trainer.run(cf, devices, from_run_id_iter, mini_epoch_iter)
             first_run = False
 
-            if not getattr(trainer.cf, "_curriculum_exit", False):
+            if not trainer.cf.get("_curriculum_exit", False):
                 break
 
             logger.info("Restarting training for next curriculum stage...")
@@ -239,7 +239,7 @@ def run_train(args):
             else:
                 trainer.run(cf, devices)
 
-            if not getattr(trainer.cf, "_curriculum_exit", False):
+            if not trainer.cf.get("_curriculum_exit", False):
                 break
 
             logger.info("Restarting training for next curriculum stage...")

--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -156,6 +156,7 @@ def run_continue(args):
                     args.private_config, from_run_id_iter, mini_epoch_iter, args.base_config, *args.config, {}, cli_overwrite
                 )
                 cf = config.set_run_id(cf, cf.general.run_id, True)
+                cf = Trainer.init_ddp(cf)
                 cf.streams = config.load_streams(Path(cf.streams_directory))
                 trainer = Trainer(cf.train_logging)
                 
@@ -216,6 +217,7 @@ def run_train(args):
                     args.private_config, from_run_id_iter, mini_epoch_iter, args.base_config, *args.config, cli_overwrite
                 )
                 cf = config.set_run_id(cf, cf.general.run_id, True)
+                cf = Trainer.init_ddp(cf)
                 cf.streams = config.load_streams(Path(cf.streams_directory))
                 trainer = Trainer(cf.train_logging)
                 trainer.run(cf, devices, from_run_id_iter, mini_epoch_iter)

--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -150,10 +150,11 @@ def run_continue(args):
         from_run_id_iter = args.from_run_id
         mini_epoch_iter = args.mini_epoch
         first_run = True
+        istep_override = {}
         while True:
             if not first_run:
                 cf = config.load_merge_configs(
-                    args.private_config, from_run_id_iter, mini_epoch_iter, args.base_config, *args.config, {}, cli_overwrite
+                    args.private_config, from_run_id_iter, mini_epoch_iter, args.base_config, *args.config, istep_override, cli_overwrite
                 )
                 cf = config.set_run_id(cf, cf.general.run_id, True)
                 cf = Trainer.init_ddp(cf)
@@ -169,6 +170,7 @@ def run_continue(args):
             logger.info("Restarting training for next curriculum stage...")
             from_run_id_iter = trainer.cf.general.run_id
             mini_epoch_iter = -1
+            istep_override = {"general": {"istep": trainer.cf.general.istep}}
     except Exception:
         extype, value, tb = sys.exc_info()
         traceback.print_exc()
@@ -211,10 +213,11 @@ def run_train(args):
     try:
         from_run_id_iter = None
         mini_epoch_iter = None
+        istep_override = {}
         while True:
             if from_run_id_iter is not None:
                 cf = config.load_merge_configs(
-                    args.private_config, from_run_id_iter, mini_epoch_iter, args.base_config, *args.config, cli_overwrite
+                    args.private_config, from_run_id_iter, mini_epoch_iter, args.base_config, *args.config, istep_override, cli_overwrite
                 )
                 cf = config.set_run_id(cf, cf.general.run_id, True)
                 cf = Trainer.init_ddp(cf)
@@ -230,6 +233,7 @@ def run_train(args):
             logger.info("Restarting training for next curriculum stage...")
             from_run_id_iter = trainer.cf.general.run_id
             mini_epoch_iter = -1
+            istep_override = {"general": {"istep": trainer.cf.general.istep}}
     except Exception:
         extype, value, tb = sys.exc_info()
         traceback.print_exc()

--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -147,7 +147,27 @@ def run_continue(args):
     trainer = Trainer(cf.train_logging)
 
     try:
-        trainer.run(cf, devices, args.from_run_id, args.mini_epoch)
+        from_run_id_iter = args.from_run_id
+        mini_epoch_iter = args.mini_epoch
+        first_run = True
+        while True:
+            if not first_run:
+                cf = config.load_merge_configs(
+                    args.private_config, from_run_id_iter, mini_epoch_iter, args.base_config, *args.config, {}, cli_overwrite
+                )
+                cf = config.set_run_id(cf, cf.general.run_id, True)
+                cf.streams = config.load_streams(Path(cf.streams_directory))
+                trainer = Trainer(cf.train_logging)
+                
+            trainer.run(cf, devices, from_run_id_iter, mini_epoch_iter)
+            first_run = False
+            
+            if not getattr(cf, "_curriculum_exit", False):
+                break
+                
+            logger.info("Restarting training for next curriculum stage...")
+            from_run_id_iter = cf.general.run_id
+            mini_epoch_iter = -1
     except Exception:
         extype, value, tb = sys.exc_info()
         traceback.print_exc()
@@ -188,7 +208,26 @@ def run_train(args):
     trainer = Trainer(cf.train_logging)
 
     try:
-        trainer.run(cf, devices)
+        from_run_id_iter = None
+        mini_epoch_iter = None
+        while True:
+            if from_run_id_iter is not None:
+                cf = config.load_merge_configs(
+                    args.private_config, from_run_id_iter, mini_epoch_iter, args.base_config, *args.config, cli_overwrite
+                )
+                cf = config.set_run_id(cf, cf.general.run_id, True)
+                cf.streams = config.load_streams(Path(cf.streams_directory))
+                trainer = Trainer(cf.train_logging)
+                trainer.run(cf, devices, from_run_id_iter, mini_epoch_iter)
+            else:
+                trainer.run(cf, devices)
+                
+            if not getattr(cf, "_curriculum_exit", False):
+                break
+                
+            logger.info("Restarting training for next curriculum stage...")
+            from_run_id_iter = cf.general.run_id
+            mini_epoch_iter = -1
     except Exception:
         extype, value, tb = sys.exc_info()
         traceback.print_exc()

--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -154,19 +154,25 @@ def run_continue(args):
         while True:
             if not first_run:
                 cf = config.load_merge_configs(
-                    args.private_config, from_run_id_iter, mini_epoch_iter, args.base_config, *args.config, istep_override, cli_overwrite
+                    args.private_config,
+                    from_run_id_iter,
+                    mini_epoch_iter,
+                    args.base_config,
+                    *args.config,
+                    istep_override,
+                    cli_overwrite,
                 )
                 cf = config.set_run_id(cf, cf.general.run_id, True)
                 cf = Trainer.init_ddp(cf)
                 cf.streams = config.load_streams(Path(cf.streams_directory))
                 trainer = Trainer(cf.train_logging)
-                
+
             trainer.run(cf, devices, from_run_id_iter, mini_epoch_iter)
             first_run = False
-            
+
             if not getattr(trainer.cf, "_curriculum_exit", False):
                 break
-                
+
             logger.info("Restarting training for next curriculum stage...")
             from_run_id_iter = trainer.cf.general.run_id
             mini_epoch_iter = -1
@@ -217,7 +223,13 @@ def run_train(args):
         while True:
             if from_run_id_iter is not None:
                 cf = config.load_merge_configs(
-                    args.private_config, from_run_id_iter, mini_epoch_iter, args.base_config, *args.config, istep_override, cli_overwrite
+                    args.private_config,
+                    from_run_id_iter,
+                    mini_epoch_iter,
+                    args.base_config,
+                    *args.config,
+                    istep_override,
+                    cli_overwrite,
                 )
                 cf = config.set_run_id(cf, cf.general.run_id, True)
                 cf = Trainer.init_ddp(cf)
@@ -226,10 +238,10 @@ def run_train(args):
                 trainer.run(cf, devices, from_run_id_iter, mini_epoch_iter)
             else:
                 trainer.run(cf, devices)
-                
+
             if not getattr(trainer.cf, "_curriculum_exit", False):
                 break
-                
+
             logger.info("Restarting training for next curriculum stage...")
             from_run_id_iter = trainer.cf.general.run_id
             mini_epoch_iter = -1

--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -162,11 +162,11 @@ def run_continue(args):
             trainer.run(cf, devices, from_run_id_iter, mini_epoch_iter)
             first_run = False
             
-            if not getattr(cf, "_curriculum_exit", False):
+            if not getattr(trainer.cf, "_curriculum_exit", False):
                 break
                 
             logger.info("Restarting training for next curriculum stage...")
-            from_run_id_iter = cf.general.run_id
+            from_run_id_iter = trainer.cf.general.run_id
             mini_epoch_iter = -1
     except Exception:
         extype, value, tb = sys.exc_info()
@@ -222,11 +222,11 @@ def run_train(args):
             else:
                 trainer.run(cf, devices)
                 
-            if not getattr(cf, "_curriculum_exit", False):
+            if not getattr(trainer.cf, "_curriculum_exit", False):
                 break
                 
             logger.info("Restarting training for next curriculum stage...")
-            from_run_id_iter = cf.general.run_id
+            from_run_id_iter = trainer.cf.general.run_id
             mini_epoch_iter = -1
     except Exception:
         extype, value, tb = sys.exc_info()

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -578,12 +578,14 @@ class Trainer(TrainerBase):
 
             if hasattr(self.cf, "healpix_curriculum") and self.cf.healpix_curriculum:
                 unique_curr = {int(hl): steps for hl, steps in self.cf.healpix_curriculum.items()}
-                cumulative = sum(steps for hl, steps in unique_curr.items() if hl <= self.cf.healpix_level)
-                if self.cf.general.istep >= cumulative:
-                    if is_root():
-                        logger.info(f"Curriculum stage for HEALPix level {self.cf.healpix_level} finished at istep {self.cf.general.istep}. Exiting mini_epoch early.")
-                    self.cf._curriculum_exit = True
-                    break
+                max_hl = max(unique_curr.keys())
+                if self.cf.healpix_level < max_hl:
+                    cumulative = sum(steps for hl, steps in unique_curr.items() if hl <= self.cf.healpix_level)
+                    if self.cf.general.istep >= cumulative:
+                        if is_root():
+                            logger.info(f"Curriculum stage for HEALPix level {self.cf.healpix_level} finished at istep {self.cf.general.istep}. Exiting mini_epoch early.")
+                        self.cf._curriculum_exit = True
+                        break
 
         self.dataset.advance()
 

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -577,9 +577,6 @@ class Trainer(TrainerBase):
             self.cf.general.istep += 1
 
             if hasattr(self.cf, "healpix_curriculum") and self.cf.healpix_curriculum:
-                if bidx == 0 and is_root():
-                    cumulative_debug = sum(steps for hl, steps in self.cf.healpix_curriculum.items() if int(hl) <= self.cf.healpix_level)
-                    logger.info(f"[Curriculum] healpix_level={self.cf.healpix_level}, istep={self.cf.general.istep}, cumulative_exit_at={cumulative_debug}, curriculum={dict(self.cf.healpix_curriculum)}")
                 cumulative = sum(steps for hl, steps in self.cf.healpix_curriculum.items() if int(hl) <= self.cf.healpix_level)
                 if self.cf.general.istep >= cumulative:
                     if is_root():

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -425,13 +425,13 @@ class Trainer(TrainerBase):
                 )
             self.save_model(mini_epoch)
 
-            if getattr(self.cf, "_curriculum_exit", False):
+            if self.cf.get("_curriculum_exit", False):
                 if is_root():
                     logger.info("Curriculum stage completed. Exiting training loop.")
                 break
 
         # log final model
-        if getattr(self.cf, "_curriculum_exit", False):
+        if self.cf.get("_curriculum_exit", False):
             self.save_model(-1)
         else:
             self.save_model(self.training_cfg.num_mini_epochs)

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -577,6 +577,9 @@ class Trainer(TrainerBase):
             self.cf.general.istep += 1
 
             if hasattr(self.cf, "healpix_curriculum") and self.cf.healpix_curriculum:
+                if bidx == 0 and is_root():
+                    cumulative_debug = sum(steps for hl, steps in self.cf.healpix_curriculum.items() if int(hl) <= self.cf.healpix_level)
+                    logger.info(f"[Curriculum] healpix_level={self.cf.healpix_level}, istep={self.cf.general.istep}, cumulative_exit_at={cumulative_debug}, curriculum={dict(self.cf.healpix_curriculum)}")
                 cumulative = sum(steps for hl, steps in self.cf.healpix_curriculum.items() if int(hl) <= self.cf.healpix_level)
                 if self.cf.general.istep >= cumulative:
                     if is_root():

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -358,6 +358,22 @@ class Trainer(TrainerBase):
         if self.cf.general.istep > 0 and is_root():
             logger.info(f"Continuing run with learning rate: {self.lr_scheduler.get_lr()}")
 
+        if hasattr(self.cf, "healpix_curriculum") and self.cf.healpix_curriculum and is_root():
+            unique_curr = {int(hl): steps for hl, steps in self.cf.healpix_curriculum.items()}
+            max_hl = max(unique_curr.keys())
+            if self.cf.healpix_level < max_hl:
+                cumulative = sum(steps for hl, steps in unique_curr.items() if hl <= self.cf.healpix_level)
+                logger.info(
+                    f"Curriculum active: Training HEALPix level {self.cf.healpix_level}. "
+                    f"Next stage will begin at istep {cumulative}. "
+                    f"(Note: Total run length is dictated by num_mini_epochs)"
+                )
+            else:
+                logger.info(
+                    f"Curriculum max level ({max_hl}) reached. "
+                    f"Continuing standard training until num_mini_epochs limit."
+                )
+
         # Instantiate loss calculator modules to compute losses
         self.loss_calculator = LossCalculator(cf, self.training_cfg, TRAIN, device=self.device)
         val_cfg = self.validation_cfg

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -362,7 +362,9 @@ class Trainer(TrainerBase):
             unique_curr = {int(hl): steps for hl, steps in self.cf.healpix_curriculum.items()}
             max_hl = max(unique_curr.keys())
             if self.cf.healpix_level < max_hl:
-                cumulative = sum(steps for hl, steps in unique_curr.items() if hl <= self.cf.healpix_level)
+                cumulative = sum(
+                    steps for hl, steps in unique_curr.items() if hl <= self.cf.healpix_level
+                )
                 logger.info(
                     f"Curriculum active: Training HEALPix level {self.cf.healpix_level}. "
                     f"Next stage will begin at istep {cumulative}. "
@@ -596,10 +598,15 @@ class Trainer(TrainerBase):
                 unique_curr = {int(hl): steps for hl, steps in self.cf.healpix_curriculum.items()}
                 max_hl = max(unique_curr.keys())
                 if self.cf.healpix_level < max_hl:
-                    cumulative = sum(steps for hl, steps in unique_curr.items() if hl <= self.cf.healpix_level)
+                    cumulative = sum(
+                        steps for hl, steps in unique_curr.items() if hl <= self.cf.healpix_level
+                    )
                     if self.cf.general.istep >= cumulative:
                         if is_root():
-                            logger.info(f"Curriculum stage for HEALPix level {self.cf.healpix_level} finished at istep {self.cf.general.istep}. Exiting mini_epoch early.")
+                            logger.info(
+                                f"Curriculum stage for HEALPix level {self.cf.healpix_level} "
+                                f"finished at istep {self.cf.general.istep}. Exiting early."
+                            )
                         self.cf._curriculum_exit = True
                         break
 

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -413,7 +413,10 @@ class Trainer(TrainerBase):
                 break
 
         # log final model
-        self.save_model(self.training_cfg.num_mini_epochs)
+        if getattr(self.cf, "_curriculum_exit", False):
+            self.save_model(-1)
+        else:
+            self.save_model(self.training_cfg.num_mini_epochs)
 
     def validate_before_training(self):
         """

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -407,6 +407,11 @@ class Trainer(TrainerBase):
                 )
             self.save_model(mini_epoch)
 
+            if getattr(self.cf, "_curriculum_exit", False):
+                if is_root():
+                    logger.info("Curriculum stage completed. Exiting training loop.")
+                break
+
         # log final model
         self.save_model(self.training_cfg.num_mini_epochs)
 
@@ -567,6 +572,18 @@ class Trainer(TrainerBase):
                 self.save_model(-1)
 
             self.cf.general.istep += 1
+
+            if hasattr(self.cf, "healpix_curriculum") and self.cf.healpix_curriculum:
+                cumulative = 0
+                for hl, steps in self.cf.healpix_curriculum.items():
+                    cumulative += steps
+                    if self.cf.healpix_level == int(hl):
+                        break
+                if self.cf.general.istep >= cumulative:
+                    if is_root():
+                        logger.info(f"Curriculum stage for HEALPix level {self.cf.healpix_level} finished at istep {self.cf.general.istep}. Exiting mini_epoch early.")
+                    self.cf._curriculum_exit = True
+                    break
 
         self.dataset.advance()
 

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -577,7 +577,8 @@ class Trainer(TrainerBase):
             self.cf.general.istep += 1
 
             if hasattr(self.cf, "healpix_curriculum") and self.cf.healpix_curriculum:
-                cumulative = sum(steps for hl, steps in self.cf.healpix_curriculum.items() if int(hl) <= self.cf.healpix_level)
+                unique_curr = {int(hl): steps for hl, steps in self.cf.healpix_curriculum.items()}
+                cumulative = sum(steps for hl, steps in unique_curr.items() if hl <= self.cf.healpix_level)
                 if self.cf.general.istep >= cumulative:
                     if is_root():
                         logger.info(f"Curriculum stage for HEALPix level {self.cf.healpix_level} finished at istep {self.cf.general.istep}. Exiting mini_epoch early.")

--- a/src/weathergen/train/trainer.py
+++ b/src/weathergen/train/trainer.py
@@ -574,11 +574,7 @@ class Trainer(TrainerBase):
             self.cf.general.istep += 1
 
             if hasattr(self.cf, "healpix_curriculum") and self.cf.healpix_curriculum:
-                cumulative = 0
-                for hl, steps in self.cf.healpix_curriculum.items():
-                    cumulative += steps
-                    if self.cf.healpix_level == int(hl):
-                        break
+                cumulative = sum(steps for hl, steps in self.cf.healpix_curriculum.items() if int(hl) <= self.cf.healpix_level)
                 if self.cf.general.istep >= cumulative:
                     if is_root():
                         logger.info(f"Curriculum stage for HEALPix level {self.cf.healpix_level} finished at istep {self.cf.general.istep}. Exiting mini_epoch early.")

--- a/src/weathergen/train/trainer_base.py
+++ b/src/weathergen/train/trainer_base.py
@@ -136,6 +136,11 @@ class TrainerBase:
                     dist.all_reduce(l_seed, op=torch.distributed.ReduceOp.SUM)
                     cf.data_loader_rng_seed = l_seed.item()
 
+        if dist.is_initialized():
+            rank = dist.get_rank()
+            world_size = dist.get_world_size()
+            local_rank = int(os.environ.get("LOCAL_RANK", os.environ.get("SLURM_LOCALID", "0")))
+
         cf.world_size = world_size
         cf.rank = rank
         cf.local_rank = local_rank


### PR DESCRIPTION
## Description

This adds a HEALPix curriculum to our training pipeline. During my bachelor thesis, I found that starting at a lower HEALPix Level (HL) and stepping it up during training cuts early compute time by almost 95%, all without hurting the final model performance. 

### How it works
- **Easy config**: Uses the `healpix_curriculum` parameter to set how many `isteps` each HL should run for.
- **Dynamic streams**: Uses OmegaConf interpolation (e.g., `streams_directory: "${curriculum_streams.${healpix_level}}"`) so the datasets swap automatically as the HL goes up.
- **Auto-restarts**: `run_train.py` now handles the transitions. When a stage ends, it stops the mini-epoch, saves a checkpoint and immediately starts the next stage within the same Slurm job.

### FYI
- **Configs**: I threw in `config_curriculum.yml` just to make reviewing the OmegaConf logic easier. Before merging it can be deleted so we don't clutter the repo with new configs.

## Issue Number

Closes #2794 

@kctezcan 

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [x] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [x] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel

#### FastEvaluation
 - [ ] I have updated the public documentation if necessary

