### PR TITLE
Inference Pipeline Optimization- Transpose what is needed

### DIFF
--- a/src/weathergen/datasets/data_reader_anemoi.py
+++ b/src/weathergen/datasets/data_reader_anemoi.py
@@ -30,6 +30,31 @@ from weathergen.train.utils import Stage
 _logger = logging.getLogger(__name__)
 
 
+def _take_var_axis(arr: NDArray[np.float32], var_idx: list[int] | NDArray) -> NDArray[np.float32]:
+    """Select variables from a (time, var, grid) cube.
+
+    Matches ``arr.transpose(0, 2, 1).reshape(time * grid, n_var)[:, var_idx]`` without
+    materialising the unused variables. The n320 ERA5 chunk stores all 113 variables
+    together, so the zarr read cannot be smaller; this only cuts the CPU transpose.
+    """
+    n_time, _, n_grid = arr.shape
+    n_sel = len(var_idx)
+    if n_sel == 0:
+        return np.empty((n_time * n_grid, 0), dtype=arr.dtype)
+    selected = arr[:, np.asanyarray(var_idx, dtype=np.intp), :]
+    return np.ascontiguousarray(selected.transpose(0, 2, 1)).reshape(n_time * n_grid, n_sel)
+
+
+def _repeat_latlon(
+    latitudes: NDArray[np.float32], longitudes: NDArray[np.float32], n_times: int
+) -> NDArray[np.float32]:
+    """Repeat (lat, lon) once per timestep. Same values as concatenate + vstack."""
+    latlon = np.column_stack((latitudes, longitudes))
+    if n_times == 1:
+        return latlon
+    return np.tile(latlon, (n_times, 1))
+
+
 class DataReaderAnemoi(DataReaderTimestep):
     "Wrapper for Anemoi datasets"
 
@@ -104,6 +129,7 @@ class DataReaderAnemoi(DataReaderTimestep):
         # caches lats and lons
         self.latitudes = _clip_lat(ds.latitudes)
         self.longitudes = _clip_lon(ds.longitudes)
+        self._latlon = np.column_stack((self.latitudes, self.longitudes))
 
         # select/filter requested source channels
         if stream_info.get(str(stage) + "_source_channels") is None:
@@ -198,31 +224,17 @@ class DataReaderAnemoi(DataReaderTimestep):
         # subsetting is pushed to the ctor via frequency argument; this also ensures that no sub-
         # sampling is required here
         try:
-            data = self.ds[didx_start:didx_end][:, :, 0].astype(np.float32)
+            # (time, var, ensemble, grid) → (time, var, grid). Already float32 on disk.
+            cube = np.asarray(self.ds[didx_start:didx_end][:, :, 0], dtype=np.float32)
         except MissingDateError as e:
             _logger.debug(f"Date not present in anemoi dataset: {str(e)}. Skipping.")
             return ReaderData.empty(
                 num_data_fields=len(channels_idx), num_geo_fields=len(self.geoinfo_idx)
             )
 
-        # coords-first representation and collapse multiple steps
-        data = data.transpose([0, 2, 1]).reshape((data.shape[0] * data.shape[2], -1))
-
-        # extract geoinfo channels (can be time-varying, so read from dataset)
-        geoinfos = data[:, list(self.geoinfo_idx)]
-        # extract channels
-        data = data[:, list(channels_idx)]
-
-        # construct lat/lon coords
-        latlon = np.concatenate(
-            [
-                np.expand_dims(self.latitudes, 0),
-                np.expand_dims(self.longitudes, 0),
-            ],
-            axis=0,
-        ).transpose()
-        # repeat latlon len(t_idxs) times
-        coords = np.vstack((latlon,) * len(t_idxs))
+        geoinfos = _take_var_axis(cube, self.geoinfo_idx)
+        data = _take_var_axis(cube, channels_idx)
+        coords = np.tile(self._latlon, (len(t_idxs), 1))
 
         # date time matching #data points of data
         # Assuming a fixed frequency for the dataset

--- a/tests/test_anemoi_get.py
+++ b/tests/test_anemoi_get.py
@@ -1,0 +1,68 @@
+# (C) Copyright 2025 WeatherGenerator contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Equivalence of the vectorized anemoi _get post-process vs the original transpose+slice."""
+
+import numpy as np
+import pytest
+
+from weathergen.datasets.data_reader_anemoi import _repeat_latlon, _take_var_axis
+
+
+def _take_var_axis_original(arr, var_idx):
+    data = arr.transpose([0, 2, 1]).reshape((arr.shape[0] * arr.shape[2], -1))
+    return data[:, list(var_idx)]
+
+
+def _repeat_latlon_original(latitudes, longitudes, n_times):
+    latlon = np.concatenate(
+        [
+            np.expand_dims(latitudes, 0),
+            np.expand_dims(longitudes, 0),
+        ],
+        axis=0,
+    ).transpose()
+    return np.vstack((latlon,) * n_times)
+
+
+@pytest.mark.parametrize("n_time,n_var,n_grid", [(1, 16, 64), (6, 113, 128), (6, 113, 1024)])
+def test_take_var_axis_matches_original(n_time, n_var, n_grid):
+    rng = np.random.default_rng(0)
+    arr = rng.standard_normal((n_time, n_var, n_grid)).astype(np.float32)
+    idx = [0, 3, 7, n_var - 1, 2]
+    original = _take_var_axis_original(arr, idx)
+    vectorized = _take_var_axis(arr, idx)
+    np.testing.assert_array_equal(vectorized, original)
+    assert vectorized.dtype == arr.dtype
+
+
+def test_take_var_axis_empty_selection():
+    arr = np.zeros((2, 8, 16), dtype=np.float32)
+    original = _take_var_axis_original(arr, [])
+    vectorized = _take_var_axis(arr, [])
+    np.testing.assert_array_equal(vectorized, original)
+    assert vectorized.shape == (32, 0)
+
+
+def test_take_var_axis_numpy_idx():
+    rng = np.random.default_rng(1)
+    arr = rng.standard_normal((3, 10, 20)).astype(np.float32)
+    idx = np.array([9, 0, 4], dtype=np.int64)
+    np.testing.assert_array_equal(_take_var_axis(arr, idx), _take_var_axis_original(arr, idx))
+
+
+def test_repeat_latlon_matches_original():
+    rng = np.random.default_rng(2)
+    lats = rng.uniform(-90, 90, size=40).astype(np.float32)
+    lons = rng.uniform(-180, 180, size=40).astype(np.float32)
+    for n_times in (1, 2, 6):
+        np.testing.assert_array_equal(
+            _repeat_latlon(lats, lons, n_times),
+            _repeat_latlon_original(lats, lons, n_times),
+        )


### PR DESCRIPTION
## Description

`DataReaderAnemoi._get` read a `(time, var, grid)` cube then did:

```python

arr.transpose([0, 2, 1]).reshape(time * grid, n_var)[:, channels_idx]

```

That transposes **all variables** (n320 ERA5 chunk is `(1, 113, 1, 542080)` — all vars in one chunk) and only then slices the channels that are needed. CPU transpose of the unused variables was the bottleneck, not Zarr I/O. Unused vars still cannot be skipped on disk because of that chunk layout.

This selects the needed variable indices first, then transposes a smaller cube:

- **`_take_var_axis`:** `arr[:, var_idx, :]` then contiguous transpose/reshape to `(time * grid, n_sel)`. Same values as transpose-then-slice.

## Inference timing
**Environment:** Jupiter, 1 node, mini-epoch 8 from `cw6a4szu`
The following command was used for both branches. `test_config.output.num_samples=0` is required to avoid OOM.
```bash
../WeatherGenerator-private/hpc/launch-slurm.py --stage inference --from-run-id cw6a4szu \
  --mini-epoch 8 --nodes 1 --time 15:00 \
  --options test_config.output.num_samples=0 test_config.forecast.num_steps=8 \
    test_config.samples_per_mini_epoch=4 test_config.validation_noise_levels=[] \
    data_loading.num_workers=1 data_loading.num_workers_validation=1 \
    test_config.compute_full_validation_loss=False
```

| Run | RUN_ID | Slurm | s/it | loss | valid? |
| --- | --- | --- | --- | --- | --- |
| 1 | `lt3hs6l4` | `1517724` | 35.46 | 3.2945E-02 | yes |
| 2 | `g2h2ht0n` | `1517727` | 35.92 | 3.2942E-02 | yes |
| 3 | `qdjky3ee` | `1517733` | 35.73 | 3.2942E-02 | yes |
| **Mean (valid)** | — | — | **35.70** | cluster | **yes** |

Vs **develop-ssl-diffusion-v1** control mean **59.15 s/it**: **1.66×**.

**Note:** These timings only show up if the job tree is running `javad/optimize-hpy_splits`. `launch-slurm.py --from-run-id cw6a4szu` copies Python from that training run, not from your checkout, so launching from the optimized branch alone does not change `_get` unless those files are overlaid (or otherwise copied) into the new job directory.


<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->


## Issue Number
https://github.com/ecmwf/WeatherGenerator/issues/2778
<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [ ] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel

#### FastEvaluation
 - [ ] I have updated the public documentation if necessary

