### PR TITLE
[2803][datareader] Output the encoded initial conditions with the latent writer

### DIFF
--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -54,10 +54,12 @@ class ModelOutput:
 
     physical: list[dict[StreamName, torch.Tensor]]
     latent: list[dict[str, torch.Tensor | LatentState]]
+    initial_latent: LatentState | None
 
     def __init__(self, len_output: int) -> None:
         self.physical = [{} for _ in range(len_output)]
         self.latent = [{} for _ in range(len_output)]
+        self.initial_latent = None
 
     def add_physical_prediction(
         self, fstep: int, stream_name: StreamName, pred: torch.Tensor
@@ -689,6 +691,7 @@ class Model(torch.nn.Module):
         shape = (len(batch), batch.get_num_source_steps(), *tokens.shape[1:])
         # collapse along input step dimension
         tokens = tokens.reshape(shape).sum(axis=1)
+        output.initial_latent = self.tokens_to_latent_state(self.latent_pre_norm(tokens), tokens)
 
         # Allow for pushforward trick
         p_fwd = self.cf.training_config.get("forecast", {}).get("pushforward", False)

--- a/src/weathergen/utils/validation_io.py
+++ b/src/weathergen/utils/validation_io.py
@@ -224,8 +224,7 @@ def _write_latent_data_to_zarr(zio, data, cf, batch, batch_idx, batch_size):
             # Calculate global sample index
             global_sample_idx = sample_start + sample_idx_in_batch
 
-            # Reserve latent step 0 for the initial encoded state.
-            group_path = f"{global_sample_idx}/{io.LATENT_STREAM}/{t_idx + 1}"
+            group_path = f"{global_sample_idx}/{io.LATENT_STREAM}/{t_idx}"
 
             npoints = _infer_latent_points_for_metadata(latents_in_sample)
             (
@@ -433,6 +432,8 @@ def get_latent_output(batch, model_output):
     fp32 = torch.float32
 
     timestep_idxs = [0] if len(batch.get_output_idxs()) == 0 else batch.get_output_idxs()
+    latent_preds = [{"latent_state": model_output.initial_latent}]
+    latent_preds.extend(model_output.get_latent_prediction(t_idx) for t_idx in timestep_idxs)
 
     sample_idxs = [
         list(sample.streams_data.values())[0].sample_idx
@@ -440,13 +441,14 @@ def get_latent_output(batch, model_output):
     ]
 
     latents_all: list[list[dict]] = []
-    for t_idx in timestep_idxs:
+    for latent_pred in latent_preds:
         latents_all.append([])
-        latent_pred = model_output.get_latent_prediction(t_idx)
         n_samples = len(sample_idxs)
         for i_sample in range(n_samples):
             per_sample: dict = {}
             for lname, lval in latent_pred.items():
+                if lval is None or lname == "posteriors":
+                    continue
                 if isinstance(lval, LatentState):
                     fields = {
                         "tokens": lval.z_pre_norm,


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->

Functionality for writing the latent space to file is already implemented in develop. However, this writer can only be combined with the forecast engine, as it writes out the forecasted latent space from the forecast engine. For many applications this is sufficient, but sometimes it would be useful to write the encoded initial conditions as well. An example is when generating a dataset of latent states to train tail networks on.

Here, this feature is implemented in the most minimal way

## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Closes #2803 

Is this PR a draft? Mark it as draft.

## Checklist before asking for review

-   [x] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel

#### FastEvaluation
 - [ ] I have updated the public documentation if necessary

