### PR TITLE
Change xyz-coordinates to float64 in verif exporter

### DIFF
--- a/packages/evaluate/src/weathergen/evaluate/export/verif_interpolator.py
+++ b/packages/evaluate/src/weathergen/evaluate/export/verif_interpolator.py
@@ -18,7 +18,7 @@ def convert_coordinates(coords: np.typing.NDArray) -> np.typing.NDArray:
     Convert lat-lon coordinates to cartesian coordinates in a unit box
     """
 
-    xyz_coords = np.empty((coords.shape[0], 3), dtype="float32")
+    xyz_coords = np.empty((coords.shape[0], 3), dtype="float64")
 
     xyz_coords[:, 0] = np.cos(np.pi * coords[:, 0] / 180.0) * np.cos(np.pi * coords[:, 1] / 180.0)
     xyz_coords[:, 1] = np.cos(np.pi * coords[:, 0] / 180.0) * np.sin(np.pi * coords[:, 1] / 180.0)
@@ -54,7 +54,7 @@ class Verif2DInterpolator(VerifInterpolator):
         grid_xyz = convert_coordinates(grid_points)
         obs_xyz = convert_coordinates(obs_points)
 
-        self.indices = np.empty((obs_points.shape[0], 5), dtype="float32")
+        self.indices = np.empty((obs_points.shape[0], 5), dtype="int32")
         tree = KDTree(grid_xyz)
         _, self.indices = tree.query(obs_xyz, k=5)
 


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes introduced in this pull request.

Change the title of the PR to a short sentence easy to understand:
[1234][model] Adds FSDP2 monitoring code
-->

Change type of XYZ coordinates from float32 to float64 in verif exporter.

## Issue Number

<!--
Link the Issue number this change addresses:
Closes #XYZ 
-->

Closes #2805 

Draft until tested 

## Checklist before asking for review

-   [X] I have performed a self-review of my code
-   [ ] My changes comply with basic sanity checks:
      - I have fixed formatting issues with `./scripts/actions.sh lint`
      - I have run unit tests with `./scripts/actions.sh unit-test`
      - I have documented my code and I have updated the docstrings.
      - I have added unit tests, if relevant
-   [ ] I have tried my changes with data and code:
      - I have run the integration tests with `./scripts/actions.sh integration-test`
      - (bigger changes) I have run a full training and I have written in the comment the run_id(s): `launch-slurm.py --time 60`
      - (bigger changes and experiments) I have shared a hegdedoc in the github issue with all the configurations and runs for this experiments
-   [ ] I have informed and aligned with people impacted by my change:
    - for config changes: the MatterMost channels and/or a design doc
    - for changes of dependencies: the MatterMost software development channel

#### FastEvaluation
 - [ ] I have updated the public documentation if necessary

